### PR TITLE
refactor: add an argument to enable strict argument checking in abigen macro

### DIFF
--- a/fuels-abi-cli/src/main.rs
+++ b/fuels-abi-cli/src/main.rs
@@ -104,7 +104,7 @@ fn code_gen(code: Codegen) -> anyhow::Result<String> {
     } = code;
 
     let contract = fs::read_to_string(input)?;
-    let mut abi = Abigen::new(&name, contract, false)?;
+    let mut abi = Abigen::new(&name, contract)?;
 
     if no_std {
         abi = abi.no_std();

--- a/fuels-abi-cli/src/main.rs
+++ b/fuels-abi-cli/src/main.rs
@@ -104,7 +104,7 @@ fn code_gen(code: Codegen) -> anyhow::Result<String> {
     } = code;
 
     let contract = fs::read_to_string(input)?;
-    let mut abi = Abigen::new(&name, contract)?;
+    let mut abi = Abigen::new(&name, contract, false)?;
 
     if no_std {
         abi = abi.no_std();

--- a/fuels-abigen-macro/src/lib.rs
+++ b/fuels-abigen-macro/src/lib.rs
@@ -4,7 +4,7 @@ use proc_macro2::Span;
 
 use std::ops::Deref;
 use syn::parse::{Parse, ParseStream, Result as ParseResult};
-use syn::{parse_macro_input, Ident, LitBool, LitStr, Token};
+use syn::{parse_macro_input, Ident, LitStr, Token};
 
 /// Abigen proc macro definition and helper functions/types.
 
@@ -12,7 +12,7 @@ use syn::{parse_macro_input, Ident, LitBool, LitStr, Token};
 pub fn abigen(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as Spanned<ContractArgs>);
 
-    let c = Abigen::new(&args.name, &args.abi, args.strict_checking).unwrap();
+    let c = Abigen::new(&args.name, &args.abi).unwrap();
 
     c.expand().unwrap().into()
 }
@@ -21,9 +21,7 @@ pub fn abigen(input: TokenStream) -> TokenStream {
 pub fn wasm_abigen(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as Spanned<ContractArgs>);
 
-    let c = Abigen::new(&args.name, &args.abi, args.strict_checking)
-        .unwrap()
-        .no_std();
+    let c = Abigen::new(&args.name, &args.abi).unwrap().no_std();
 
     c.expand().unwrap().into()
 }
@@ -78,7 +76,6 @@ impl<T> Deref for Spanned<T> {
 pub(crate) struct ContractArgs {
     name: String,
     abi: String,
-    strict_checking: bool,
 }
 
 impl ParseInner for ContractArgs {
@@ -93,20 +90,10 @@ impl ParseInner for ContractArgs {
             let literal = input.parse::<LitStr>()?;
             (literal.span(), literal.value())
         };
-        input.parse::<Token![,]>()?;
-        let strict_checking = input.parse::<LitBool>()?.value();
-
         if !input.is_empty() {
             input.parse::<Token![,]>()?;
         }
 
-        Ok((
-            span,
-            ContractArgs {
-                name,
-                abi,
-                strict_checking,
-            },
-        ))
+        Ok((span, ContractArgs { name, abi }))
     }
 }

--- a/fuels-abigen-macro/tests/harness.rs
+++ b/fuels-abigen-macro/tests/harness.rs
@@ -744,7 +744,7 @@ async fn create_struct_from_decoded_tokens() {
         hex::encode(contract_call.encoded_args)
     );
 
-    assert_eq!("00000000cb0b2f05000000000000000a0000000000000001", encoded);
+    assert_eq!("0000000087e388fd000000000000000a0000000000000001", encoded);
 }
 
 #[tokio::test]
@@ -829,7 +829,7 @@ async fn create_nested_struct_from_decoded_tokens() {
         hex::encode(contract_call.encoded_args)
     );
 
-    assert_eq!("0000000088bf8a1b000000000000000a0000000000000001", encoded);
+    assert_eq!("0000000074c481ed000000000000000a0000000000000001", encoded);
 }
 
 #[tokio::test]

--- a/fuels-abigen-macro/tests/harness.rs
+++ b/fuels-abigen-macro/tests/harness.rs
@@ -20,7 +20,6 @@ async fn compile_bindings_from_contract_file() {
     abigen!(
         SimpleContract,
         "fuels-abigen-macro/tests/takes_ints_returns_bool.json",
-        true,
     );
 
     let fuel_client = setup_local_node().await;
@@ -62,12 +61,23 @@ async fn compile_bindings_from_inline_contract() {
                 "type": "function",
                 "inputs": [
                     {
-                        "name": "arg",
-                        "type": "u32"
+                        "components": null,
+                        "name": "gas_",
+                        "type": "u64"
                     },
                     {
-                        "name": "second_arg",
-                        "type": "u16"
+                        "components": null,
+                        "name": "amount_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "color_",
+                        "type": "b256"
+                    },
+                    {
+                        "name": "only_argument",
+                        "type": "u32"
                     }
                 ],
                 "name": "takes_ints_returns_bool",
@@ -80,14 +90,13 @@ async fn compile_bindings_from_inline_contract() {
             }
         ]
         "#,
-        false,
     );
 
     let fuel_client = setup_local_node().await;
 
     let contract_instance = SimpleContract::new(Default::default(), fuel_client);
 
-    let contract_call = contract_instance.takes_ints_returns_bool(42 as u32, 10 as u16);
+    let contract_call = contract_instance.takes_ints_returns_bool(42 as u32);
 
     let encoded = format!(
         "{}{}",
@@ -95,7 +104,7 @@ async fn compile_bindings_from_inline_contract() {
         hex::encode(contract_call.encoded_args)
     );
 
-    assert_eq!("0000000003b568d4000000000000002a000000000000000a", encoded);
+    assert_eq!("00000000155799f1000000000000002a", encoded);
 }
 
 #[tokio::test]
@@ -109,6 +118,21 @@ async fn compile_bindings_single_param() {
             {
                 "type": "function",
                 "inputs": [
+                    {
+                        "components": null,
+                        "name": "gas_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "amount_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "color_",
+                        "type": "b256"
+                    },
                     {
                         "name": "arg",
                         "type": "u32"
@@ -124,7 +148,6 @@ async fn compile_bindings_single_param() {
             }
         ]
         "#,
-        false,
     );
 
     let fuel_client = setup_local_node().await;
@@ -139,7 +162,7 @@ async fn compile_bindings_single_param() {
         hex::encode(contract_call.encoded_args)
     );
 
-    assert_eq!("000000009593586c000000000000002a", encoded);
+    assert_eq!("00000000155799f1000000000000002a", encoded);
 }
 
 #[tokio::test]
@@ -154,6 +177,21 @@ async fn compile_bindings_array_input() {
                 "type":"contract",
                 "inputs":[
                     {
+                        "components": null,
+                        "name": "gas_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "amount_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "color_",
+                        "type": "b256"
+                    },
+                    {
                         "name":"arg",
                         "type":"u16[3]"
                     }
@@ -165,7 +203,6 @@ async fn compile_bindings_array_input() {
             }
         ]
         "#,
-        false,
     );
 
     let fuel_client = setup_local_node().await;
@@ -182,7 +219,7 @@ async fn compile_bindings_array_input() {
     );
 
     assert_eq!(
-        "00000000f0b878640000000000000001000000000000000200000000000000030000000000000004",
+        "00000000530300750000000000000001000000000000000200000000000000030000000000000004",
         encoded
     );
 }
