### PR TITLE
Add support for contract calls with struct as inputs

### DIFF
--- a/fuels-abigen-macro/tests/test_projects/complex_types_contract/Forc.toml
+++ b/fuels-abigen-macro/tests/test_projects/complex_types_contract/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+author  = "Rodrigo Araujo"
+license = "MIT"
+name = "contract_test"
+entry = "main.sw"
+
+[dependencies]
+std = { path = "../lib-std" }
+core = { path = "../lib-core" }

--- a/fuels-abigen-macro/tests/test_projects/complex_types_contract/src/main.sw
+++ b/fuels-abigen-macro/tests/test_projects/complex_types_contract/src/main.sw
@@ -1,0 +1,31 @@
+contract;
+
+use std::storage::store;
+use std::storage::get;
+use std::chain::log_u64;
+use std::chain::log_u8;
+
+struct CounterConfig {
+  dummy: bool,
+  initial_value: u64,
+}
+
+abi TestContract {
+  fn initialize_counter(gas_: u64, amount_: u64, color_: b256, config: CounterConfig) -> u64;
+  fn increment_counter(gas_: u64, amount_: u64, color_: b256, amount: u64) -> u64;
+}
+
+const COUNTER_KEY = 0x0000000000000000000000000000000000000000000000000000000000000000;
+
+impl TestContract for Contract {
+  fn initialize_counter(gas_: u64, amount_: u64, color_: b256, config: CounterConfig) -> u64 {
+    let value = config.initial_value;
+    store(COUNTER_KEY, value);
+    value
+  }
+  fn increment_counter(gas_: u64, amount_: u64, color_: b256, amount: u64) -> u64 {
+    let value = get::<u64>(COUNTER_KEY) + amount;
+    store(COUNTER_KEY, value);
+    value
+  }
+}

--- a/fuels-rs/src/contract.rs
+++ b/fuels-rs/src/contract.rs
@@ -12,7 +12,7 @@ use fuel_types::{Bytes32, Immediate12, Salt, Word};
 use fuel_vm::consts::{REG_CGAS, REG_RET, REG_ZERO, VM_TX_MEMORY};
 use fuel_vm::prelude::Contract as FuelContract;
 use fuels_core::ParamType;
