### PR TITLE
Match expected default params to compiler-generated ones

### DIFF
--- a/fuels-abigen-macro/tests/harness.rs
+++ b/fuels-abigen-macro/tests/harness.rs
@@ -33,7 +33,7 @@ async fn compile_bindings_from_contract_file() {
     // Currently this prints `0000000003b568d4000000000000002a000000000000000a`
     // The encoded contract call. Soon it'll be able to perform the
     // actual call.
-    let contract_call = contract_instance.takes_ints_returns_bool(42 as u32, 10 as u16);
+    let contract_call = contract_instance.takes_ints_returns_bool(42, 10);
 
     // Then you'll be able to use `.call()` to actually call the contract with the
     // specified function:
@@ -670,17 +670,17 @@ async fn example_workflow() {
                 "inputs": [
                 {
                     "components": null,
-                    "name": "gas",
+                    "name": "gas_",
                     "type": "u64"
                 },
                 {
                     "components": null,
-                    "name": "coin",
+                    "name": "amount_",
                     "type": "u64"
                 },
                 {
                     "components": null,
-                    "name": "color",
+                    "name": "color_",
                     "type": "b256"
                 },
                 {
@@ -703,22 +703,22 @@ async fn example_workflow() {
                 "inputs": [
                 {
                     "components": null,
-                    "name": "gas",
+                    "name": "gas_",
                     "type": "u64"
                 },
                 {
                     "components": null,
-                    "name": "coin",
+                    "name": "amount_",
                     "type": "u64"
                 },
                 {
                     "components": null,
-                    "name": "color",
+                    "name": "color_",
                     "type": "b256"
                 },
                 {
                     "components": null,
-                    "name": "amount",
+                    "name": "value",
                     "type": "u64"
                 }
                 ],
@@ -781,17 +781,17 @@ async fn type_safe_output_values() {
                 "inputs":[
                     {
                         "components": null,
-                        "name": "gas",
+                        "name": "gas_",
                         "type": "u64"
                     },
                     {
                         "components": null,
-                        "name": "coin",
+                        "name": "amount_",
                         "type": "u64"
                     },
                     {
                         "components": null,
-                        "name": "color",
+                        "name": "color_",
                         "type": "b256"
                     },
                     {
@@ -814,17 +814,17 @@ async fn type_safe_output_values() {
                 "inputs":[
                     {
                         "components": null,
-                        "name": "gas",
+                        "name": "gas_",
                         "type": "u64"
                     },
                     {
                         "components": null,
-                        "name": "coin",
+                        "name": "amount_",
                         "type": "u64"
                     },
                     {
                         "components": null,
-                        "name": "color",
+                        "name": "color_",
                         "type": "b256"
                     },
                     {
@@ -847,17 +847,17 @@ async fn type_safe_output_values() {
                 "inputs":[
                     {
                         "components": null,
-                        "name": "gas",
+                        "name": "gas_",
                         "type": "u64"
                     },
                     {
                         "components": null,
-                        "name": "coin",
+                        "name": "amount_",
                         "type": "u64"
                     },
                     {
                         "components": null,
-                        "name": "color",
+                        "name": "color_",
                         "type": "b256"
                     },
                     {

--- a/fuels-abigen-macro/tests/takes_ints_returns_bool.json
+++ b/fuels-abigen-macro/tests/takes_ints_returns_bool.json
@@ -3,15 +3,15 @@
         "type": "function",
         "inputs": [
             {
-                "name": "gas",
+                "name": "gas_",
                 "type": "u64"
             },
             {
-                "name": "coin",
+                "name": "amount_",
                 "type": "u64"
             },
             {
-                "name": "color",
+                "name": "color_",
                 "type": "b256"
             },
             {

--- a/fuels-abigen-macro/tests/test_projects/contract_test/src/main.sw
+++ b/fuels-abigen-macro/tests/test_projects/contract_test/src/main.sw
@@ -6,7 +6,7 @@ use std::storage::*;
 
 abi TestContract {
   fn initialize_counter(gas: u64, coin: u64, color: b256, value: u64) -> u64;
-  fn increment_counter(gas: u64, coin: u64, color: b256, amount: u64) -> u64;
+  fn increment_counter(gas: u64, coin: u64, color: b256, value: u64) -> u64;
 }
 
 const COUNTER_KEY = 0x0000000000000000000000000000000000000000000000000000000000000000;
@@ -16,9 +16,9 @@ impl TestContract for Contract {
     store(COUNTER_KEY, value);
     value
   }
-  fn increment_counter(gas: u64, coin: u64, color: b256, amount: u64) -> u64 {
-    let value = get::<u64>(COUNTER_KEY) + amount;
-    store(COUNTER_KEY, value);
-    value
+  fn increment_counter(gas: u64, coin: u64, color: b256, value: u64) -> u64 {
+    let new_value = get::<u64>(COUNTER_KEY) + value;
+    store(COUNTER_KEY, new_value);
+    new_value
   }
 }

--- a/fuels-rs/src/code_gen/functions_gen.rs
+++ b/fuels-rs/src/code_gen/functions_gen.rs
@@ -134,7 +134,7 @@ fn expand_function_arguments(
         // contract_instance.increment_counter(42)
         // Note that _any_ significant change in the way the JSON ABI is generated
         // could affect this function expansion.
-        if param.name == "gas" || param.name == "coin" || param.name == "color" {
+        if param.name == "gas_" || param.name == "amount_" || param.name == "color_" {
             continue;
         }
         // TokenStream representing the name of the argument

--- a/fuels-rs/src/json_abi.rs
+++ b/fuels-rs/src/json_abi.rs
@@ -1279,17 +1279,17 @@ mod tests {
                 "inputs": [
                     {
                         "components": null,
-                        "name": "gas",
+                        "name": "gas_",
                         "type": "u64"
                     },
                     {
                         "components": null,
-                        "name": "amount",
+                        "name": "amount_",
                         "type": "u64"
                     },
                     {
                         "components": null,
-                        "name": "color",
+                        "name": "color_",
                         "type": "b256"
                     },
                     {
@@ -1312,17 +1312,17 @@ mod tests {
                 "inputs": [
                     {
                         "components": null,
-                        "name": "gas",
+                        "name": "gas_",
                         "type": "u64"
                     },
                     {
                         "components": null,
-                        "name": "amount",
+                        "name": "amount_",
                         "type": "u64"
                     },
                     {
                         "components": null,
-                        "name": "color",
+                        "name": "color_",
                         "type": "b256"
                     },
                     {


### PR DESCRIPTION
Before the latest version of the Forc json abigen, `fuels-rs` was
expecting the default params to be `("gas", "coin", "color")`.

But right now, it is `("gas_", "amount_", "color_")`. This drift
was causing the generated Rust types to include the default params
in the generated methods.

This PR fixes that.