@@ -199,6 +236,21 @@ async fn compile_bindings_bool_array_input() {
                 "type":"contract",
                 "inputs":[
                     {
+                        "components": null,
+                        "name": "gas_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "amount_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "color_",
+                        "type": "b256"
+                    },
+                    {
                         "name":"arg",
                         "type":"bool[3]"
                     }
@@ -210,7 +262,6 @@ async fn compile_bindings_bool_array_input() {
             }
         ]
         "#,
-        false,
     );
 
     let fuel_client = setup_local_node().await;
@@ -227,7 +278,7 @@ async fn compile_bindings_bool_array_input() {
     );
 
     assert_eq!(
-        "00000000f8fe942c000000000000000100000000000000000000000000000001",
+        "000000000abaed98000000000000000100000000000000000000000000000001",
         encoded
     );
 }
@@ -244,6 +295,21 @@ async fn compile_bindings_byte_input() {
                 "type":"contract",
                 "inputs":[
                     {
+                        "components": null,
+                        "name": "gas_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "amount_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "color_",
+                        "type": "b256"
+                    },
+                    {
                         "name":"arg",
                         "type":"byte"
                     }
@@ -255,7 +321,6 @@ async fn compile_bindings_byte_input() {
             }
         ]
         "#,
-        false,
     );
 
     let fuel_client = setup_local_node().await;
@@ -270,7 +335,7 @@ async fn compile_bindings_byte_input() {
         hex::encode(contract_call.encoded_args)
     );
 
-    assert_eq!("00000000a4bd3861000000000000000a", encoded);
+    assert_eq!("000000001be28a53000000000000000a", encoded);
 }
 
 #[tokio::test]
@@ -285,6 +350,21 @@ async fn compile_bindings_string_input() {
                 "type":"contract",
                 "inputs":[
                     {
+                        "components": null,
+                        "name": "gas_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "amount_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "color_",
+                        "type": "b256"
+                    },
+                    {
                         "name":"arg",
                         "type":"str[23]"
                     }
@@ -296,7 +376,6 @@ async fn compile_bindings_string_input() {
             }
         ]
         "#,
-        false,
     );
 
     let fuel_client = setup_local_node().await;
@@ -312,7 +391,7 @@ async fn compile_bindings_string_input() {
     );
 
     assert_eq!(
-        "00000000d56e76515468697320697320612066756c6c2073656e74656e636500",
+        "00000000da2c7a675468697320697320612066756c6c2073656e74656e636500",
         encoded
     );
 }
@@ -329,6 +408,21 @@ async fn compile_bindings_b256_input() {
                 "type":"contract",
                 "inputs":[
                     {
+                        "components": null,
+                        "name": "gas_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "amount_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "color_",
+                        "type": "b256"
+                    },
+                    {
                         "name":"arg",
                         "type":"b256"
                     }
@@ -340,7 +434,6 @@ async fn compile_bindings_b256_input() {
             }
         ]
         "#,
-        false,
     );
 
     let fuel_client = setup_local_node().await;
@@ -361,7 +454,7 @@ async fn compile_bindings_b256_input() {
     );
 
     assert_eq!(
-        "0000000054992852d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b",
+        "00000000250fb0f2d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b",
         encoded
     );
 }
@@ -377,6 +470,21 @@ async fn compile_bindings_struct_input() {
             {
                 "type":"contract",
                 "inputs":[
+                    {
+                        "components": null,
+                        "name": "gas_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "amount_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "color_",
+                        "type": "b256"
+                    },
                     {
                         "name":"value",
                         "type":"struct MyStruct",
@@ -397,7 +505,6 @@ async fn compile_bindings_struct_input() {
             }
         ]
         "#,
-        false,
     );
 
     let fuel_client = setup_local_node().await;
@@ -420,7 +527,7 @@ async fn compile_bindings_struct_input() {
     );
 
     assert_eq!(
-        "00000000f427d499000000000000000a00000000000000026675656c00000000",
+        "0000000081dae8d1000000000000000a00000000000000026675656c00000000",
         encoded
     );
 }
@@ -436,6 +543,21 @@ async fn compile_bindings_nested_struct_input() {
             {
                 "type":"contract",
                 "inputs":[
+                    {
+                        "components": null,
+                        "name": "gas_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "amount_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "color_",
+                        "type": "b256"
+                    },
                     {
                         "name":"top_value",
                         "type":"struct MyNestedStruct",
@@ -462,7 +584,6 @@ async fn compile_bindings_nested_struct_input() {
             }
         ]
         "#,
-        false,
     );
 
     let inner_struct = InnerStruct { a: true };
@@ -484,7 +605,7 @@ async fn compile_bindings_nested_struct_input() {
         hex::encode(contract_call.encoded_args)
     );
 
-    assert_eq!("0000000088bf8a1b000000000000000a0000000000000001", encoded);
+    assert_eq!("0000000074c481ed000000000000000a0000000000000001", encoded);
 }
 
 #[tokio::test]
@@ -498,6 +619,21 @@ async fn compile_bindings_enum_input() {
             {
                 "type":"contract",
                 "inputs":[
+                    {
+                        "components": null,
+                        "name": "gas_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "amount_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "color_",
+                        "type": "b256"
+                    },
                     {
                         "name":"my_enum",
                         "type":"enum MyEnum",
@@ -518,7 +654,6 @@ async fn compile_bindings_enum_input() {
             }
         ]
         "#,
-        false,
     );
 
     let variant = MyEnum::X(42);
@@ -535,7 +670,7 @@ async fn compile_bindings_enum_input() {
         hex::encode(contract_call.encoded_args)
     );
 
-    assert_eq!("00000000082e0dfa0000000000000000000000000000002a", encoded);
+    assert_eq!("0000000085dab9fc0000000000000000000000000000002a", encoded);
 }
 
 #[tokio::test]
@@ -549,6 +684,21 @@ async fn create_struct_from_decoded_tokens() {
             {
                 "type":"contract",
                 "inputs":[
+                    {
+                        "components": null,
+                        "name": "gas_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "amount_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "color_",
+                        "type": "b256"
+                    },
                     {
                         "name":"my_val",
                         "type":"struct MyStruct",
@@ -569,7 +719,6 @@ async fn create_struct_from_decoded_tokens() {
             }
         ]
         "#,
-        false,
     );
 
     // Decoded tokens
@@ -610,6 +759,21 @@ async fn create_nested_struct_from_decoded_tokens() {
                 "type":"contract",
                 "inputs":[
                     {
+                        "components": null,
+                        "name": "gas_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "amount_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "color_",
+                        "type": "b256"
+                    },
+                    {
                         "name":"input",
                         "type":"struct MyNestedStruct",
                         "components": [
@@ -635,7 +799,6 @@ async fn create_nested_struct_from_decoded_tokens() {
             }
         ]
         "#,
-        false,
     );
 
     // Creating just the InnerStruct is possible
@@ -747,7 +910,6 @@ async fn example_workflow() {
             }
         ]
         "#,
-        true,
     );
 
     // Build the contract
@@ -909,7 +1071,6 @@ async fn type_safe_output_values() {
             }
         ]
         "#,
-        true
     );
 
     // Build the contract
@@ -1032,7 +1193,6 @@ async fn call_with_structs() {
             }
         ]
         "#,
-        true,
     );
 
     // Build the contract
@@ -1116,7 +1276,6 @@ async fn call_with_empty_return() {
             }
         ]
         "#,
