### PR TITLE
Add --no-verify flag to publish crate action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,4 +85,5 @@ jobs:
       uses: katyo/publish-crates@v1
       with:
           publish-delay: 30000
+          args: --no-verify
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Our crate publishing step is still blocked by this PR: https://github.com/katyo/publish-crates/pull/394. 

However, as shown by `katyo` (author of `publish-crates`), one can work around the cyclic deps issue by using the `--no-verify` flag, which is equivalent to the `--no-verify` flag in here: https://doc.rust-lang.org/cargo/commands/cargo-publish.html. Here's the concrete example linked by the author: https://github.com/DelSkayn/rquickjs/blob/master/.github/workflows/ci.yml#L349. 

This PR enables that in order to try and unblock us for the release of the `v0.3.0`. 

