### PR TITLE
feat: return receipts in data returned by contract calls

### DIFF
--- a/fuels-abigen-macro/tests/harness.rs
+++ b/fuels-abigen-macro/tests/harness.rs
@@ -755,7 +755,7 @@ async fn example_workflow() {
         .await
         .unwrap();
 
-    assert_eq!(42, result);
+    assert_eq!(42, result.value);
 
     let result = contract_instance
         .increment_counter(10)
@@ -763,7 +763,7 @@ async fn example_workflow() {
         .await
         .unwrap();
 
-    assert_eq!(52, result);
+    assert_eq!(52, result.value);
 }
 
 #[tokio::test]
@@ -912,7 +912,7 @@ async fn type_safe_output_values() {
 
     // `response`'s type matches the return type of `is_event()`
     let response = contract_instance.is_even(10).call().await.unwrap();
-    assert!(response);
+    assert!(response.value);
 
     // `response`'s type matches the return type of `return_my_string()`
     let response = contract_instance
@@ -921,7 +921,7 @@ async fn type_safe_output_values() {
         .await
         .unwrap();
 
-    assert_eq!(response, "fuel");
+    assert_eq!(response.value, "fuel");
 
     let my_struct = MyStruct { foo: 10, bar: true };
 
@@ -1044,7 +1044,7 @@ async fn call_with_structs() {
         .await
         .unwrap();
 
-    assert_eq!(42, result);
+    assert_eq!(42, result.value);
 
     let result = contract_instance
         .increment_counter(10)
@@ -1052,7 +1052,7 @@ async fn call_with_structs() {
         .await
         .unwrap();
 
-    assert_eq!(52, result);
+    assert_eq!(52, result.value);
 }
 
 #[tokio::test]

--- a/fuels-rs/src/contract.rs
+++ b/fuels-rs/src/contract.rs
@@ -362,7 +362,7 @@ where
         .await
         .unwrap();
 
-        let encoded_value = match receipts.iter().find(|&receipts| receipt.val().is_some()) {
+        let encoded_value = match receipts.iter().find(|&receipt| receipt.val().is_some()) {
             Some(r) => r.val().unwrap().to_be_bytes(),
             None => [0u8; 8],
         };

--- a/fuels-rs/src/contract.rs
+++ b/fuels-rs/src/contract.rs
@@ -297,12 +297,12 @@ impl<D> ContractCall<D>
 where
     D: Detokenize,
 {
-    /// Call a contract's method. Note that it will return
-    /// the method's value as an actual typed value `D`.
-    /// For instance, if your method returns a `bool`, this will be a
-    /// `Result<bool, Error>`. Also works for structs! If your method
-    /// returns `MyStruct`, `MyStruct` will be generated through the `abigen!()`
-    /// and this will return `Result<MyStruct, Error>`.
+    /// Call a contract's method. Return a Result<CallResponse, Error>.
+    /// The CallResponse structs contains the method's value in its `value`
+    /// field as an actual typed value `D` (if your method returns `bool`, it will
+    /// be a bool, works also for structs thanks to the `abigen!()`).
+    /// The other field of CallResponse, `receipts`, contains the receipts of the
+    /// transaction
     pub async fn call(self) -> Result<CallResponse<D>, Error> {
         let mut receipts = Contract::call(
             self.contract_id,


### PR DESCRIPTION
- Introduce the CallResult struct, that holds the call return in its
  `value` field, and the receipts in the `receipts` field.
- This closes issue #35