-        true,
     );
 
     // Build the contract
@@ -1146,7 +1305,6 @@ async fn abigen_different_structs_same_arg_name() {
     abigen!(
         MyContract,
         "fuels-abigen-macro/tests/test_projects/two-structs/abi.json",
-        true
     );
 
     // Build the contract

--- a/fuels-abigen-macro/tests/harness.rs
+++ b/fuels-abigen-macro/tests/harness.rs
@@ -19,7 +19,8 @@ async fn compile_bindings_from_contract_file() {
     // The generated bindings can be accessed through `SimpleContract`.
     abigen!(
         SimpleContract,
-        "fuels-abigen-macro/tests/takes_ints_returns_bool.json"
+        "fuels-abigen-macro/tests/takes_ints_returns_bool.json",
+        true,
     );
 
     let fuel_client = setup_local_node().await;
@@ -33,7 +34,7 @@ async fn compile_bindings_from_contract_file() {
     // Currently this prints `0000000003b568d4000000000000002a000000000000000a`
     // The encoded contract call. Soon it'll be able to perform the
     // actual call.
-    let contract_call = contract_instance.takes_ints_returns_bool(42, 10);
+    let contract_call = contract_instance.takes_ints_returns_bool(42);
 
     // Then you'll be able to use `.call()` to actually call the contract with the
     // specified function:
@@ -46,7 +47,7 @@ async fn compile_bindings_from_contract_file() {
         hex::encode(contract_call.encoded_args)
     );
 
-    assert_eq!("00000000c39ba1e9000000000000002a000000000000000a", encoded);
+    assert_eq!("00000000155799f1000000000000002a", encoded);
 }
 
 #[tokio::test]
@@ -78,7 +79,8 @@ async fn compile_bindings_from_inline_contract() {
                 ]
             }
         ]
-        "#
+        "#,
+        false,
     );
 
     let fuel_client = setup_local_node().await;
@@ -121,7 +123,8 @@ async fn compile_bindings_single_param() {
                 ]
             }
         ]
-        "#
+        "#,
+        false,
     );
 
     let fuel_client = setup_local_node().await;
@@ -161,7 +164,8 @@ async fn compile_bindings_array_input() {
                 ]
             }
         ]
-        "#
+        "#,
+        false,
     );
 
     let fuel_client = setup_local_node().await;
@@ -205,7 +209,8 @@ async fn compile_bindings_bool_array_input() {
                 ]
             }
         ]
-        "#
+        "#,
+        false,
     );
 
     let fuel_client = setup_local_node().await;
@@ -249,7 +254,8 @@ async fn compile_bindings_byte_input() {
                 ]
             }
         ]
-        "#
+        "#,
+        false,
     );
 
     let fuel_client = setup_local_node().await;
@@ -289,7 +295,8 @@ async fn compile_bindings_string_input() {
                 ]
             }
         ]
-        "#
+        "#,
+        false,
     );
 
     let fuel_client = setup_local_node().await;
@@ -332,7 +339,8 @@ async fn compile_bindings_b256_input() {
                 ]
             }
         ]
-        "#
+        "#,
+        false,
     );
 
     let fuel_client = setup_local_node().await;
@@ -388,7 +396,8 @@ async fn compile_bindings_struct_input() {
                 "outputs":[]
             }
         ]
-        "#
+        "#,
+        false,
     );
 
     let fuel_client = setup_local_node().await;
@@ -452,7 +461,8 @@ async fn compile_bindings_nested_struct_input() {
                 "outputs":[]
             }
         ]
-        "#
+        "#,
+        false,
     );
 
     let inner_struct = InnerStruct { a: true };
@@ -507,7 +517,8 @@ async fn compile_bindings_enum_input() {
                 "outputs":[]
             }
         ]
-        "#
+        "#,
+        false,
     );
 
     let variant = MyEnum::X(42);
@@ -557,7 +568,8 @@ async fn create_struct_from_decoded_tokens() {
                 "outputs":[]
             }
         ]
-        "#
+        "#,
+        false,
     );
 
     // Decoded tokens
@@ -622,7 +634,8 @@ async fn create_nested_struct_from_decoded_tokens() {
                 "outputs":[]
             }
         ]
-        "#
+        "#,
+        false,
     );
 
     // Creating just the InnerStruct is possible
@@ -733,7 +746,8 @@ async fn example_workflow() {
                 "type": "function"
             }
         ]
-        "#
+        "#,
+        true,
     );
 
     // Build the contract
@@ -894,7 +908,8 @@ async fn type_safe_output_values() {
                 ]
             }
         ]
-        "#
+        "#,
+        true
     );
 
     // Build the contract
@@ -1016,7 +1031,8 @@ async fn call_with_structs() {
                 "type": "function"
             }
         ]
-        "#
+        "#,
+        true,
     );
 
     // Build the contract
@@ -1099,7 +1115,8 @@ async fn call_with_empty_return() {
                 "type": "function"
             }
         ]
-        "#
+        "#,
+        true,
     );
 
     // Build the contract
@@ -1128,7 +1145,8 @@ async fn abigen_different_structs_same_arg_name() {
 
     abigen!(
         MyContract,
-        "fuels-abigen-macro/tests/test_projects/two-structs/abi.json"
+        "fuels-abigen-macro/tests/test_projects/two-structs/abi.json",
+        true
     );
 
     // Build the contract

--- a/fuels-abigen-macro/tests/takes_ints_returns_bool.json
+++ b/fuels-abigen-macro/tests/takes_ints_returns_bool.json
@@ -15,7 +15,7 @@
                 "type": "b256"
             },
             {
-                "name": "first_arg",
+                "name": "only_argument",
                 "type": "u32"
             }
         ],

