### PR TITLE
Fixes ambiguity on two diff structs with same arg name

### DIFF
--- a/fuels-abigen-macro/tests/test_projects/two-structs/Cargo.toml
+++ b/fuels-abigen-macro/tests/test_projects/two-structs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "demo"
 version = "0.1.0"
-authors = ["Rodrigo Araujo"]
+authors = ["Fuel Labs"]
 edition = "2021"
 license = "Apache-2.0"
 

--- a/fuels-abigen-macro/tests/test_projects/two-structs/Cargo.toml
+++ b/fuels-abigen-macro/tests/test_projects/two-structs/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "demo"
+version = "0.1.0"
+authors = ["Rodrigo Araujo"]
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+fuels-abigen-macro = "0.2"
+fuels-core = "0.2"
+fuels-rs = "0.2"
+fuel-gql-client = { version = "0.2", default-features = false }
+fuel-tx = "0.3"
+rand = "0.8"
+tokio = { version = "1.12", features = ["rt", "macros"] }
+
+[[test]]
+name = "integration_tests"
+path = "tests/harness.rs"
+harness = true

--- a/fuels-abigen-macro/tests/test_projects/two-structs/Forc.toml
+++ b/fuels-abigen-macro/tests/test_projects/two-structs/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+name = "demo"
+author = "Rodrigo Araujo"
+entry = "main.sw"
+license = "Apache-2.0"
+
+[dependencies]
+core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std" }

--- a/fuels-abigen-macro/tests/test_projects/two-structs/Forc.toml
+++ b/fuels-abigen-macro/tests/test_projects/two-structs/Forc.toml
@@ -1,6 +1,6 @@
 [project]
 name = "demo"
-author = "Rodrigo Araujo"
+author = "Fuel Labs"
 entry = "main.sw"
 license = "Apache-2.0"
 

--- a/fuels-abigen-macro/tests/test_projects/two-structs/abi.json
+++ b/fuels-abigen-macro/tests/test_projects/two-structs/abi.json
@@ -1,0 +1,80 @@
+[
+    {
+        "inputs": [
+            {
+                "components": null,
+                "name": "gas_",
+                "type": "u64"
+            },
+            {
+                "components": null,
+                "name": "amount_",
+                "type": "u64"
+            },
+            {
+                "components": null,
+                "name": "color_",
+                "type": "b256"
+            },
+            {
+                "components": [
+                    {
+                        "components": null,
+                        "name": "foo",
+                        "type": "u64"
+                    }
+                ],
+                "name": "input",
+                "type": "struct StructOne"
+            }
+        ],
+        "name": "something",
+        "outputs": [
+            {
+                "components": null,
+                "name": "",
+                "type": "u64"
+            }
+        ],
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": null,
+                "name": "gas_",
+                "type": "u64"
+            },
+            {
+                "components": null,
+                "name": "amount_",
+                "type": "u64"
+            },
+            {
+                "components": null,
+                "name": "color_",
+                "type": "b256"
+            },
+            {
+                "components": [
+                    {
+                        "components": null,
+                        "name": "bar",
+                        "type": "u64"
+                    }
+                ],
+                "name": "input",
+                "type": "struct StructTwo"
+            }
+        ],
+        "name": "something_else",
+        "outputs": [
+            {
+                "components": null,
+                "name": "",
+                "type": "u64"
+            }
+        ],
+        "type": "function"
+    }
+]

--- a/fuels-abigen-macro/tests/test_projects/two-structs/src/main.sw
+++ b/fuels-abigen-macro/tests/test_projects/two-structs/src/main.sw
@@ -1,0 +1,26 @@
+contract;
+
+pub struct StructOne {
+    foo: u64,
+}
+
+pub struct StructTwo {
+    bar: u64,
+}
+
+abi MyTest {
+    fn something(gas_: u64, amount_: u64, color_: b256, input: StructTwo) -> u64;
+    fn something_else(gas_: u64, amount_: u64, color_: b256, input: StructOne) -> u64;
+}
+
+impl MyTest for Contract {
+    fn something(gas_: u64, amount_: u64, color_: b256, input: StructOne) -> u64 {
+        let v = input.foo; 
+        v + 1
+    }    
+
+    fn something_else(gas_: u64, amount_: u64, color_: b256, input: StructTwo) -> u64 {
+        let v = input.bar; 
+        v - 1
+    }    
+}

--- a/fuels-abigen-macro/tests/test_projects/two-structs/tests/harness.rs
+++ b/fuels-abigen-macro/tests/test_projects/two-structs/tests/harness.rs
@@ -1,0 +1,22 @@
+use fuel_tx::Salt;
+use fuels_abigen_macro::abigen;
+use fuels_rs::contract::Contract;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+abigen!(MyContract, "./abi.json");
+
+#[tokio::test]
+async fn harness() {
+    let rng = &mut StdRng::seed_from_u64(2322u64);
+
+    // Build the contract
+    let salt: [u8; 32] = rng.gen();
+    let salt = Salt::from(salt);
+    let compiled = Contract::compile_sway_contract("./", salt).unwrap();
+
+    // Launch a local network and deploy the contract
+    let (client, _contract_id) = Contract::launch_and_deploy(&compiled).await.unwrap();
+
+    let contract_instance = MyContract::new(compiled, client);
+}


### PR DESCRIPTION
Fixes https://github.com/FuelLabs/fuels-rs/issues/77. 

Also simplifies some things related to custom types.