### PR TITLE
Make fuel-core && fuel-gql-client optional deps

### DIFF
--- a/fuels-abigen-macro/Cargo.toml
+++ b/fuels-abigen-macro/Cargo.toml
@@ -18,12 +18,10 @@ bytes = { version = "1.0.1", features = ["serde"] }
 forc = { version = "0.2", features = ["test", "util"], default-features = false }
 fuels-core = { version = "0.1.3", path = "../fuels-core" }
 fuel-asm = { version = "0.1", features = ["serde-types"] }
-fuel-gql-client = { version = "0.1", default-features = false }
-fuel-core = { version = "0.1", default-features = false }
 fuel-tx = "0.1"
 fuel-types = "0.1"
 fuel-vm = "0.1"
-fuels-rs = { version = "0.1.3", path = "../fuels-rs" }
+fuels-rs = { version = "0.1.3", path = "../fuels-rs", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 itertools = "0.10.1"
 proc-macro2 = "1.0"
@@ -38,3 +36,8 @@ strum_macros = "0.21"
 syn = "1.0.12"
 thiserror = { version = "1.0.26", default-features = false }
 tokio = "1.15.0"
+
+[dev-dependencies]
+fuel-gql-client = { version = "0.1", default-features = false }
+fuel-core = { version = "0.1", default-features = false }
+fuels-rs = { version = "0.1.3", path = "../fuels-rs" }

--- a/fuels-rs/Cargo.toml
+++ b/fuels-rs/Cargo.toml
@@ -8,6 +8,9 @@ license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuels-rs"
 description = "Fuel Rust SDK."
 
+[features]
+default = ["fuel-core", "fuel-gql-client"]
+
 [dependencies]
 Inflector = "0.11"
 anyhow = "1"
@@ -15,8 +18,8 @@ bytes = { version = "1.0.1", features = ["serde"] }
 forc = { version = "0.2", features = ["test", "util"], default-features = false }
 fuels-core = { version = "0.1.3", path = "../fuels-core" }
 fuel-asm = { version = "0.1", features = ["serde-types"] }
-fuel-gql-client = { version = "0.1", default-features = false }
-fuel-core = { version = "0.1", default-features = false }
+fuel-gql-client = { version = "0.1", default-features = false, optional = true }
+fuel-core = { version = "0.1", default-features = false, optional = true }
 fuel-tx = "0.1"
 fuel-types = "0.1"
 fuel-vm = "0.1"

--- a/fuels-rs/src/contract.rs
+++ b/fuels-rs/src/contract.rs
@@ -1,11 +1,14 @@
 use crate::abi_decoder::ABIDecoder;
 use crate::abi_encoder::ABIEncoder;
 use crate::errors::Error;
+#[cfg(feature = "fuel-gql-client")]
 use crate::script::Script;
 use forc::test::{forc_build, BuildCommand};
 use forc::util::helpers::read_manifest;
 use fuel_asm::Opcode;
+#[cfg(feature = "fuel-core")]
 use fuel_core::service::{Config, FuelService};
+#[cfg(feature = "fuel-gql-client")]
 use fuel_gql_client::client::FuelClient;
 use fuel_tx::{ContractId, Input, Output, Receipt, Transaction};
 use fuel_types::{Bytes32, Immediate12, Salt, Word};
@@ -47,6 +50,7 @@ impl Contract {
     /// Calls an already-deployed contract code.
     /// Note that this is a "generic" call to a contract
     /// and it doesn't, yet, call a specific ABI function in that contract.
+    #[cfg(feature = "fuel-gql-client")]
     pub async fn call(
         contract_id: ContractId,
         encoded_selector: Option<Selector>,
@@ -154,6 +158,7 @@ impl Contract {
     ///     }
     /// }
     /// For more details see `code_gen/functions_gen.rs`.
+    #[cfg(feature = "fuel-gql-client")]
     pub fn method_hash<D: Detokenize>(
         fuel_client: &FuelClient,
         compiled_contract: &CompiledContract,
@@ -206,6 +211,7 @@ impl Contract {
     /// Launches a local `fuel-core` network and deploys a contract to it.
     /// If you want to deploy a contract against another network of
     /// your choosing, use the `deploy` function instead.
+    #[cfg(all(feature = "fuel-core", feature = "fuel-gql-client"))]
     pub async fn launch_and_deploy(
         compiled_contract: &CompiledContract,
     ) -> Result<(FuelClient, ContractId), Error> {
@@ -219,6 +225,7 @@ impl Contract {
     }
 
     /// Deploys a compiled contract to a running node
+    #[cfg(feature = "fuel-gql-client")]
     pub async fn deploy(
         compiled_contract: &CompiledContract,
         fuel_client: &FuelClient,
@@ -306,6 +313,7 @@ impl Contract {
 #[must_use = "contract calls do nothing unless you `call` them"]
 /// Helper for managing a transaction before submitting it to a node
 pub struct ContractCall<D> {
+    #[cfg(feature = "fuel-gql-client")]
     pub fuel_client: FuelClient,
     pub compiled_contract: CompiledContract,
     pub encoded_args: Vec<u8>,
@@ -333,6 +341,7 @@ where
     /// `Result<bool, Error>`. Also works for structs! If your method
     /// returns `MyStruct`, `MyStruct` will be generated through the `abigen!()`
     /// and this will return `Result<MyStruct, Error>`.
+    #[cfg(feature = "fuel-gql-client")]
     pub async fn call(self) -> Result<D, Error> {
         let receipts = Contract::call(
             self.contract_id,

--- a/fuels-rs/src/contract.rs
+++ b/fuels-rs/src/contract.rs
@@ -1,22 +1,34 @@
+#[cfg(feature = "fuel-gql-client")]
 use crate::abi_decoder::ABIDecoder;
+#[cfg(feature = "fuel-gql-client")]
 use crate::abi_encoder::ABIEncoder;
 use crate::errors::Error;
 #[cfg(feature = "fuel-gql-client")]
 use crate::script::Script;
 use forc::test::{forc_build, BuildCommand};
 use forc::util::helpers::read_manifest;
+#[cfg(feature = "fuel-gql-client")]
 use fuel_asm::Opcode;
 #[cfg(feature = "fuel-core")]
 use fuel_core::service::{Config, FuelService};
 #[cfg(feature = "fuel-gql-client")]
 use fuel_gql_client::client::FuelClient;
-use fuel_tx::{ContractId, Input, Output, Receipt, Transaction};
-use fuel_types::{Bytes32, Immediate12, Salt, Word};
+#[cfg(feature = "fuel-gql-client")]
+use fuel_tx::Receipt;
+use fuel_tx::{ContractId, Input, Output, Transaction};
+use fuel_types::{Bytes32, Salt};
+#[cfg(feature = "fuel-gql-client")]
+use fuel_types::{Immediate12, Word};
+#[cfg(feature = "fuel-gql-client")]
 use fuel_vm::consts::{REG_CGAS, REG_RET, REG_ZERO, VM_TX_MEMORY};
 use fuel_vm::prelude::Contract as FuelContract;
 use fuels_core::ParamType;
-use fuels_core::{Detokenize, Selector, Token, WORD_SIZE};
+use fuels_core::{Detokenize, Selector};
+#[cfg(feature = "fuel-gql-client")]
+use fuels_core::{Token, WORD_SIZE};
+#[cfg(feature = "fuel-gql-client")]
 use rand::rngs::StdRng;
+#[cfg(feature = "fuel-gql-client")]
 use rand::{Rng, SeedableRng};
 use std::marker::PhantomData;
 use std::path::PathBuf;
@@ -372,6 +384,7 @@ where
         Ok(D::from_tokens(decoded)?)
     }
 
+    #[cfg(feature = "fuel-gql-client")]
     fn get_receipt_value(receipts: &[Receipt]) -> Option<u64> {
         for receipt in receipts {
             if receipt.val().is_some() {

--- a/fuels-rs/src/lib.rs
+++ b/fuels-rs/src/lib.rs
@@ -3,6 +3,7 @@ pub mod contract;
 pub mod errors;
 pub mod json_abi;
 pub mod rustfmt;
+#[cfg(feature = "fuel-core")]
 pub mod script;
 pub mod source;
 pub mod types;


### PR DESCRIPTION
The abi-gen-macro crate transitively includes fuel-core and fuel-gql-client even though those deps aren't used at all in the codegen process. This was causing circular dependencies when testing abi gen in the fuel-core indexer service. 

Ideally, codegen is refactored to live in fuels-core without requiring fuel-core or fuel-gql-client. I attempted this, but it was going to be too much of a major change, and resorted to feature flagging for now (basically the only thing left in fuels-rs after my refactor was the script module and some contract deployment and call functions). 