### PR TITLE
Update to `fuel-core` 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrown"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "008b57b368e638ed60664350ea4f2f3647a0192173478df2736cc255a025a796"
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,10 +1201,10 @@ dependencies = [
  "clap 3.1.5",
  "dirs 3.0.2",
  "flate2",
- "fuel-asm",
- "fuel-gql-client",
+ "fuel-asm 0.1.0",
+ "fuel-gql-client 0.3.2",
  "fuel-tx 0.5.0",
- "fuel-vm",
+ "fuel-vm 0.4.1",
  "futures",
  "hex",
  "prettydiff",
@@ -1238,31 +1244,45 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58631627ae1dccf81f7c8a214722746883b03d304ececbdb020bca08954f8312"
 dependencies = [
- "fuel-types",
+ "fuel-types 0.1.0",
+ "serde",
+]
+
+[[package]]
+name = "fuel-asm"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3861b1aa9a6729865d6499c3f6a731caf157bc2033810ac4157c1b6a96e04c3"
+dependencies = [
+ "fuel-types 0.3.0",
  "serde",
 ]
 
 [[package]]
 name = "fuel-core"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d10595075a63802eebdf1cfde8199491d41f4e56d2c60502ee2ea667797cd404"
+checksum = "5cd48883d228dea32642913934340c3ee0a9ad93bda40fc8ea7177a50d2f6516"
 dependencies = [
+ "anyhow",
  "async-graphql",
  "async-trait",
  "axum",
  "bincode",
  "chrono",
+ "clap 3.1.5",
  "derive_more",
  "dirs 3.0.2",
  "env_logger",
- "fuel-asm",
+ "fuel-asm 0.2.0",
  "fuel-core-interfaces",
+ "fuel-crypto 0.3.0",
+ "fuel-merkle",
  "fuel-storage",
- "fuel-tx 0.5.0",
+ "fuel-tx 0.6.0",
  "fuel-txpool",
- "fuel-types",
- "fuel-vm",
+ "fuel-types 0.3.0",
+ "fuel-vm 0.5.0",
  "futures",
  "graphql-parser",
  "hex",
@@ -1273,9 +1293,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "structopt",
  "strum",
  "strum_macros",
+ "tempfile",
  "thiserror",
  "tokio",
  "tower-http",
@@ -1287,22 +1307,47 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-interfaces"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a2ed155c30313cf159c8d3d8d98ce8239a8e26e003c7d9fc21bdf2e6422318"
+checksum = "10ec5dd68f8e3869e02e2f39109f19c3aa4350f82bb9c910b38ae30269323bc5"
 dependencies = [
  "anyhow",
  "async-trait",
- "fuel-asm",
+ "fuel-asm 0.2.0",
  "fuel-storage",
- "fuel-tx 0.5.0",
- "fuel-types",
- "fuel-vm",
+ "fuel-tx 0.6.0",
+ "fuel-types 0.3.0",
+ "fuel-vm 0.5.0",
  "futures",
  "lazy_static",
  "parking_lot 0.11.2",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "fuel-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb541e22388f3e21d416128e5ec2a33b80bb8976124a79587fe1328d7d04e149"
+dependencies = [
+ "borrown",
+ "fuel-types 0.3.0",
+ "secp256k1",
+ "serde",
+ "sha2",
+]
+
+[[package]]
+name = "fuel-crypto"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5b455f5b4e59a5e772ba73744caf52a0835f564c0f82b4702c3bb23b2fe453"
+dependencies = [
+ "borrown",
+ "fuel-types 0.3.0",
+ "secp256k1",
+ "sha2",
 ]
 
 [[package]]
@@ -1316,8 +1361,8 @@ dependencies = [
  "derive_more",
  "fuel-storage",
  "fuel-tx 0.5.0",
- "fuel-types",
- "fuel-vm",
+ "fuel-types 0.1.0",
+ "fuel-vm 0.4.1",
  "futures",
  "hex",
  "itertools",
@@ -1325,6 +1370,30 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
+ "surf",
+ "thiserror",
+]
+
+[[package]]
+name = "fuel-gql-client"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e9f918979fb9d7348510a7d993e4204cdc71b7163f1e1cfc7a0b3891af7063"
+dependencies = [
+ "chrono",
+ "clap 3.1.5",
+ "cynic",
+ "derive_more",
+ "fuel-storage",
+ "fuel-tx 0.6.0",
+ "fuel-types 0.3.0",
+ "fuel-vm 0.5.0",
+ "futures",
+ "hex",
+ "itertools",
+ "schemafy_lib",
+ "serde",
+ "serde_json",
  "surf",
  "thiserror",
 ]
@@ -1400,8 +1469,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ae7148d11382ae57c1336f3b59465c8d4affb68031c23b264151b16a8f56c4c"
 dependencies = [
- "fuel-asm",
- "fuel-types",
+ "fuel-asm 0.1.0",
+ "fuel-types 0.1.0",
  "itertools",
  "rand 0.8.5",
  "sha2",
@@ -1413,24 +1482,38 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f2f7b870e050bab2e9a2178ed6ac627a56ce7ea4fb036cecdacbcc2854212ef"
 dependencies = [
- "fuel-asm",
- "fuel-types",
+ "fuel-asm 0.1.0",
+ "fuel-types 0.1.0",
  "itertools",
  "serde",
  "sha2",
 ]
 
 [[package]]
-name = "fuel-txpool"
-version = "0.3.2"
+name = "fuel-tx"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f6e4631c185b363db909ab698230120a173f92940894811f4fd620166734ec8"
+checksum = "8ac5e893eae18d812a14cd1dfb996834705bcaa24eae1f3924c1677ee29d9014"
+dependencies = [
+ "fuel-asm 0.2.0",
+ "fuel-crypto 0.3.0",
+ "fuel-types 0.3.0",
+ "itertools",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "fuel-txpool"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335cda5af6e2048b57b47783783d7f6a23810bc9d9bfda43f0cd592f8c84bc33"
 dependencies = [
  "anyhow",
  "async-trait",
  "fuel-core-interfaces",
- "fuel-tx 0.5.0",
- "fuel-types",
+ "fuel-tx 0.6.0",
+ "fuel-types 0.3.0",
  "futures",
  "parking_lot 0.11.2",
  "thiserror",
@@ -1448,16 +1531,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuel-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c3c8b8c3248c201495fab4e8a570840ab14fc33e3da8353e2bdb6a42314f9bf"
+dependencies = [
+ "serde",
+ "serde-big-array",
+]
+
+[[package]]
 name = "fuel-vm"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88118d0be5bdda4ae30c939a771b7cb8f1c99cd1de300be266ea77519b2a7e11"
 dependencies = [
- "fuel-asm",
+ "fuel-asm 0.1.0",
  "fuel-merkle",
  "fuel-storage",
  "fuel-tx 0.5.0",
- "fuel-types",
+ "fuel-types 0.1.0",
+ "itertools",
+ "secp256k1",
+ "serde",
+ "sha3",
+ "tracing",
+]
+
+[[package]]
+name = "fuel-vm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ec55ff935848e476dbcfca3931723252b5c33ad90d126f49a886600a8a731a3"
+dependencies = [
+ "fuel-asm 0.2.0",
+ "fuel-crypto 0.3.0",
+ "fuel-merkle",
+ "fuel-storage",
+ "fuel-tx 0.6.0",
+ "fuel-types 0.3.0",
  "itertools",
  "secp256k1",
  "serde",
@@ -1483,8 +1595,8 @@ name = "fuels-abigen-macro"
 version = "0.5.2"
 dependencies = [
  "fuel-core",
- "fuel-gql-client",
- "fuel-tx 0.5.0",
+ "fuel-gql-client 0.4.1",
+ "fuel-tx 0.6.0",
  "fuels-contract",
  "fuels-core",
  "fuels-signers",
@@ -1503,12 +1615,12 @@ version = "0.5.2"
 dependencies = [
  "bytes 1.1.0",
  "forc",
- "fuel-asm",
+ "fuel-asm 0.1.0",
  "fuel-core",
- "fuel-gql-client",
- "fuel-tx 0.5.0",
- "fuel-types",
- "fuel-vm",
+ "fuel-gql-client 0.4.1",
+ "fuel-tx 0.6.0",
+ "fuel-types 0.3.0",
+ "fuel-vm 0.5.0",
  "fuels-core",
  "hex",
  "proc-macro2",
@@ -1532,9 +1644,9 @@ version = "0.5.2"
 dependencies = [
  "Inflector",
  "anyhow",
- "fuel-tx 0.5.0",
- "fuel-types",
- "fuel-vm",
+ "fuel-tx 0.6.0",
+ "fuel-types 0.3.0",
+ "fuel-vm 0.5.0",
  "hex",
  "itertools",
  "proc-macro2",
@@ -1558,10 +1670,12 @@ dependencies = [
  "async-trait",
  "bytes 1.1.0",
  "fuel-core",
- "fuel-gql-client",
- "fuel-tx 0.5.0",
- "fuel-types",
- "fuel-vm",
+ "fuel-crypto 0.4.0",
+ "fuel-gql-client 0.4.1",
+ "fuel-tx 0.6.0",
+ "fuel-types 0.1.0",
+ "fuel-types 0.3.0",
+ "fuel-vm 0.5.0",
  "fuels-core",
  "hex",
  "rand 0.8.5",
@@ -3168,6 +3282,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18b20e7752957bbe9661cff4e0bb04d183d0948cdab2ea58cdb9df36a61dfe62"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3550,10 +3674,10 @@ dependencies = [
  "derivative",
  "dirs 3.0.2",
  "either",
- "fuel-asm",
+ "fuel-asm 0.1.0",
  "fuel-pest",
  "fuel-pest_derive",
- "fuel-vm",
+ "fuel-vm 0.4.1",
  "generational-arena",
  "lazy_static",
  "nanoid",
@@ -3615,7 +3739,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c95b5007edad1e2cfeb5a6fb6d49f0d2d6505a7fd188d1e957dbc7f5bf08b6a"
 dependencies = [
- "fuel-asm",
+ "fuel-asm 0.1.0",
  "fuel-tx 0.1.0",
  "serde",
 ]
@@ -3626,7 +3750,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e5e2d88699eecc8e0c25dfcc4e30329ef265eef2972d5fac7cc6cc6e26b0af"
 dependencies = [
- "fuel-asm",
+ "fuel-asm 0.1.0",
  "fuel-pest",
  "fuel-pest_derive",
  "fuel-tx 0.5.0",

--- a/fuels-abigen-macro/Cargo.toml
+++ b/fuels-abigen-macro/Cargo.toml
@@ -12,7 +12,7 @@ description = "Fuel Rust SDK marcros to generate types from ABI."
 proc-macro = true
 
 [dependencies]
-fuel-tx = "0.5"
+fuel-tx = "0.6"
 fuels-core = { version = "0.5.2", path = "../fuels-core" }
 proc-macro2 = "1.0"
 quote = "1.0"
@@ -20,8 +20,8 @@ rand = "0.8"
 syn = "1.0.12"
 
 [dev-dependencies]
-fuel-core = { version = "0.3", default-features = false }
-fuel-gql-client = { version = "0.3", default-features = false }
+fuel-core = { version = "0.4", default-features = false }
+fuel-gql-client = { version = "0.4", default-features = false }
 fuels-contract = { version = "0.5.2", path = "../fuels-contract" }
 fuels-signers = { version = "0.5.2", path = "../fuels-signers", features = ["test-helpers"] }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }

--- a/fuels-abigen-macro/tests/test_projects/foo-caller-contract/Cargo.toml
+++ b/fuels-abigen-macro/tests/test_projects/foo-caller-contract/Cargo.toml
@@ -6,8 +6,8 @@ name = "two-contracts"
 version = "0.1.0"
 
 [dependencies]
-fuel-gql-client = { version = "0.2", default-features = false }
-fuel-tx = "0.3"
+fuel-gql-client = { version = "0.4", default-features = false }
+fuel-tx = "0.6"
 fuels-abigen-macro = "0.3"
 fuels-contract = "0.3"
 fuels-core = "0.3"

--- a/fuels-abigen-macro/tests/test_projects/foo-contract/Cargo.toml
+++ b/fuels-abigen-macro/tests/test_projects/foo-contract/Cargo.toml
@@ -6,8 +6,8 @@ name = "two-contracts"
 version = "0.1.0"
 
 [dependencies]
-fuel-gql-client = { version = "0.2", default-features = false }
-fuel-tx = "0.3"
+fuel-gql-client = { version = "0.4", default-features = false }
+fuel-tx = "0.6"
 fuels-abigen-macro = "0.3"
 fuels-contract = "0.3"
 fuels-core = "0.3"

--- a/fuels-abigen-macro/tests/test_projects/two-structs/Cargo.toml
+++ b/fuels-abigen-macro/tests/test_projects/two-structs/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuel-gql-client = { version = "0.3", default-features = false }
-fuel-tx = "0.5"
+fuel-gql-client = { version = "0.4", default-features = false }
+fuel-tx = "0.6"
 fuels-abigen-macro = "0.2"
 fuels-core = "0.2"
 fuels-rs = "0.2"

--- a/fuels-contract/Cargo.toml
+++ b/fuels-contract/Cargo.toml
@@ -12,11 +12,11 @@ description = "Fuel Rust SDK contracts."
 bytes = { version = "1.0.1", features = ["serde"] }
 forc = { version = "0.5", features = ["test", "util"], default-features = false }
 fuel-asm = { version = "0.1", features = ["serde-types"] }
-fuel-core = { version = "0.3", default-features = false }
-fuel-gql-client = { version = "0.3", default-features = false }
-fuel-tx = "0.5"
-fuel-types = "0.1"
-fuel-vm = "0.4"
+fuel-core = { version = "0.4", default-features = false }
+fuel-gql-client = { version = "0.4", default-features = false }
+fuel-tx = "0.6"
+fuel-types = "0.3"
+fuel-vm = "0.5"
 fuels-core = { version = "0.5.2", path = "../fuels-core" }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 proc-macro2 = "1.0"

--- a/fuels-contract/src/contract.rs
+++ b/fuels-contract/src/contract.rs
@@ -6,7 +6,7 @@ use forc::test::{forc_build, BuildCommand};
 use fuel_asm::Opcode;
 use fuel_gql_client::client::FuelClient;
 use fuel_tx::{
-    Address, Color, ContractId, Input, Output, Receipt, StorageSlot, Transaction, UtxoId, Witness,
+    Address, AssetId, ContractId, Input, Output, Receipt, StorageSlot, Transaction, UtxoId, Witness,
 };
 use fuel_types::{Bytes32, Immediate12, Salt, Word};
 use fuel_vm::consts::{REG_CGAS, REG_RET, REG_ZERO, VM_TX_MEMORY};
@@ -170,7 +170,7 @@ impl Contract {
             UtxoId::new(Bytes32::from(rng.gen::<[u8; 32]>()), 0),
             Address::from(rng.gen::<[u8; 32]>()),
             rng.next_u64(),
-            Color::from([0u8; 32]),
+            AssetId::from([0u8; 32]),
             0,
             0,
             vec![],

--- a/fuels-core/Cargo.toml
+++ b/fuels-core/Cargo.toml
@@ -11,9 +11,9 @@ description = "Fuel Rust SDK core."
 [dependencies]
 Inflector = "0.11"
 anyhow = "1"
-fuel-tx = "0.5"
-fuel-types = "0.1"
-fuel-vm = "0.4"
+fuel-tx = "0.6"
+fuel-types = "0.3"
+fuel-vm = "0.5"
 hex = { version = "0.4.3", features = ["std"] }
 itertools = "0.10.1"
 proc-macro2 = "1.0"

--- a/fuels-signers/Cargo.toml
+++ b/fuels-signers/Cargo.toml
@@ -11,11 +11,12 @@ description = "Fuel Rust SDK signers."
 [dependencies]
 async-trait = { version = "0.1.50", default-features = false }
 bytes = { version = "1.1.0", features = ["serde"] }
-fuel-core = { version = "0.3.2", default-features = false }
-fuel-gql-client = { version = "0.3.2", default-features = false }
-fuel-tx = "0.5"
-fuel-types = { version = "0.1", default-features = false }
-fuel-vm = "0.4"
+fuel-core = { version = "0.4", default-features = false }
+fuel-crypto = "0.4"
+fuel-gql-client = { version = "0.4", default-features = false }
+fuel-tx = "0.6"
+fuel-types = { version = "0.3", default-features = false }
+fuel-vm = "0.5"
 fuels-core = { version = "0.5.2", path = "../fuels-core" }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 rand = { version = "0.8.4", default-features = false }

--- a/fuels-signers/src/provider.rs
+++ b/fuels-signers/src/provider.rs
@@ -2,7 +2,7 @@ use fuel_core::service::{Config, FuelService};
 use fuel_gql_client::client::schema::coin::Coin;
 use fuel_gql_client::client::{FuelClient, PageDirection, PaginationRequest};
 use fuel_tx::Receipt;
-use fuel_tx::{Address, Color, Input, Output, Transaction};
+use fuel_tx::{Address, AssetId, Input, Output, Transaction};
 use fuel_vm::consts::REG_ONE;
 use std::io;
 use std::net::SocketAddr;
@@ -84,7 +84,7 @@ impl Provider {
     pub async fn get_spendable_coins(
         &self,
         from: &Address,
-        color: Color,
+        color: AssetId,
         amount: u64,
     ) -> io::Result<Vec<Coin>> {
         let res = self

--- a/fuels-signers/src/signature.rs
+++ b/fuels-signers/src/signature.rs
@@ -1,5 +1,5 @@
-use fuel_tx::{crypto::Hasher, Bytes32, Bytes64};
-use fuel_types::Address;
+use fuel_crypto::Hasher;
+use fuel_tx::{Address, Bytes32, Bytes64};
 use fuel_vm::crypto::secp256k1_sign_compact_recover;
 use fuels_core::Bits256;
 use std::{convert::TryFrom, fmt, str::FromStr};

--- a/fuels-signers/src/util.rs
+++ b/fuels-signers/src/util.rs
@@ -8,8 +8,8 @@ pub mod test_helpers {
         database::Database,
         model::coin::{Coin, CoinStatus},
     };
+    use fuel_crypto::Hasher;
     use fuel_gql_client::client::FuelClient;
-    use fuel_tx::crypto::Hasher;
     use fuel_tx::{Address, Bytes32, Bytes64, UtxoId};
     use fuel_vm::prelude::Storage;
     use rand::{Fill, Rng};
@@ -49,7 +49,7 @@ pub mod test_helpers {
                 let coin = Coin {
                     owner: Address::from(*hashed),
                     amount,
-                    color: Default::default(),
+                    asset_id: Default::default(),
                     maturity: Default::default(),
                     status: CoinStatus::Unspent,
                     block_created: Default::default(),

--- a/fuels-signers/src/wallet.rs
+++ b/fuels-signers/src/wallet.rs
@@ -2,10 +2,9 @@ use crate::provider::{Provider, ProviderError};
 use crate::signature::Signature;
 use crate::Signer;
 use async_trait::async_trait;
+use fuel_crypto::Hasher;
 use fuel_gql_client::client::schema::coin::Coin;
-use fuel_tx::crypto::Hasher;
-use fuel_tx::{Bytes64, Color, Input, Output, Receipt, Transaction, UtxoId, Witness};
-use fuel_types::Address;
+use fuel_tx::{Address, AssetId, Bytes64, Input, Output, Receipt, Transaction, UtxoId, Witness};
 use fuel_vm::crypto::secp256k1_sign_compact_recoverable;
 use secp256k1::{PublicKey, Secp256k1, SecretKey};
 use std::{fmt, io};
@@ -118,7 +117,7 @@ impl Wallet {
     /// use fuels_signers::util::test_helpers::{
     ///     setup_address_and_coins, setup_local_node, setup_test_provider,
     /// };
-    /// use fuel_tx::{Bytes32, Color, Input, Output, UtxoId};
+    /// use fuel_tx::{Bytes32, AssetId, Input, Output, UtxoId};
     /// use rand::{rngs::StdRng, RngCore, SeedableRng};
     /// use secp256k1::SecretKey;
     /// use std::str::FromStr;
@@ -153,7 +152,7 @@ impl Wallet {
         &self,
         to: &Address,
         amount: u64,
-        color: Color,
+        color: AssetId,
     ) -> io::Result<Vec<Receipt>> {
         let spendable = self.get_spendable_coins(&color, amount).await?;
 
@@ -198,7 +197,7 @@ impl Wallet {
     /// Gets spendable coins from this wallet.
     /// Note that this is a simple wrapper on provider's
     /// `get_spendable_coins`.
-    pub async fn get_spendable_coins(&self, color: &Color, amount: u64) -> io::Result<Vec<Coin>> {
+    pub async fn get_spendable_coins(&self, color: &AssetId, amount: u64) -> io::Result<Vec<Coin>> {
         Ok(self
             .provider
             .get_spendable_coins(&self.address(), *color, amount)


### PR DESCRIPTION
`fuel-core` `0.4.x` brought in lots of changes, such as:

- Renaming `color` to `asset id`;
- Some structural changes to the GraphQL schema;
- Some changes to its types;
- And some more.

This PR makes the necessary changes to support these changes. Also, `Hasher` was moved from `fuel-tx` to `fuel-crypto`, so we introduce `fuel-crypto` as a dependency to `fuels-rs`. 

Closes https://github.com/FuelLabs/fuels-rs/issues/140.