### PR TITLE
Fetch field names

### DIFF
--- a/fuels-rs/src/code_gen/abigen.rs
+++ b/fuels-rs/src/code_gen/abigen.rs
@@ -91,7 +91,7 @@ impl Abigen {
         let (includes, code) = if self.no_std {
             (
                 quote! {
-                    use alloc::vec::Vec;
+                    use alloc::{vec, vec::Vec};
                 },
                 quote! {},
             )
@@ -161,7 +161,7 @@ impl Abigen {
         let mut seen_struct: Vec<&str> = vec![];
 
         for prop in self.custom_structs.values() {
-            if !seen_struct.contains(&prop.type_field.as_str()) {
+            if !seen_struct.contains(&prop.name.as_str()) {
                 structs.extend(expand_internal_struct(prop)?);
                 seen_struct.push(&prop.type_field);
             }

--- a/fuels-rs/src/code_gen/custom_types_gen.rs
+++ b/fuels-rs/src/code_gen/custom_types_gen.rs
@@ -207,5 +207,5 @@ pub fn expand_internal_enum(name: &str, prop: &Property) -> Result<TokenStream, 
 // A custom type name is coming in as `struct $name
 // We want to grab its `$name`.
 pub fn extract_struct_name_from_abi_property(prop: &Property) -> String {
-    prop.type_field.split_whitespace().collect::<Vec<&str>>()[1].to_string()
+    prop.name.clone()
 }


### PR DESCRIPTION
Found a couple places where codegen was breaking. When I have multiple structs to generate, only one of them would generate, these changes use the `name` field instead.