### PR TITLE
Support for typed return values and output with custom types

### DIFF
--- a/fuels-abigen-macro/Cargo.toml
+++ b/fuels-abigen-macro/Cargo.toml
@@ -34,4 +34,4 @@ strum = "0.21"
 strum_macros = "0.21"
 syn = "1.0.12"
 thiserror = { version = "1.0.26", default-features = false }
-tokio = "1.12.0"
+tokio = "1.15.0"

--- a/fuels-abigen-macro/tests/test_projects/contract_output_test/Forc.toml
+++ b/fuels-abigen-macro/tests/test_projects/contract_output_test/Forc.toml
@@ -1,0 +1,10 @@
+[project]
+author  = "Rodrigo Araujo"
+license = "MIT"
+name = "contract_test"
+entry = "main.sw"
+
+[dependencies]
+increment_abi = { path = "../library_test" }
+std = { path = "../lib-std" }
+core = { path = "../lib-core" }

--- a/fuels-abigen-macro/tests/test_projects/contract_output_test/src/main.sw
+++ b/fuels-abigen-macro/tests/test_projects/contract_output_test/src/main.sw
@@ -1,0 +1,36 @@
+contract;
+
+use std::*;
+use core::*;
+use std::storage::*;
+
+struct MyStruct {
+  foo: u8,
+  bar: bool,
+}
+
+abi TestContract {
+  fn is_even(gas: u64, coin: u64, color: b256, value: u64) -> bool;
+  fn return_my_string(gas: u64, coin: u64, color: b256, value: str[4]) -> str[4];
+  fn return_my_struct(gas: u64, coin: u64, color: b256, value: MyStruct) -> MyStruct;
+  
+}
+
+impl TestContract for Contract {
+  fn is_even(gas: u64, coin: u64, color: b256, value: u64) -> bool {
+    if (value / 2) * 2 == value {
+      true
+    } else {
+      false
+    }
+  }
+  fn return_my_string(gas: u64, coin: u64, color: b256, value: str[4]) -> str[4] {
+    value
+  }
+
+
+  fn return_my_struct(gas: u64, coin: u64, color: b256, value: MyStruct) -> MyStruct {
+    value
+  }
+  
+}

--- a/fuels-rs/src/errors.rs
+++ b/fuels-rs/src/errors.rs
@@ -1,5 +1,6 @@
 use core::str::Utf8Error;
 use fuels_core::errors::CodecError;
+use fuels_core::InvalidOutputType;
 use thiserror::Error;
 pub type Result<T> = core::result::Result<T, Error>;
 use std::net;
@@ -42,5 +43,11 @@ impl From<CodecError> for Error {
             CodecError::InvalidData => Error::InvalidData,
             CodecError::Utf8Error(e) => Error::Utf8Error(e),
         }
+    }
+}
+
+impl From<InvalidOutputType> for Error {
+    fn from(err: InvalidOutputType) -> Error {
+        Error::ContractCallError(err.0)
     }
 }

--- a/fuels-rs/src/types.rs
+++ b/fuels-rs/src/types.rs
@@ -16,9 +16,9 @@ pub fn expand_type(kind: &ParamType) -> Result<TokenStream, Error> {
         ParamType::Bool => Ok(quote! { bool }),
         ParamType::B256 => Ok(quote! { [u8; 32] }),
         ParamType::String(_) => Ok(quote! { String }),
-        ParamType::Array(t, size) => {
+        ParamType::Array(t, _size) => {
             let inner = expand_type(t)?;
-            Ok(quote! { [#inner; #size] })
+            Ok(quote! { ::std::vec::Vec<#inner> })
         }
         ParamType::Struct(members) => {
             if members.is_empty() {


### PR DESCRIPTION
This PR introduces decoded and type-safe output for contract calls.

It also adds support for structs as return values for contract calls.

Before this, contract calls through the SDK would just return a `u64`.

Now, we're fully leveraging the `Tokenizable` and `Detokenize` traits
that were designed earlier to decode the return values coming from
contract calls. For instance:

```Rust
let response: bool = contract_instance.is_even(10).call().await.unwrap();

let my_struct = MyStruct { foo: 10, bar: true };
let response: MyStruct = contract_instance
                            .return_my_struct(my_struct)
                            .call()
                            .await
                            .unwrap();
```