-use fuels_core::{Detokenize, Selector, Token};
+use fuels_core::{Detokenize, Selector, Token, WORD_SIZE};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use std::marker::PhantomData;
@@ -59,6 +59,7 @@ impl Contract {
         gas_price: Word,
         gas_limit: Word,
         maturity: Word,
+        custom_inputs: bool,
     ) -> Result<Vec<Receipt>, String> {
         // Based on the defined script length,
         // we set the appropriate data offset.
@@ -87,16 +88,37 @@ impl Contract {
         assert!(script.len() == script_len, "Script length *must* be 16");
 
         // `script_data` consists of:
-        // 1. The contract ID
-        // 2. The function selector
-        // 3. The encoded arguments, in order
+        // Primitive types as input:
+        // ┌─────────────┬─────────────┬──────────────┐
+        // │ contract_id │ fn selector │ encoded args │
+        // └─────────────┴─────────────┴──────────────┘
+        // Structs as input:
+        // ┌─────────────┬─────────────┬─────────────────┬──────────────┐
+        // │ contract_id │ fn selector │call_data_offset │ encoded args │
+        // └─────────────┴─────────────┴─────────────────┴──────────────┘
         let mut script_data: Vec<u8> = vec![];
+
+        // Insert contract_id
         script_data.extend(contract_id.as_ref());
 
+        // Insert encoded function selector, if any
         if let Some(e) = encoded_selector {
             script_data.extend(e)
         }
 
+        // If the method call takes custom inputs, such as structs or enums,
+        // we need to calculate the `call_data_offset`, which points to
+        // where the data for the custom types start in the transaction.
+        // If it doesn't take any custom inputs, this isn't necessary.
+        if custom_inputs {
+            // Offset of the script data relative to the call data
+            let call_data_offset = script_data_offset as usize + ContractId::LEN + 2 * WORD_SIZE;
+            let call_data_offset = call_data_offset as Word;
+
+            script_data.extend(&call_data_offset.to_be_bytes());
+        }
+
+        // Insert encoded arguments, if any
         if let Some(e) = encoded_args {
             script_data.extend(e)
         }
@@ -162,6 +184,8 @@ impl Contract {
         let maturity = 0;
         let input_index = 0;
 
+        let custom_inputs = args.iter().any(|t| matches!(t, Token::Struct(_)));
+
         Ok(ContractCall {
             compiled_contract: compiled_contract.clone(),
             contract_id: Self::compute_contract_id(compiled_contract),
@@ -177,6 +201,7 @@ impl Contract {
             fuel_client: fuel_client.clone(),
             datatype: PhantomData,
             output_params: output_params.to_vec(),
+            custom_inputs,
         })
     }
 
@@ -297,6 +322,7 @@ pub struct ContractCall<D> {
     pub maturity: u64,
     pub datatype: PhantomData<D>,
     pub output_params: Vec<ParamType>,
+    pub custom_inputs: bool,
 }
 
 impl<D> ContractCall<D>
@@ -322,6 +348,7 @@ where
             self.gas_price,
             self.gas_limit,
             self.maturity,
+            self.custom_inputs,
         )
         .await
         .unwrap();

--- a/fuels-rs/src/contract.rs
+++ b/fuels-rs/src/contract.rs
@@ -88,14 +88,12 @@ impl Contract {
         assert!(script.len() == script_len, "Script length *must* be 16");
 
         // `script_data` consists of:
-        // Primitive types as input:
-        // ┌─────────────┬─────────────┬──────────────┐
-        // │ contract_id │ fn selector │ encoded args │
-        // └─────────────┴─────────────┴──────────────┘
-        // Structs as input:
-        // ┌─────────────┬─────────────┬─────────────────┬──────────────┐
-        // │ contract_id │ fn selector │call_data_offset │ encoded args │
-        // └─────────────┴─────────────┴─────────────────┴──────────────┘
+        // 1. Contract ID (ContractID::LEN);
+        // 2. Function selector (1 * WORD_SIZE);
+        // 3. Calldata offset, if it has structs as input,
+        // computed as `script_data_offset` + ContractId::LEN
+        //                                  + 2 * WORD_SIZE;
+        // 4. Encoded arguments.
         let mut script_data: Vec<u8> = vec![];
 
         // Insert contract_id

--- a/fuels-rs/tests/calls.rs
+++ b/fuels-rs/tests/calls.rs
@@ -100,6 +100,7 @@ async fn contract_call() {
         gas_price,
         gas_limit,
         maturity,
+        false,
     )
     .await
     .unwrap();


### PR DESCRIPTION
Before the changes introduced here, using the SDK to call contracts
that takes structs as input would cause weird bugs -- it didn't really
cause a panic on the VM, but it made the access to fields within
a struct retrieve garbage data.

That was happening because in the `script_data` we sent in the tx
we weren't including a `call_data_offset` that's computed as:

```rust
let call_data_offset = script_data_offset as usize
                        + ContractId::LEN + 2 * WORD_SIZE;
```

Once that was included, struct field access worked perfectly.

Curiously, this `call_data_offset` isn't needed if the input is a
primitive type (u8, bool, ...). So a conditional check that adds
the `call_data_offset` to the `script_data` iff the ABI method called
takes a struct is now in place.

This enables users to successfully perform the following:

```Rust
// ...
let contract_instance = MyContract::new(compiled, client);

let counter_config = CounterConfig {
    dummy: true,
    initial_value: 42,
};

let result = contract_instance
    .initialize_counter(counter_config)
    .call()
    .await
    .unwrap();

assert_eq!(42, result);
```

Closes https://github.com/FuelLabs/fuels-rs/issues/30