### PR TITLE
feat: capture error from reverting transactions in the SDK

### DIFF
--- a/fuels-abigen-macro/tests/harness.rs
+++ b/fuels-abigen-macro/tests/harness.rs
@@ -3,6 +3,7 @@ use fuel_gql_client::client::FuelClient;
 use fuel_tx::Salt;
 use fuels_abigen_macro::abigen;
 use fuels_contract::contract::Contract;
+use fuels_contract::errors::Error;
 use fuels_core::Token;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -1334,6 +1335,30 @@ async fn abigen_different_structs_same_arg_name() {
         .unwrap();
 
     assert_eq!(res_two.value, 41);
+}
+#[tokio::test]
+async fn test_reverting_transaction() {
+    let rng = &mut StdRng::seed_from_u64(2322u64);
+
+    abigen!(
+        RevertingContract,
+        "fuels-abigen-macro/tests/test_projects/revert_transaction_error/abi.json"
+    );
+
+    // Build the contract
+    let salt: [u8; 32] = rng.gen();
+    let salt = Salt::from(salt);
+
+    let compiled =
+        Contract::compile_sway_contract("tests/test_projects/revert_transaction_error", salt)
+            .unwrap();
+
+    let (client, contract_id) = Contract::launch_and_deploy(&compiled).await.unwrap();
+    println!("Contract deployed @ {:x}", contract_id);
+    let contract_instance = RevertingContract::new(compiled, client);
+
+    let result = contract_instance.make_transaction_fail(0).call().await;
+    assert!(matches!(result, Err(Error::ContractCallError(_))));
 }
 
 #[tokio::test]

