### PR TITLE
remove the Url crate from fuels-core

### DIFF
--- a/fuels-core/Cargo.toml
+++ b/fuels-core/Cargo.toml
@@ -28,4 +28,3 @@ sway-types = { version = "0.1" }
 sway-utils = { version = "0.1" }
 syn = "1.0.12"
 thiserror = "1.0.30"
-url = "2.1"


### PR DESCRIPTION
This removes the use of the `Url` crate for loading ABI .json files. This approach was incompatible with Windows paths so has been removed in order to support that OS. [See here](https://github.com/FuelLabs/fuels-rs/issues/93) for more discussion on this issue.

closes #93 