### PR TITLE
Rename color to asset ID.

### DIFF
--- a/fuels-core/src/json_abi.rs
+++ b/fuels-core/src/json_abi.rs
@@ -1411,10 +1411,11 @@ mod tests {
 
         let gas = "1000000".to_string();
         let coins = "0".to_string();
-        let color = "0000000000000000000000000000000000000000000000000000000000000000".to_string();
+        let asset_id =
+            "0000000000000000000000000000000000000000000000000000000000000000".to_string();
         let s = "(true, 42)".to_string();
 
-        let values: Vec<String> = vec![gas, coins, color, s];
+        let values: Vec<String> = vec![gas, coins, asset_id, s];
 
         let mut abi = ABIParser::new();
 

--- a/fuels-signers/src/provider.rs
+++ b/fuels-signers/src/provider.rs
@@ -84,14 +84,14 @@ impl Provider {
     pub async fn get_spendable_coins(
         &self,
         from: &Address,
-        color: AssetId,
+        asset_id: AssetId,
         amount: u64,
     ) -> io::Result<Vec<Coin>> {
         let res = self
             .client
             .coins_to_spend(
                 &from.to_string(),
-                vec![(format!("{:#x}", color).as_str(), amount)],
+                vec![(format!("{:#x}", asset_id).as_str(), amount)],
                 None,
             )
             .await?;

--- a/fuels-signers/src/wallet.rs
+++ b/fuels-signers/src/wallet.rs
@@ -108,7 +108,7 @@ impl Wallet {
     }
 
     /// Transfer funds from this wallet to another `Address`.
-    /// Fails if amount for color is larger than address's spendable coins.
+    /// Fails if amount for asset ID is larger than address's spendable coins.
     ///
     /// # Examples
     /// ```
@@ -152,16 +152,16 @@ impl Wallet {
         &self,
         to: &Address,
         amount: u64,
-        color: AssetId,
+        asset_id: AssetId,
     ) -> io::Result<Vec<Receipt>> {
-        let spendable = self.get_spendable_coins(&color, amount).await?;
+        let spendable = self.get_spendable_coins(&asset_id, amount).await?;
 
         let mut inputs: Vec<Input> = vec![];
         let outputs: Vec<Output> = vec![
-            Output::coin(*to, amount, color),
+            Output::coin(*to, amount, asset_id),
             // Note that the change will be computed by the node.
-            // Here we only have to tell the node who will own the change and its color.
-            Output::change(self.address(), 0, color),
+            // Here we only have to tell the node who will own the change and its asset ID.
+            Output::change(self.address(), 0, asset_id),
         ];
 
         for coin in spendable {
@@ -169,7 +169,7 @@ impl Wallet {
                 UtxoId::from(coin.utxo_id),
                 coin.owner.into(),
                 coin.amount.0,
-                color,
+                asset_id,
                 0,
                 0,
                 vec![],
@@ -197,10 +197,14 @@ impl Wallet {
     /// Gets spendable coins from this wallet.
     /// Note that this is a simple wrapper on provider's
     /// `get_spendable_coins`.
-    pub async fn get_spendable_coins(&self, color: &AssetId, amount: u64) -> io::Result<Vec<Coin>> {
+    pub async fn get_spendable_coins(
+        &self,
+        asset_id: &AssetId,
+        amount: u64,
+    ) -> io::Result<Vec<Coin>> {
         Ok(self
             .provider
-            .get_spendable_coins(&self.address(), *color, amount)
+            .get_spendable_coins(&self.address(), *asset_id, amount)
             .await?)
     }
 }


### PR DESCRIPTION
Remove stragglers missed in #147.

Remaining instances of the word `color` should only be as ABI parameters, which will be removed with #13, and a single use of the stdlib `ETH_COLOR` constant, which can be changed in the stdlib first.