--- a/fuels-abigen-macro/tests/takes_ints_returns_bool.json
+++ b/fuels-abigen-macro/tests/takes_ints_returns_bool.json
@@ -15,12 +15,8 @@
                 "type": "b256"
             },
             {
-                "name": "arg",
+                "name": "first_arg",
                 "type": "u32"
-            },
-            {
-                "name": "second_arg",
-                "type": "u16"
             }
         ],
         "name": "takes_ints_returns_bool",

--- a/fuels-core/src/code_gen/abigen.rs
+++ b/fuels-core/src/code_gen/abigen.rs
@@ -35,6 +35,10 @@ pub struct Abigen {
 
     /// Generate no-std safe code
     no_std: bool,
+
+    /// Check that the arguments are exactly as follows:
+    /// [gas_(u64), amount_(u64), color_(b256), custom(T)]
+    strict_checking: bool,
 }
 
 impl Abigen {
@@ -65,11 +69,17 @@ impl Abigen {
             abi_parser: ABIParser::new(),
             rustfmt: true,
             no_std: false,
+            strict_checking: false,
         })
     }
 
     pub fn no_std(mut self) -> Self {
         self.no_std = true;
+        self
+    }
+
+    pub fn strict_checking(mut self) -> Self {
+        self.strict_checking = true;
         self
     }
 
@@ -160,6 +170,7 @@ impl Abigen {
                 &self.abi_parser,
                 &self.custom_enums,
                 &self.custom_structs,
+                &self.strict_checking,
             )?;
             tokenized_functions.push(tokenized_fn);
         }

--- a/fuels-core/src/code_gen/abigen.rs
+++ b/fuels-core/src/code_gen/abigen.rs
@@ -35,19 +35,11 @@ pub struct Abigen {
 
     /// Generate no-std safe code
     no_std: bool,
-
-    /// Check that the arguments are exactly as follows:
-    /// [gas_(u64), amount_(u64), color_(b256), custom(T)]
-    strict_checking: bool,
 }
 
 impl Abigen {
     /// Creates a new contract with the given ABI JSON source.
-    pub fn new<S: AsRef<str>>(
-        contract_name: &str,
-        abi_source: S,
-        strict_checking: bool,
-    ) -> Result<Self, Error> {
+    pub fn new<S: AsRef<str>>(contract_name: &str, abi_source: S) -> Result<Self, Error> {
         let source = Source::parse(abi_source).unwrap();
         let mut parsed_abi: JsonABI = serde_json::from_str(&source.get().unwrap())?;
 
@@ -73,17 +65,11 @@ impl Abigen {
             abi_parser: ABIParser::new(),
             rustfmt: true,
             no_std: false,
-            strict_checking,
         })
     }
 
     pub fn no_std(mut self) -> Self {
         self.no_std = true;
-        self
-    }
-
-    pub fn strict_checking(mut self) -> Self {
-        self.strict_checking = true;
         self
     }
 
@@ -174,7 +160,6 @@ impl Abigen {
                 &self.abi_parser,
                 &self.custom_enums,
                 &self.custom_structs,
-                self.strict_checking,
             )?;
             tokenized_functions.push(tokenized_fn);
         }
