### PR TITLE
Match current JSON ABI generation

### DIFF
--- a/fuels-abigen-macro/tests/harness.rs
+++ b/fuels-abigen-macro/tests/harness.rs
@@ -370,8 +370,8 @@ async fn compile_bindings_struct_input() {
                 "type":"contract",
                 "inputs":[
                     {
-                        "name":"MyStruct",
-                        "type":"struct",
+                        "name":"my_struct",
+                        "type":"struct MyStruct",
                         "components": [
                             {
                                 "name": "foo",
@@ -410,7 +410,7 @@ async fn compile_bindings_struct_input() {
         hex::encode(contract_call.encoded_args)
     );
 
-    assert_eq!("00000000f5957fce000000000000000a0000000000000001", encoded);
+    assert_eq!("00000000dba1aa14000000000000000a0000000000000001", encoded);
 }
 
 #[tokio::test]
@@ -425,8 +425,8 @@ async fn compile_bindings_nested_struct_input() {
                 "type":"contract",
                 "inputs":[
                     {
-                        "name":"MyNestedStruct",
-                        "type":"struct",
+                        "name":"my_nested_struct",
+                        "type":"struct MyNestedStruct",
                         "components": [
                             {
                                 "name": "x",
@@ -434,7 +434,7 @@ async fn compile_bindings_nested_struct_input() {
                             },
                             {
                                 "name": "inner_struct",
-                                "type": "struct",
+                                "type": "struct InnerStruct",
                                 "components": [
                                     {
                                         "name":"a",
@@ -471,7 +471,7 @@ async fn compile_bindings_nested_struct_input() {
         hex::encode(contract_call.encoded_args)
     );
 
-    assert_eq!("00000000e8a04d9c000000000000000a0000000000000001", encoded);
+    assert_eq!("0000000000b6189a000000000000000a0000000000000001", encoded);
 }
 
 #[tokio::test]
@@ -486,8 +486,8 @@ async fn compile_bindings_enum_input() {
                 "type":"contract",
                 "inputs":[
                     {
-                        "name":"MyEnum",
-                        "type":"enum",
+                        "name":"my_enum",
+                        "type":"enum MyEnum",
                         "components": [
                             {
                                 "name": "x",
@@ -521,7 +521,7 @@ async fn compile_bindings_enum_input() {
         hex::encode(contract_call.encoded_args)
     );
 
-    assert_eq!("000000009542a3c90000000000000000000000000000002a", encoded);
+    assert_eq!("00000000f13c1c590000000000000000000000000000002a", encoded);
 }
 
 #[tokio::test]
@@ -536,8 +536,8 @@ async fn create_struct_from_decoded_tokens() {
                 "type":"contract",
                 "inputs":[
                     {
-                        "name":"MyStruct",
-                        "type":"struct",
+                        "name":"my_struct",
+                        "type":"struct MyStruct",
                         "components": [
                             {
                                 "name": "foo",
@@ -580,7 +580,7 @@ async fn create_struct_from_decoded_tokens() {
         hex::encode(contract_call.encoded_args)
     );
 
-    assert_eq!("00000000f5957fce000000000000000a0000000000000001", encoded);
+    assert_eq!("00000000dba1aa14000000000000000a0000000000000001", encoded);
 }
 
 #[tokio::test]
@@ -595,8 +595,8 @@ async fn create_nested_struct_from_decoded_tokens() {
                 "type":"contract",
                 "inputs":[
                     {
-                        "name":"MyNestedStruct",
-                        "type":"struct",
+                        "name":"my_nested_struct",
+                        "type":"struct MyNestedStruct",
                         "components": [
                             {
                                 "name": "x",
@@ -604,7 +604,7 @@ async fn create_nested_struct_from_decoded_tokens() {
                             },
                             {
                                 "name": "inner_struct",
-                                "type": "struct",
+                                "type": "struct InnerStruct",
                                 "components": [
                                     {
                                         "name":"a",
@@ -650,7 +650,7 @@ async fn create_nested_struct_from_decoded_tokens() {
         hex::encode(contract_call.encoded_args)
     );
 
-    assert_eq!("00000000e8a04d9c000000000000000a0000000000000001", encoded);
+    assert_eq!("0000000000b6189a000000000000000a0000000000000001", encoded);
 }
 
 #[tokio::test]
@@ -719,7 +719,7 @@ async fn example_workflow() {
                     }
                 ]
             }
-        ] 
+        ]
         "#
     );
 

--- a/fuels-rs/src/code_gen/custom_types_gen.rs
+++ b/fuels-rs/src/code_gen/custom_types_gen.rs
@@ -64,7 +64,7 @@ pub fn expand_internal_struct(name: &str, prop: &Property) -> Result<TokenStream
         }
     }
 
-    let name = ident(name);
+    let name = ident(&name.to_class_case());
 
     // Actual creation of the struct, using the inner TokenStreams from above
     // to produce the TokenStream that represents the whole struct + methods
@@ -103,7 +103,7 @@ pub fn expand_internal_enum(name: &str, prop: &Property) -> Result<TokenStream, 
     // creating an enum [`Token`].
     let mut enum_selector_builder = Vec::new();
 
-    let name = ident(name);
+    let name = ident(&name.to_class_case());
 
     for (discriminant, component) in components.iter().enumerate() {
         let field_name = ident(&component.name.to_class_case());

--- a/fuels-rs/src/code_gen/functions_gen.rs
+++ b/fuels-rs/src/code_gen/functions_gen.rs
@@ -32,7 +32,7 @@ pub fn expand_function(
     let name = safe_ident(&function.name);
     let fn_signature = abi_parser.build_fn_selector(&function.name, &function.inputs);
 
-    let encoded = ABIEncoder::encode_function_selector(fn_signature.as_bytes());
+    let encoded = ABIEncoder::encode_function_selector(fn_signature?.as_bytes());
 
     let tokenized_signature = expand_selector(encoded);
     let tokenized_output = expand_fn_outputs(&function.outputs)?;
@@ -177,11 +177,11 @@ fn expand_input_param(
             })
         }
         ParamType::Enum(_) => {
-            let ident = ident(&rust_enum_name.unwrap().name);
+            let ident = ident(&rust_enum_name.unwrap().name.to_class_case());
             Ok(quote! { #ident })
         }
         ParamType::Struct(_) => {
-            let ident = ident(&rust_struct_name.unwrap().name);
+            let ident = ident(&rust_struct_name.unwrap().name.to_class_case());
             Ok(quote! { #ident })
         }
         // Primitive type


### PR DESCRIPTION
Before, `fuels-rs` was expecting the generated JSON ABI for custom types to look like this:

```json
[
    {
        "type":"contract",
        "inputs":[
            {
                "name":"MyStruct",
                "type":"struct",
                "components": [
                    {
                        "name": "foo",
                        "type": "u8"
                    },
                    {
                        "name": "bar",
                        "type": "bool"
                    }
                ]
            }
        ],
        "name":"takes_struct",
        "outputs":[]
    }
]
```

Where the `type` was only `"struct"` | `"enum"`. But since the work done on the compiler's side to generate the JSON ABI, it was changed to follow this format: `"type": "struct <struct_name>"`. For example:

```json
[
    {
        "type":"contract",
        "inputs":[
            {
                "name":"my_struct",
                "type":"struct MyStruct",
                "components": [
                    {
                        "name": "foo",
                        "type": "u8"
                    },
                    {
                        "name": "bar",
                        "type": "bool"
                    }
                ]
            }
        ],
        "name":"takes_struct",
        "outputs":[]
    }
]
```

This PR changes the codegen and overall parsing to support this current format. Everything works the same from a UX perspective.