### PR TITLE
refactor: remove the `launch_and_deploy` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ let compiled =
 let contract_id = Contract::deploy(compiled_contract, fuel_client).await.unwrap();
 ```
 
-Alternatively, if you want to launch a local node for every deployment, which is usually useful for smaller tests where you don't want to keep state between each test, you can use `Contract::launch_and_deploy()`:
+Alternatively, if you want to launch a local node for every deployment, which is usually 
+useful for smaller tests where you don't want to keep state between each test, you can use 
+`Contract::launch(Config::local_node())`:
 
 ```Rust
 // Build the contract
@@ -96,8 +98,9 @@ let salt = Salt::from(salt);
 let compiled =
     Contract::compile_sway_contract("path/to/your/fuel/project", salt).unwrap();
 
-// Now you get both the Fuel client _and_ the contract_id back.
-let (client, contract_id) = Contract::launch_and_deploy(&compiled).await.unwrap();
+// Now get the Fuel client _and_ contract_id back.
+let client = Contract::launch(Config::local_node()).await.unwrap();
+let contract_id = Contract::deploy(&compiled, &client).await.unwrap();
 ```
 
 ### Generating type-safe Rust bindings

--- a/fuels-abigen-macro/tests/harness.rs
+++ b/fuels-abigen-macro/tests/harness.rs
@@ -920,7 +920,8 @@ async fn example_workflow() {
     let compiled =
         Contract::compile_sway_contract("tests/test_projects/contract_test", salt).unwrap();
 
-    let (client, contract_id) = Contract::launch_and_deploy(&compiled).await.unwrap();
+    let client = Contract::launch(Config::local_node()).await.unwrap();
+    let contract_id = Contract::deploy(&compiled, &client).await.unwrap();
 
     println!("Contract deployed @ {:x}", contract_id);
 
@@ -1081,7 +1082,8 @@ async fn type_safe_output_values() {
     let compiled =
         Contract::compile_sway_contract("tests/test_projects/contract_output_test", salt).unwrap();
 
-    let (client, contract_id) = Contract::launch_and_deploy(&compiled).await.unwrap();
+    let client = Contract::launch(Config::local_node()).await.unwrap();
+    let contract_id = Contract::deploy(&compiled, &client).await.unwrap();
 
     println!("Contract deployed @ {:x}", contract_id);
 
@@ -1204,7 +1206,8 @@ async fn call_with_structs() {
         Contract::compile_sway_contract("tests/test_projects/complex_types_contract", salt)
             .unwrap();
 
-    let (client, contract_id) = Contract::launch_and_deploy(&compiled).await.unwrap();
+    let client = Contract::launch(Config::local_node()).await.unwrap();
+    let contract_id = Contract::deploy(&compiled, &client).await.unwrap();
 
     println!("Contract deployed @ {:x}", contract_id);
 
@@ -1286,7 +1289,8 @@ async fn call_with_empty_return() {
     let compiled =
         Contract::compile_sway_contract("tests/test_projects/call_empty_return", salt).unwrap();
 
-    let (client, contract_id) = Contract::launch_and_deploy(&compiled).await.unwrap();
+    let client = Contract::launch(Config::local_node()).await.unwrap();
+    let contract_id = Contract::deploy(&compiled, &client).await.unwrap();
 
     println!("Contract deployed @ {:x}", contract_id);
 
@@ -1315,7 +1319,8 @@ async fn abigen_different_structs_same_arg_name() {
     let compiled =
         Contract::compile_sway_contract("tests/test_projects/two-structs", salt).unwrap();
 
-    let (client, contract_id) = Contract::launch_and_deploy(&compiled).await.unwrap();
+    let client = Contract::launch(Config::local_node()).await.unwrap();
+    let contract_id = Contract::deploy(&compiled, &client).await.unwrap();
 
     println!("Contract deployed @ {:x}", contract_id);
 
@@ -1353,7 +1358,7 @@ async fn test_reverting_transaction() {
         Contract::compile_sway_contract("tests/test_projects/revert_transaction_error", salt)
             .unwrap();
 
-    let (client, _) = Contract::launch_and_deploy(&compiled).await.unwrap();
+    let client = Contract::launch(Config::local_node()).await.unwrap();
     let contract_instance = RevertingContract::new(compiled, client);
 
     let result = contract_instance.make_transaction_fail(0).call().await;
@@ -1376,7 +1381,8 @@ async fn multiple_read_calls() {
     let compiled =
         Contract::compile_sway_contract("tests/test_projects/multiple-read-calls", salt).unwrap();
 
-    let (client, contract_id) = Contract::launch_and_deploy(&compiled).await.unwrap();
+    let client = Contract::launch(Config::local_node()).await.unwrap();
+    let contract_id = Contract::deploy(&compiled, &client).await.unwrap();
 
     println!("Contract deployed @ {:x}", contract_id);
 
@@ -1409,7 +1415,8 @@ async fn test_methods_typeless_argument() {
 
     let compiled =
         Contract::compile_sway_contract("tests/test_projects/empty-arguments", salt).unwrap();
-    let (client, contract_id) = Contract::launch_and_deploy(&compiled).await.unwrap();
+    let client = Contract::launch(Config::local_node()).await.unwrap();
+    let contract_id = Contract::deploy(&compiled, &client).await.unwrap();
     println!("Contract deployed @ {:x}", contract_id);
     let contract_instance = MyContract::new(compiled, client);
     let result = contract_instance

--- a/fuels-abigen-macro/tests/test_projects/two-structs/tests/harness.rs
+++ b/fuels-abigen-macro/tests/test_projects/two-structs/tests/harness.rs
@@ -1,3 +1,4 @@
+use fuel_core::service::{Config, FuelService};
 use fuel_tx::Salt;
 use fuels_abigen_macro::abigen;
 use fuels_rs::contract::Contract;
@@ -16,7 +17,8 @@ async fn harness() {
     let compiled = Contract::compile_sway_contract("./", salt).unwrap();
 
     // Launch a local network and deploy the contract
-    let (client, _contract_id) = Contract::launch_and_deploy(&compiled).await.unwrap();
+    let client = Contract::launch(Config::local_node()).await.unwrap();
+    let contract_id = Contract::deployed(&compiled, &client).await.unwrap();
 
     let contract_instance = MyContract::new(compiled, client);
 }

--- a/fuels-contract/src/contract.rs
+++ b/fuels-contract/src/contract.rs
@@ -220,19 +220,10 @@ impl Contract {
         })
     }
 
-    /// Launches a local `fuel-core` network and deploys a contract to it.
-    /// If you want to deploy a contract against another network of
-    /// your choosing, use the `deploy` function instead.
-    pub async fn launch_and_deploy(
-        compiled_contract: &CompiledContract,
-    ) -> Result<(FuelClient, ContractId), Error> {
-        let srv = FuelService::new_node(Config::local_node()).await.unwrap();
-
-        let fuel_client = FuelClient::from(srv.bound_address);
-
-        let contract_id = Self::deploy(compiled_contract, &fuel_client).await?;
-
-        Ok((fuel_client, contract_id))
+    /// Launches a local `fuel-core` network based on provided config.
+    pub async fn launch(config: Config) -> Result<FuelClient, Error> {
+        let srv = FuelService::new_node(config).await.unwrap();
+        Ok(FuelClient::from(srv.bound_address))
     }
 
     /// Deploys a compiled contract to a running node


### PR DESCRIPTION
This PR closes #98.
This PR replace the `launch_and_deploy` function with a simpler `launch`
function whose only responsibility is to launch a node. 
Implementation of a `connect` function is tracked in issue #112 and will be done later.