@@ -288,6 +273,21 @@ mod tests {
                 "type":"contract",
                 "inputs":[
                     {
+                        "components": null,
+                        "name": "gas_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "amount_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "color_",
+                        "type": "b256"
+                    },
+                    {
                         "name":"arg",
                         "type":"u32"
                     }
@@ -303,10 +303,7 @@ mod tests {
         ]
         "#;
 
-        let bindings = Abigen::new("test", contract, false)
-            .unwrap()
-            .generate()
-            .unwrap();
+        let bindings = Abigen::new("test", contract).unwrap().generate().unwrap();
         bindings.write(std::io::stdout()).unwrap();
     }
 
@@ -317,6 +314,21 @@ mod tests {
             {
                 "type":"contract",
                 "inputs":[
+                    {
+                        "components": null,
+                        "name": "gas_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "amount_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "color_",
+                        "type": "b256"
+                    },
                     {
                         "name":"arg",
                         "type":"u32"
@@ -337,11 +349,8 @@ mod tests {
         ]
         "#;
 
-        let bindings = Abigen::new("test", contract, false)
-            .unwrap()
-            .generate()
-            .unwrap();
-        bindings.write(std::io::stdout()).unwrap();
+        let bindings = Abigen::new("test", contract).unwrap().generate();
+        assert!(matches!(bindings, Err(Error::MissingData(_))));
     }
 
     #[test]
@@ -351,6 +360,21 @@ mod tests {
             {
                 "type":"contract",
                 "inputs":[
+                    {
+                        "components": null,
+                        "name": "gas_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "amount_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "color_",
+                        "type": "b256"
+                    },
                     {
                         "name":"value",
                         "type":"struct MyStruct",
@@ -372,7 +396,7 @@ mod tests {
         ]
         "#;
 
-        let contract = Abigen::new("custom", contract, false).unwrap();
+        let contract = Abigen::new("custom", contract).unwrap();
 
         assert_eq!(1, contract.custom_structs.len());
 
@@ -389,6 +413,21 @@ mod tests {
             {
                 "type":"contract",
                 "inputs":[
+                    {
+                        "components": null,
+                        "name": "gas_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "amount_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "color_",
+                        "type": "b256"
+                    },
                 {
                     "name":"input",
                     "type":"struct MyNestedStruct",
@@ -448,7 +487,7 @@ mod tests {
         ]
         "#;
 
-        let contract = Abigen::new("custom", contract, false).unwrap();
+        let contract = Abigen::new("custom", contract).unwrap();
 
         assert_eq!(5, contract.custom_structs.len());
 
@@ -464,8 +503,8 @@ mod tests {
             assert!(contract.custom_structs.contains_key(name));
         }
 
-        let bindings = contract.generate().unwrap();
-        bindings.write(std::io::stdout()).unwrap();
+        let bindings = contract.generate();
+        assert!(matches!(bindings, Err(Error::MissingData(_))));
     }
 
     #[test]
@@ -475,6 +514,21 @@ mod tests {
             {
                 "type":"contract",
                 "inputs":[
+                    {
+                        "components": null,
+                        "name": "gas_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "amount_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "color_",
+                        "type": "b256"
+                    },
                     {
                         "name":"top_value",
                         "type":"struct MyNestedStruct",
@@ -502,7 +556,7 @@ mod tests {
         ]
         "#;
 
-        let contract = Abigen::new("custom", contract, false).unwrap();
+        let contract = Abigen::new("custom", contract).unwrap();
 
         assert_eq!(2, contract.custom_structs.len());
 
@@ -520,6 +574,21 @@ mod tests {
             {
                 "type":"contract",
                 "inputs":[
+                    {
+                        "components": null,
+                        "name": "gas_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "amount_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "color_",
+                        "type": "b256"
+                    },
                     {
                         "name":"my_enum",
                         "type":"enum MyEnum",
@@ -541,7 +610,7 @@ mod tests {
         ]
         "#;
 
-        let contract = Abigen::new("custom", contract, false).unwrap();
+        let contract = Abigen::new("custom", contract).unwrap();
 
         assert_eq!(1, contract.custom_enums.len());
         assert_eq!(0, contract.custom_structs.len());
@@ -558,6 +627,21 @@ mod tests {
             {
                 "type":"contract",
                 "inputs":[
+                    {
+                        "components": null,
+                        "name": "gas_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "amount_",
+                        "type": "u64"
+                    },
+                    {
+                        "components": null,
+                        "name": "color_",
+                        "type": "b256"
+                    },
                     {
                         "name":"value",
                         "type":"struct MyStruct",
@@ -602,7 +686,7 @@ mod tests {
         ]
         "#;
 
-        let contract = Abigen::new("custom", contract, false).unwrap();
+        let contract = Abigen::new("custom", contract).unwrap();
         let bindings = contract.generate().unwrap();
         bindings.write(std::io::stdout()).unwrap();
     }

--- a/fuels-core/src/code_gen/abigen.rs
+++ b/fuels-core/src/code_gen/abigen.rs
@@ -43,7 +43,11 @@ pub struct Abigen {
 
 impl Abigen {
     /// Creates a new contract with the given ABI JSON source.
-    pub fn new<S: AsRef<str>>(contract_name: &str, abi_source: S) -> Result<Self, Error> {
+    pub fn new<S: AsRef<str>>(
+        contract_name: &str,
+        abi_source: S,
+        strict_checking: bool,
+    ) -> Result<Self, Error> {
         let source = Source::parse(abi_source).unwrap();
         let mut parsed_abi: JsonABI = serde_json::from_str(&source.get().unwrap())?;
 
@@ -69,7 +73,7 @@ impl Abigen {
             abi_parser: ABIParser::new(),
             rustfmt: true,
             no_std: false,
-            strict_checking: false,
+            strict_checking,
         })
     }
 
@@ -170,7 +174,7 @@ impl Abigen {
                 &self.abi_parser,
                 &self.custom_enums,
                 &self.custom_structs,
-                &self.strict_checking,
+                self.strict_checking,
             )?;
             tokenized_functions.push(tokenized_fn);
         }
@@ -299,7 +303,10 @@ mod tests {
         ]
         "#;
 
-        let bindings = Abigen::new("test", contract).unwrap().generate().unwrap();
+        let bindings = Abigen::new("test", contract, false)
+            .unwrap()
+            .generate()
+            .unwrap();
         bindings.write(std::io::stdout()).unwrap();
     }
 
@@ -330,7 +337,10 @@ mod tests {
         ]
         "#;
 
-        let bindings = Abigen::new("test", contract).unwrap().generate().unwrap();
+        let bindings = Abigen::new("test", contract, false)
+            .unwrap()
+            .generate()
+            .unwrap();
         bindings.write(std::io::stdout()).unwrap();
     }
 
@@ -362,7 +372,7 @@ mod tests {
         ]
         "#;
 
-        let contract = Abigen::new("custom", contract).unwrap();
+        let contract = Abigen::new("custom", contract, false).unwrap();
 
         assert_eq!(1, contract.custom_structs.len());
 
@@ -438,7 +448,7 @@ mod tests {
         ]
         "#;
 
-        let contract = Abigen::new("custom", contract).unwrap();
+        let contract = Abigen::new("custom", contract, false).unwrap();
 
         assert_eq!(5, contract.custom_structs.len());
 
@@ -492,7 +502,7 @@ mod tests {
         ]
         "#;
 
-        let contract = Abigen::new("custom", contract).unwrap();
+        let contract = Abigen::new("custom", contract, false).unwrap();
 
         assert_eq!(2, contract.custom_structs.len());
 
@@ -531,7 +541,7 @@ mod tests {
         ]
         "#;
 
-        let contract = Abigen::new("custom", contract).unwrap();
+        let contract = Abigen::new("custom", contract, false).unwrap();
 
         assert_eq!(1, contract.custom_enums.len());
         assert_eq!(0, contract.custom_structs.len());
@@ -592,7 +602,7 @@ mod tests {
         ]
         "#;
 
-        let contract = Abigen::new("custom", contract).unwrap();
+        let contract = Abigen::new("custom", contract, false).unwrap();
         let bindings = contract.generate().unwrap();
         bindings.write(std::io::stdout()).unwrap();
     }

--- a/fuels-core/src/code_gen/abigen.rs
+++ b/fuels-core/src/code_gen/abigen.rs
@@ -349,6 +349,9 @@ mod tests {
         ]
         "#;
 
+        // We are expecting a MissingData error because at the moment, the
+        // ABIgen expects exactly 4 arguments (see `expand_function_arguments`), here
+        // there are 5
         let bindings = Abigen::new("test", contract).unwrap().generate();
         assert!(matches!(bindings, Err(Error::MissingData(_))));
     }
@@ -503,6 +506,9 @@ mod tests {
             assert!(contract.custom_structs.contains_key(name));
         }
 
+        // We are expecting a MissingData error because at the moment, the
+        // ABIgen expects exactly 4 arguments (see `expand_function_arguments`), here
+        // there are 5
         let bindings = contract.generate();
         assert!(matches!(bindings, Err(Error::MissingData(_))));
     }

--- a/fuels-core/src/code_gen/functions_gen.rs
+++ b/fuels-core/src/code_gen/functions_gen.rs
@@ -28,6 +28,7 @@ pub fn expand_function(
     abi_parser: &ABIParser,
     custom_enums: &HashMap<String, Property>,
     custom_structs: &HashMap<String, Property>,
+    strict_checking: &bool,
 ) -> Result<TokenStream, Error> {
     let name = safe_ident(&function.name);
     let fn_signature = abi_parser.build_fn_selector(&function.name, &function.inputs);
@@ -38,7 +39,8 @@ pub fn expand_function(
     let tokenized_output = expand_fn_outputs(&function.outputs)?;
     let result = quote! { ContractCall<#tokenized_output> };
 
-    let (input, arg) = expand_function_arguments(function, custom_enums, custom_structs)?;
+    let (input, arg) =
+        expand_function_arguments(function, custom_enums, custom_structs, strict_checking)?;
 
     let doc = expand_doc(&format!(
         "Calls the contract's `{}` (0x{}) function",
@@ -113,6 +115,7 @@ fn expand_function_arguments(
     fun: &Function,
     custom_enums: &HashMap<String, Property>,
     custom_structs: &HashMap<String, Property>,
+    strict_checking: bool,
 ) -> Result<(TokenStream, TokenStream), Error> {
     let mut args = Vec::with_capacity(fun.inputs.len());
     let mut call_args = Vec::with_capacity(fun.inputs.len());

--- a/fuels-core/src/code_gen/functions_gen.rs
+++ b/fuels-core/src/code_gen/functions_gen.rs
@@ -28,7 +28,6 @@ pub fn expand_function(
     abi_parser: &ABIParser,
     custom_enums: &HashMap<String, Property>,
     custom_structs: &HashMap<String, Property>,
-    strict_checking: bool,
 ) -> Result<TokenStream, Error> {
     let name = safe_ident(&function.name);
     let fn_signature = abi_parser.build_fn_selector(&function.name, &function.inputs);
@@ -39,8 +38,7 @@ pub fn expand_function(
     let tokenized_output = expand_fn_outputs(&function.outputs)?;
     let result = quote! { ContractCall<#tokenized_output> };
 
-    let (input, arg) =
-        expand_function_arguments(function, custom_enums, custom_structs, strict_checking)?;
+    let (input, arg) = expand_function_arguments(function, custom_enums, custom_structs)?;
 
     let doc = expand_doc(&format!(
         "Calls the contract's `{}` (0x{}) function",
@@ -115,35 +113,31 @@ fn expand_function_arguments(
     fun: &Function,
     custom_enums: &HashMap<String, Property>,
     custom_structs: &HashMap<String, Property>,
-    strict_checking: bool,
 ) -> Result<(TokenStream, TokenStream), Error> {
     let n_inputs = fun.inputs.len();
-    let mut first_index = 0;
     // Check that we have the expected types
-    if strict_checking {
-        if n_inputs != 4 {
-            return Err(Error::MissingData(format!(
-                "Expected 4 inputs because `strict_checking` is true, found {}",
-                n_inputs
-            )));
-        }
-        let given_types: Vec<String> = fun.inputs[..3]
-            .iter()
-            .map(|x| x.type_field.clone())
-            .collect();
-        let expected = ["u64", "u64", "b256"];
-        if given_types != expected {
-            return Err(Error::InvalidType(format!(
-                "Expected the 3 first types to be {:?}, found {:?}",
-                expected, given_types
-            )));
-        };
-        // Ignore the first three arguments so we don't have to provide them when calling
-        // the contracts' methods
-        first_index = 3
+    if n_inputs != 4 {
+        return Err(Error::MissingData(format!(
+            "Expected exactly 4 inputs, found {}",
+            n_inputs
+        )));
     }
-    let mut args = Vec::with_capacity(n_inputs);
-    let mut call_args = Vec::with_capacity(n_inputs);
+    let given_types: Vec<String> = fun.inputs[..3]
+        .iter()
+        .map(|x| x.type_field.clone())
+        .collect();
+    let expected = ["u64", "u64", "b256"];
+    if given_types != expected {
+        return Err(Error::InvalidType(format!(
+            "Expected the 3 first types to be {:?}, found {:?}",
+            expected, given_types
+        )));
+    };
+    // Ignore the first three arguments so we don't have to provide them when calling
+    // the contracts' methods
+    let first_index = 3;
+    let mut args = Vec::with_capacity(1);
+    let mut call_args = Vec::with_capacity(1);
     // For each [`Property`] in a function input we expand:
     // 1. The name of the argument;
     // 2. The type of the argument;
@@ -263,36 +257,55 @@ fn expand_input_param(
 mod tests {
     use super::*;
     use std::str::FromStr;
+    fn generate_base_inputs() -> Vec<Property> {
+        let mut inputs = Vec::with_capacity(4);
+        inputs.push(Property {
+            name: "gas_".to_string(),
+            type_field: String::from("u64"),
+            components: None,
+        });
+        inputs.push(Property {
+            name: "amount_".to_string(),
+            type_field: String::from("u64"),
+            components: None,
+        });
+        inputs.push(Property {
+            name: "color_".to_string(),
+            type_field: String::from("b256"),
+            components: None,
+        });
+        inputs
+    }
     // --- expand_function ---
     #[test]
     fn test_expand_function_simple() {
-        let f = Function {
+        let mut the_function = Function {
             type_field: "unused".to_string(),
-            inputs: vec![Property {
-                name: String::from("bimbam"),
-                type_field: String::from("bool"),
-                components: None,
-            }],
+            inputs: generate_base_inputs(),
             name: "HelloWorld".to_string(),
             outputs: vec![],
         };
+        the_function.inputs.push(Property {
+            name: String::from("bimbam"),
+            type_field: String::from("bool"),
+            components: None,
+        });
         let result = expand_function(
-            &f,
+            &the_function,
             &ABIParser::new(),
             &Default::default(),
             &Default::default(),
-            false,
         );
         let expected = TokenStream::from_str(
             r#"
-#[doc = "Calls the contract's `HelloWorld` (0x0000000097d4de45) function"]
+#[doc = "Calls the contract's `HelloWorld` (0x000000007e387733) function"]
 pub fn HelloWorld(&self, bimbam: bool) -> ContractCall<()> {
     Contract::method_hash(
         &self.fuel_client,
         &self.compiled,
-        [0, 0, 0, 0, 151, 212, 222, 69],
+        [0, 0, 0, 0, 126, 56, 119, 51],
         &[],
-        &[bimbam.into_token(), ]
+        &[bimbam.into_token() ,]
     )
     .expect("method not found (this should never happen)")
 }
@@ -303,43 +316,10 @@ pub fn HelloWorld(&self, bimbam: bool) -> ContractCall<()> {
     }
     #[test]
     fn test_expand_function_complex() {
-        let the_function = Function {
+        let mut the_function = Function {
             type_field: "function".to_string(),
             name: "hello_world".to_string(),
-            inputs: vec![
-                Property {
-                    name: String::from("input"),
-                    type_field: String::from("struct BimBapStruct"),
-                    components: Some(vec![
-                        Property {
-                            name: String::from("Meat"),
-                            type_field: String::from("bool"),
-                            components: None,
-                        },
-                        Property {
-                            name: String::from("Rice"),
-                            type_field: String::from("u64"),
-                            components: None,
-                        },
-                    ]),
-                },
-                Property {
-                    name: String::from("another_input"),
-                    type_field: String::from("enum BurgundyBeefEnum"),
-                    components: Some(vec![
-                        Property {
-                            name: String::from("Beef"),
-                            type_field: String::from("bool"),
-                            components: None,
-                        },
-                        Property {
-                            name: String::from("BurgundyWine"),
-                            type_field: String::from("u64"),
-                            components: None,
-                        },
-                    ]),
-                },
-            ],
+            inputs: generate_base_inputs(),
             outputs: vec![
                 Property {
                     name: String::from("notused"),
@@ -375,12 +355,28 @@ pub fn HelloWorld(&self, bimbam: bool) -> ContractCall<()> {
                 },
             ],
         };
+        the_function.inputs.push(Property {
+            name: String::from("the_only_allowed_input"),
+            type_field: String::from("struct BurgundyBeefStruct"),
+            components: Some(vec![
+                Property {
+                    name: String::from("Beef"),
+                    type_field: String::from("bool"),
+                    components: None,
+                },
+                Property {
+                    name: String::from("BurgundyWine"),
+                    type_field: String::from("u64"),
+                    components: None,
+                },
+            ]),
+        });
         let mut custom_structs = HashMap::new();
         custom_structs.insert(
-            "BimBapStruct".to_string(),
+            "BurgundyBeefStruct".to_string(),
             Property {
                 name: "unused".to_string(),
-                type_field: "struct BimBapStruct".to_string(),
+                type_field: "struct SomeWeirdFrenchCuisine".to_string(),
                 components: None,
             },
         );
@@ -401,39 +397,24 @@ pub fn HelloWorld(&self, bimbam: bool) -> ContractCall<()> {
                 components: None,
             },
         );
-        custom_enums.insert(
-            "BurgundyBeefEnum".to_string(),
-            Property {
-                name: "unused".to_string(),
-                type_field: "enum BurgundyBeefEnum".to_string(),
-                components: None,
-            },
-        );
         let abi_parser = ABIParser::new();
-        let result = expand_function(
-            &the_function,
-            &abi_parser,
-            &custom_enums,
-            &custom_structs,
-            false,
-        );
+        let result = expand_function(&the_function, &abi_parser, &custom_enums, &custom_structs);
         // Some more editing was required because it is not rustfmt-compatible (adding/removing parentheses or commas)
         let expected = TokenStream::from_str(
             r#"
-#[doc = "Calls the contract's `hello_world` (0x000000004d65f217) function"]
+#[doc = "Calls the contract's `hello_world` (0x000000001f51690a) function"]
 pub fn hello_world(
     &self,
-    input: BimBapStruct,
-    another_input: BurgundyBeefEnum
+    the_only_allowed_input: SomeWeirdFrenchCuisine
 ) -> ContractCall<((bool , u64 ,) , (bool, u64 ,))> {
     Contract::method_hash(
         &self.fuel_client,
         &self.compiled,
-        [0, 0, 0, 0, 77, 101, 242, 23],
+        [0, 0, 0, 0, 31, 81, 105, 10],
         &[
             ParamType::Struct(vec![ParamType::Bool, ParamType::U64]),
             ParamType::Enum([Bool , U64])] , 
-            &[input.into_token(), another_input.into_token(),]
+            &[the_only_allowed_input . into_token () ,]
     )
     .expect("method not found (this should never happen)")
 }
@@ -611,114 +592,84 @@ pub fn hello_world(
 
     // --- expand_function_argument ---
     #[test]
-    fn test_expand_function_arguments_strict_checks() {
+    fn test_expand_function_arguments() {
         let hm: HashMap<String, Property> = HashMap::new();
-        let mut gas_prop = Property {
-            name: "gas_".to_string(),
-            type_field: String::from("u64"),
-            components: None,
-        };
-        let amount_prop = Property {
-            name: "amount_".to_string(),
-            type_field: String::from("u64"),
-            components: None,
-        };
-        let color_prop = Property {
-            name: "color_".to_string(),
-            type_field: String::from("b256"),
-            components: None,
-        };
-        let arg_prop = Property {
+        let the_argument = Property {
             name: "some_argument".to_string(),
             type_field: String::from("u32"),
             components: None,
         };
 
-        let function = Function {
+        // All arguments are here
+        let mut the_function = Function {
             type_field: "".to_string(),
-            inputs: vec![
-                gas_prop.clone(),
-                amount_prop.clone(),
-                color_prop.clone(),
-                arg_prop.clone(),
-            ],
+            inputs: generate_base_inputs(),
             name: "".to_string(),
             outputs: vec![],
         };
-        let result = expand_function_arguments(&function, &hm, &hm, true);
+        the_function.inputs.push(the_argument.clone());
+        let result = expand_function_arguments(&the_function, &hm, &hm);
         let (args, call_args) = result.unwrap();
         let result = format!("({},{})", args, call_args);
         let expected = "(, some_argument : u32,& [some_argument . into_token () ,])";
         assert_eq!(result, expected);
 
-        let function = Function {
+        // Missing the last argument
+        let mut the_function = Function {
             type_field: "".to_string(),
-            inputs: vec![gas_prop.clone(), amount_prop.clone(), color_prop.clone()],
+            inputs: generate_base_inputs(),
             name: "".to_string(),
             outputs: vec![],
         };
-        let result = expand_function_arguments(&function, &hm, &hm, true);
+        let result = expand_function_arguments(&the_function, &hm, &hm);
         assert!(matches!(result, Err(Error::MissingData(_))));
 
-        gas_prop.type_field = String::from("bool");
-        let function = Function {
-            type_field: "".to_string(),
-            inputs: vec![gas_prop, amount_prop, color_prop, arg_prop],
-            name: "".to_string(),
-            outputs: vec![],
-        };
-        let result = expand_function_arguments(&function, &hm, &hm, true);
+        // Change the `gas_` argument type
+        the_function.inputs[0].type_field = String::from("bool");
+        the_function.inputs.push(the_argument);
+        let result = expand_function_arguments(&the_function, &hm, &hm);
         assert!(matches!(result, Err(Error::InvalidType(_))));
     }
     #[test]
     fn test_expand_function_arguments_primitive() {
-        let function = Function {
+        let hm: HashMap<String, Property> = HashMap::new();
+        let mut the_function = Function {
             type_field: "function".to_string(),
-            inputs: vec![
-                Property {
-                    name: "bim_bam".to_string(),
-                    type_field: String::from("bool"),
-                    components: None,
-                },
-                Property {
-                    name: "".to_string(),
-                    type_field: String::from("u64"),
-                    components: None,
-                },
-            ],
+            inputs: generate_base_inputs(),
             name: "pip_pop".to_string(),
             outputs: vec![],
         };
-        let hm: HashMap<String, Property> = HashMap::new();
-        let result = expand_function_arguments(&function, &hm, &hm, false);
+
+        the_function.inputs.push(Property {
+            name: "bim_bam".to_string(),
+            type_field: String::from("u64"),
+            components: None,
+        });
+        let result = expand_function_arguments(&the_function, &hm, &hm);
         let (args, call_args) = result.unwrap();
         let result = format!("({},{})", args, call_args);
-        assert_eq!(
-            result,
-            "(, bim_bam : bool , p1 : u64,& [bim_bam . into_token () , p1 . into_token () ,])"
-        );
+        assert_eq!(result, "(, bim_bam : u64,& [bim_bam . into_token () ,])");
+
+        the_function.inputs[3].name = String::from("");
+        let result = expand_function_arguments(&the_function, &hm, &hm);
+        let (args, call_args) = result.unwrap();
+        let result = format!("({},{})", args, call_args);
+        assert_eq!(result, "(, p0 : u64,& [p0 . into_token () ,])");
     }
     #[test]
     fn test_expand_function_arguments_composite() {
-        let function = Function {
+        let mut function = Function {
             type_field: "zig_zag".to_string(),
-            inputs: vec![
-                Property {
-                    name: "bim_bam".to_string(),
-                    type_field: String::from("struct CarMaker"),
-                    // Not parsed, so can be empty but not None
-                    components: Some(vec![]),
-                },
-                Property {
-                    name: "pim_poum".to_string(),
-                    type_field: String::from("enum Bank"),
-                    // Not parsed, so can be empty but not None
-                    components: Some(vec![]),
-                },
-            ],
+            inputs: generate_base_inputs(),
             name: "PipPopFunction".to_string(),
             outputs: vec![],
         };
+        function.inputs.push(Property {
+            name: "bim_bam".to_string(),
+            type_field: String::from("struct CarMaker"),
+            // Not parsed, so can be empty but not None
+            components: Some(vec![]),
+        });
         let mut custom_structs = HashMap::new();
         custom_structs.insert(
             "CarMaker".to_string(),
@@ -729,19 +680,10 @@ pub fn hello_world(
             },
         );
 
-        let mut custom_enums = HashMap::new();
-        custom_enums.insert(
-            "Bank".to_string(),
-            Property {
-                name: "unused".to_string(),
-                type_field: "enum Bank".to_string(),
-                components: None,
-            },
-        );
-        let result = expand_function_arguments(&function, &custom_enums, &custom_structs, false);
+        let result = expand_function_arguments(&function, &custom_structs, &custom_structs);
         let (args, call_args) = result.unwrap();
         let result = format!("({},{})", args, call_args);
-        let expected = r#"(, bim_bam : CarMaker , pim_poum : Bank,& [bim_bam . into_token () , pim_poum . into_token () ,])"#;
+        let expected = r#"(, bim_bam : CarMaker,& [bim_bam . into_token () ,])"#;
         assert_eq!(result, expected);
     }
 

--- a/fuels-core/src/code_gen/functions_gen.rs
+++ b/fuels-core/src/code_gen/functions_gen.rs
@@ -611,40 +611,64 @@ pub fn hello_world(
 
     // --- expand_function_argument ---
     #[test]
-    fn test_expand_function_strict_check() {
+    fn test_expand_function_arguments_strict_checks() {
+        let hm: HashMap<String, Property> = HashMap::new();
+        let mut gas_prop = Property {
+            name: "gas_".to_string(),
+            type_field: String::from("u64"),
+            components: None,
+        };
+        let amount_prop = Property {
+            name: "amount_".to_string(),
+            type_field: String::from("u64"),
+            components: None,
+        };
+        let color_prop = Property {
+            name: "color_".to_string(),
+            type_field: String::from("b256"),
+            components: None,
+        };
+        let arg_prop = Property {
+            name: "some_argument".to_string(),
+            type_field: String::from("u32"),
+            components: None,
+        };
+
         let function = Function {
             type_field: "".to_string(),
             inputs: vec![
-                Property {
-                    name: "gas_".to_string(),
-                    type_field: String::from("u64"),
-                    components: None,
-                },
-                Property {
-                    name: "amount_".to_string(),
-                    type_field: String::from("u64"),
-                    components: None,
-                },
-                Property {
-                    name: "color_".to_string(),
-                    type_field: String::from("b256"),
-                    components: None,
-                },
-                Property {
-                    name: "some_argument".to_string(),
-                    type_field: String::from("u32"),
-                    components: None,
-                },
+                gas_prop.clone(),
+                amount_prop.clone(),
+                color_prop.clone(),
+                arg_prop.clone(),
             ],
             name: "".to_string(),
             outputs: vec![],
         };
-        let hm: HashMap<String, Property> = HashMap::new();
         let result = expand_function_arguments(&function, &hm, &hm, true);
         let (args, call_args) = result.unwrap();
         let result = format!("({},{})", args, call_args);
         let expected = "(, some_argument : u32,& [some_argument . into_token () ,])";
         assert_eq!(result, expected);
+
+        let function = Function {
+            type_field: "".to_string(),
+            inputs: vec![gas_prop.clone(), amount_prop.clone(), color_prop.clone()],
+            name: "".to_string(),
+            outputs: vec![],
+        };
+        let result = expand_function_arguments(&function, &hm, &hm, true);
+        assert!(matches!(result, Err(Error::MissingData(_))));
+
+        gas_prop.type_field = String::from("bool");
+        let function = Function {
+            type_field: "".to_string(),
+            inputs: vec![gas_prop, amount_prop, color_prop, arg_prop],
+            name: "".to_string(),
+            outputs: vec![],
+        };
+        let result = expand_function_arguments(&function, &hm, &hm, true);
+        assert!(matches!(result, Err(Error::InvalidType(_))));
     }
     #[test]
     fn test_expand_function_arguments_primitive() {

--- a/fuels-core/src/code_gen/functions_gen.rs
+++ b/fuels-core/src/code_gen/functions_gen.rs
@@ -138,10 +138,12 @@ fn expand_function_arguments(
     let first_index = 3;
     let mut args = Vec::with_capacity(1);
     let mut call_args = Vec::with_capacity(1);
-    // For each [`Property`] in a function input we expand:
-    // 1. The name of the argument;
-    // 2. The type of the argument;
+    // We use a for loop because we expect exactly 4 arguments (so len(fun.inputs)==4)
+    // but we might extend the number of authorized inputs in the future
     for (i, param) in fun.inputs[first_index..].iter().enumerate() {
+        // For each [`Property`] in a function input we expand:
+        // 1. The name of the argument;
+        // 2. The type of the argument;
         // Note that _any_ significant change in the way the JSON ABI is generated
         // could affect this function expansion.
         // TokenStream representing the name of the argument

--- a/fuels-core/src/code_gen/functions_gen.rs
+++ b/fuels-core/src/code_gen/functions_gen.rs
@@ -611,13 +611,13 @@ pub fn hello_world(
 
     // --- expand_function_argument ---
     #[test]
-    fn test_expand_function_arguments_workaround() {
+    fn test_expand_function_strict_check() {
         let function = Function {
             type_field: "".to_string(),
             inputs: vec![
                 Property {
                     name: "gas_".to_string(),
-                    type_field: String::from("bool"),
+                    type_field: String::from("u64"),
                     components: None,
                 },
                 Property {
@@ -627,7 +627,7 @@ pub fn hello_world(
                 },
                 Property {
                     name: "color_".to_string(),
-                    type_field: String::from("u32"),
+                    type_field: String::from("b256"),
                     components: None,
                 },
                 Property {
@@ -643,7 +643,8 @@ pub fn hello_world(
         let result = expand_function_arguments(&function, &hm, &hm, true);
         let (args, call_args) = result.unwrap();
         let result = format!("({},{})", args, call_args);
-        assert_eq!(result, "(,())");
+        let expected = "(, some_argument : u32,& [some_argument . into_token () ,])";
+        assert_eq!(result, expected);
     }
     #[test]
     fn test_expand_function_arguments_primitive() {


### PR DESCRIPTION
This PR refactors the function `expand_function_arguments` to avoid checking for template arguments (`gas_, amount_, color_`) every time. It propagates the argument up to the abigen macro so user can chose if the expansion should check for types or not. 
It closes #75 