### PR TITLE
Add alias to `fuel_tx::ContractId` type

### DIFF
--- a/fuels-core/src/code_gen/abigen.rs
+++ b/fuels-core/src/code_gen/abigen.rs
@@ -113,18 +113,21 @@ impl Abigen {
                 quote! {
                     use fuels_contract::contract::{Contract, ContractCall};
                     use fuel_gql_client::client::FuelClient;
-                    use fuel_tx::ContractId;
+                    // aliasing to `FuelContractId` to prevent conflicts
+                    // between `fuel_tx::ContractId` and user-defined structs
+                    // named `ContractId`.
+                    use fuel_tx::ContractId as FuelContractId;
                     use std::str::FromStr;
                 },
                 quote! {
                     pub struct #name {
-                        contract_id: ContractId,
+                        contract_id: FuelContractId,
                         fuel_client: FuelClient
                     }
 
                     impl #name {
                         pub fn new(contract_id: String, fuel_client: FuelClient) -> Self {
-                            let contract_id = ContractId::from_str(&contract_id).unwrap();
+                            let contract_id = FuelContractId::from_str(&contract_id).unwrap();
                             Self{ contract_id, fuel_client }
                         }
                         #contract_functions


### PR DESCRIPTION
This is done to prevent conflicts between different `ContractId`s: the `fuel_tx` one and user-defined structs that are named `ContractId`.  

This bug was introduced here https://github.com/FuelLabs/fuels-rs/pull/113, which brought `fuel_tx::ContractId` into the scope of the generated code (`abigen!`).

This PR fixes this but a more permanent fix would be this https://github.com/FuelLabs/fuels-rs/issues/99. 

