### PR TITLE
Remove dev dependency

### DIFF
--- a/fuels-signers/Cargo.toml
+++ b/fuels-signers/Cargo.toml
@@ -28,7 +28,6 @@ tokio = { version = "1.10.1", features = ["full"] }
 [dev-dependencies]
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 fuel-types = { version = "0.1", default-features = false, features = ["random"] }
-fuels-signers = { path = ".", version = "0.4.2", features = ["test-helpers"] }
 
 [features]
 test-helpers = ["fuel-core/test-helpers"]


### PR DESCRIPTION
Removes a `fuels-signers` dev dependency to itself, which might be causing crate publishing issues.