### PR TITLE
Implement transaction signing

### DIFF
--- a/fuels-signers/src/lib.rs
+++ b/fuels-signers/src/lib.rs
@@ -114,7 +114,7 @@ mod tests {
         // Check if signature is what we expect it to be
         assert_eq!(signature.compact, Signature::from_str("0xa1287a24af13fc102cb9e60988b558d5575d7870032f64bafcc2deda2c99125fb25eca55a29a169de156cb30700965e2b26278fcc7ad375bc720440ea50ba3cb").unwrap().compact);
 
-        // Recover address that signed the message
+        // Recover address that signed the transaction
         let recovered_address = signature.recover(&tx.id()).unwrap();
 
         assert_eq!(wallet.address, recovered_address);

--- a/fuels-signers/src/lib.rs
+++ b/fuels-signers/src/lib.rs
@@ -37,6 +37,7 @@ pub trait Signer: std::fmt::Debug + Send + Sync {
 mod tests {
     use std::str::FromStr;
 
+    use fuel_tx::{Bytes32, Color, Input, Output, UtxoId};
     use rand::{rngs::StdRng, RngCore, SeedableRng};
     use secp256k1::SecretKey;
 
@@ -67,5 +68,58 @@ mod tests {
 
         // Verify signature
         signature.verify(message, recovered_address).unwrap();
+    }
+
+    #[tokio::test]
+    async fn sign_tx_and_verify() {
+        let secret =
+            SecretKey::from_str("5f70feeff1f229e4a95e1056e8b4d80d0b24b565674860cc213bdb07127ce1b1")
+                .unwrap();
+
+        let wallet = LocalWallet::new_from_private_key(secret).unwrap();
+
+        let input_coin = Input::coin(
+            UtxoId::new(Bytes32::zeroed(), 0),
+            Address::from_str("0xf1e92c42b90934aa6372e30bc568a326f6e66a1a0288595e6e3fbd392a4f3e6e")
+                .unwrap(),
+            10000000,
+            Color::from([0u8; 32]),
+            0,
+            0,
+            vec![],
+            vec![],
+        );
+
+        let output_coin = Output::coin(
+            Address::from_str("0xc7862855b418ba8f58878db434b21053a61a2025209889cc115989e8040ff077")
+                .unwrap(),
+            1,
+            Color::from([0u8; 32]),
+        );
+
+        let tx = Transaction::script(
+            0,
+            1000000,
+            0,
+            0,
+            hex::decode("24400000").unwrap(),
+            vec![],
+            vec![input_coin],
+            vec![output_coin],
+            vec![],
+        );
+
+        let signature = wallet.sign_transaction(&tx).await.unwrap();
+
+        // Check if signature is what we expect it to be
+        assert_eq!(signature.compact, Signature::from_str("0xa1287a24af13fc102cb9e60988b558d5575d7870032f64bafcc2deda2c99125fb25eca55a29a169de156cb30700965e2b26278fcc7ad375bc720440ea50ba3cb").unwrap().compact);
+
+        // Recover address that signed the message
+        let recovered_address = signature.recover(&tx.id()).unwrap();
+
+        assert_eq!(wallet.address, recovered_address);
+
+        // Verify signature
+        signature.verify(&tx.id(), recovered_address).unwrap();
     }
 }

--- a/fuels-signers/src/signature.rs
+++ b/fuels-signers/src/signature.rs
@@ -1,4 +1,4 @@
-use fuel_tx::{crypto::Hasher, Bytes64};
+use fuel_tx::{crypto::Hasher, Bytes32, Bytes64};
 use fuel_types::Address;
 use fuel_vm::crypto::secp256k1_sign_compact_recover;
 use fuels_core::Bits256;
@@ -77,7 +77,13 @@ impl Signature {
     /// Recovers the Fuel address which was used
     /// to sign the given message. Note that this message
     /// can be either the original message or its digest (hashed message).
-    /// Both can be used to recover the address of the signature.
+    /// Both can be used to recover the address of the signature. E.g.:
+    ///
+    /// `let recovered_address = signature.recover(message).unwrap();`
+    /// Where `message` is a `&str`. Or
+    ///
+    /// `let recovered_address = signature.recover(&tx.id()).unwrap();`
+    /// Where `&tx.id()` is a `&Bytes32` representing the hash of the tx.
     pub fn recover<M>(&self, message: M) -> Result<Address, SignatureError>
     where
         M: Into<RecoveryMessage>,
@@ -148,6 +154,12 @@ impl From<String> for RecoveryMessage {
 impl From<[u8; 32]> for RecoveryMessage {
     fn from(hash: [u8; 32]) -> Self {
         RecoveryMessage::Hash(hash)
+    }
+}
+
+impl From<&Bytes32> for RecoveryMessage {
+    fn from(hash: &Bytes32) -> Self {
+        RecoveryMessage::Hash(**hash)
     }
 }
 

--- a/fuels-signers/src/wallet/mod.rs
+++ b/fuels-signers/src/wallet/mod.rs
@@ -105,7 +105,10 @@ impl Signer for Wallet {
     }
 
     async fn sign_transaction(&self, _tx: &Transaction) -> Result<Signature, Self::Error> {
-        todo!()
+        let id = _tx.id();
+        let sig = secp256k1_sign_compact_recoverable(self.private_key.as_ref(), &*id).unwrap();
+
+        Ok(Signature { compact: sig })
     }
 
     fn address(&self) -> Address {


### PR DESCRIPTION
Adds transaction signing to the wallet API: 

```rust
 let wallet = LocalWallet::new_from_private_key(secret).unwrap();

let input_coin = Input::coin(
   // ...
);

let output_coin = Output::coin(
 // ..
);

let tx = Transaction::script(
   // ..
);

let signature = wallet.sign_transaction(&tx).await.unwrap();
```

Closes https://github.com/FuelLabs/fuels-rs/issues/69.