--- a/fuels-abigen-macro/tests/harness.rs
+++ b/fuels-abigen-macro/tests/harness.rs
@@ -1353,7 +1353,7 @@ async fn test_reverting_transaction() {
         Contract::compile_sway_contract("tests/test_projects/revert_transaction_error", salt)
             .unwrap();
 
-    let (client, contract_id) = Contract::launch_and_deploy(&compiled).await.unwrap();
+    let (client, _) = Contract::launch_and_deploy(&compiled).await.unwrap();
     let contract_instance = RevertingContract::new(compiled, client);
 
     let result = contract_instance.make_transaction_fail(0).call().await;

--- a/fuels-abigen-macro/tests/harness.rs
+++ b/fuels-abigen-macro/tests/harness.rs
@@ -1354,7 +1354,6 @@ async fn test_reverting_transaction() {
             .unwrap();
 
     let (client, contract_id) = Contract::launch_and_deploy(&compiled).await.unwrap();
-    println!("Contract deployed @ {:x}", contract_id);
     let contract_instance = RevertingContract::new(compiled, client);
 
     let result = contract_instance.make_transaction_fail(0).call().await;

--- a/fuels-abigen-macro/tests/test_projects/revert_transaction_error/Forc.toml
+++ b/fuels-abigen-macro/tests/test_projects/revert_transaction_error/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "lulwat"
+author = "FuelLabs"
 entry = "main.sw"
 license = "Apache-2.0"
 name = "capture-revert-transaction-error"

--- a/fuels-abigen-macro/tests/test_projects/revert_transaction_error/Forc.toml
+++ b/fuels-abigen-macro/tests/test_projects/revert_transaction_error/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+author = "lulwat"
+entry = "main.sw"
+license = "Apache-2.0"
+name = "capture-revert-transaction-error"
+
+[dependencies]
+core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std" }

--- a/fuels-abigen-macro/tests/test_projects/revert_transaction_error/abi.json
+++ b/fuels-abigen-macro/tests/test_projects/revert_transaction_error/abi.json
@@ -1,0 +1,36 @@
+[
+  {
+    "inputs": [
+      {
+        "components": null,
+        "name": "gas_",
+        "type": "u64"
+      },
+      {
+        "components": null,
+        "name": "amount_",
+        "type": "u64"
+      },
+      {
+        "components": null,
+        "name": "color_",
+        "type": "b256"
+      },
+      {
+        "components": null,
+        "name": "input",
+        "type": "u64"
+      }
+    ],
+    "name": "make_transaction_fail",
+    "outputs": [
+      {
+        "components": null,
+        "name": "value",
+        "type": "u64"
+      }
+    ],
+    "type": "function"
+  }
+
+]

--- a/fuels-abigen-macro/tests/test_projects/revert_transaction_error/src/main.sw
+++ b/fuels-abigen-macro/tests/test_projects/revert_transaction_error/src/main.sw
@@ -1,0 +1,16 @@
+contract;
+
+abi MyContract {
+    fn make_transaction_fail(gas_: u64, amount_: u64, color_: b256, input: u64) -> u64;
+}
+
+const COUNTER_KEY = 0x0000000000000000000000000000000000000000000000000000000000000000;
+
+impl MyContract for Contract {
+    fn make_transaction_fail(gas_: u64, amount_: u64, color_: b256, input: u64) -> u64{
+        asm(r1: input) {
+            rvrt r1;
+        };
+        42
+    }
+}

--- a/fuels-abigen-macro/tests/test_projects/revert_transaction_error/tests/harness.rs
+++ b/fuels-abigen-macro/tests/test_projects/revert_transaction_error/tests/harness.rs
@@ -1,0 +1,6 @@
+
+
+#[tokio::test]
+async fn harness() {
+    assert_eq!(true, true);
+}

--- a/fuels-contract/src/contract.rs
+++ b/fuels-contract/src/contract.rs
@@ -66,7 +66,7 @@ impl Contract {
         byte_price: Word,
         maturity: Word,
         custom_inputs: bool,
-    ) -> Result<Vec<Receipt>, String> {
+    ) -> Result<Vec<Receipt>, Error> {
         // Based on the defined script length,
         // we set the appropriate data offset.
         let script_len = 16;
@@ -169,7 +169,7 @@ impl Contract {
 
         let script = Script::new(tx);
 
-        Ok(script.call(fuel_client).await.unwrap())
+        script.call(fuel_client).await
     }
 
     /// Creates an ABI call based on a function selector and
@@ -348,8 +348,7 @@ where
             self.maturity,
             self.custom_inputs,
         )
-        .await
-        .unwrap();
+        .await?;
 
         let (encoded_value, index) = match receipts.iter().find(|&receipt| receipt.val().is_some())
         {

--- a/fuels-contract/src/errors.rs
+++ b/fuels-contract/src/errors.rs
@@ -45,6 +45,11 @@ impl From<CodecError> for Error {
         }
     }
 }
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Error {
+        Error::ContractCallError(err.to_string())
+    }
+}
 
 impl From<InvalidOutputType> for Error {
     fn from(err: InvalidOutputType) -> Error {

--- a/fuels-contract/src/script.rs
+++ b/fuels-contract/src/script.rs
@@ -2,7 +2,7 @@ use crate::errors::Error;
 use forc::test::{forc_build, BuildCommand};
 use forc::util::constants;
 use forc::util::helpers::read_manifest;
-use fuel_gql_client::client::FuelClient;
+use fuel_gql_client::client::{types::TransactionStatus, FuelClient};
 use fuel_tx::{Receipt, Transaction};
 use std::path::PathBuf;
 use sway_utils::find_manifest_dir;
@@ -25,11 +25,14 @@ impl Script {
     }
 
     pub async fn call(self, fuel_client: &FuelClient) -> Result<Vec<Receipt>, Error> {
-        let tx_id = fuel_client.submit(&self.tx).await.unwrap();
+        let tx_id = fuel_client.submit(&self.tx).await.unwrap().0.to_string();
 
-        let receipts = fuel_client.receipts(&tx_id.0.to_string()).await.unwrap();
-
-        Ok(receipts)
+        let receipts = fuel_client.receipts(&tx_id).await.unwrap();
+        let status = fuel_client.transaction_status(&tx_id).await.unwrap();
+        match status {
+            TransactionStatus::Failure { reason, .. } => Err(Error::ContractCallError(reason)),
+            _ => Ok(receipts),
+        }
     }
 
     /// Compiles a Sway script

--- a/fuels-contract/src/script.rs
+++ b/fuels-contract/src/script.rs
@@ -27,8 +27,8 @@ impl Script {
     pub async fn call(self, fuel_client: &FuelClient) -> Result<Vec<Receipt>, Error> {
         let tx_id = fuel_client.submit(&self.tx).await.unwrap().0.to_string();
 
-        let receipts = fuel_client.receipts(&tx_id).await.unwrap();
-        let status = fuel_client.transaction_status(&tx_id).await.unwrap();
+        let receipts = fuel_client.receipts(&tx_id).await?;
+        let status = fuel_client.transaction_status(&tx_id).await?;
         match status {
             TransactionStatus::Failure { reason, .. } => Err(Error::ContractCallError(reason)),
             _ => Ok(receipts),


### PR DESCRIPTION
* Previously, a reverting transaction would not be captured by the SDK.
* This closes #102 .
