### PR TITLE
Bring back no-verify temporarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose
+          args: --all-features --verbose
 
   publish:
     # Only do this job if publishing a release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features --verbose
+          args: --verbose
 
   publish:
     # Only do this job if publishing a release
@@ -85,4 +85,5 @@ jobs:
       uses: katyo/publish-crates@v1
       with:
           publish-delay: 30000
+          no-verify: true
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Currently the crate publishing action is complaining about this reasonable use-case here: https://github.com/FuelLabs/fuels-rs/blob/master/fuels-signers/Cargo.toml#L31

@Voxelot will patch the action itself to accept this use-case, but for now we'll bring back the `no-verify` option so we can publish a new release.