### PR TITLE
feat: Support forwarding amounts of size up to `u64` in contract calls

### DIFF
--- a/fuels-abigen-macro/tests/harness.rs
+++ b/fuels-abigen-macro/tests/harness.rs
@@ -1332,8 +1332,10 @@ async fn test_amount_and_asset_forwarding() {
     balance_result = instance.get_balance(target, asset_id).call().await.unwrap();
     assert_eq!(balance_result.value, 5_000_000);
 
-    // Forward 1 coin of native asset_id
+    // Forward 1_000_000 gas_limit of native asset_id
     let tx_params = TxParameters::new(None, Some(1_000_000), None);
+    // Forward 1_000_000 coin amount of native asset_id
+    // this is a big number for checking that amount can a u64
     let call_params = CallParameters::new(Some(1_000_000), None);
 
     let response = instance

--- a/fuels-abigen-macro/tests/harness.rs
+++ b/fuels-abigen-macro/tests/harness.rs
@@ -3,9 +3,7 @@ use fuels_abigen_macro::abigen;
 use fuels_contract::contract::Contract;
 use fuels_contract::errors::Error;
 use fuels_contract::parameters::{CallParameters, TxParameters};
-use fuels_core::constants::{
-    NATIVE_ASSET_ID, DEFAULT_INITIAL_BALANCE
-};
+use fuels_core::constants::{DEFAULT_INITIAL_BALANCE, NATIVE_ASSET_ID};
 use fuels_core::Token;
 use fuels_signers::util::test_helpers::{
     setup_address_and_coins, setup_test_provider, setup_test_provider_and_wallet,
@@ -1276,7 +1274,11 @@ async fn test_gas_errors() {
     // Test for insufficient gas.
     let result = contract_instance
         .initialize_counter(42) // Build the ABI call
-        .tx_params(TxParameters::new(Some(DEFAULT_INITIAL_BALANCE), Some(100), None))
+        .tx_params(TxParameters::new(
+            Some(DEFAULT_INITIAL_BALANCE),
+            Some(100),
+            None,
+        ))
         .call() // Perform the network call
         .await
         .expect_err("should error");

--- a/fuels-abigen-macro/tests/harness.rs
+++ b/fuels-abigen-macro/tests/harness.rs
@@ -1335,7 +1335,7 @@ async fn test_amount_and_asset_forwarding() {
     // Forward 1_000_000 gas_limit of native asset_id
     let tx_params = TxParameters::new(None, Some(1_000_000), None);
     // Forward 1_000_000 coin amount of native asset_id
-    // this is a big number for checking that amount can a u64
+    // this is a big number for checking that amount can be a u64
     let call_params = CallParameters::new(Some(1_000_000), None);
 
     let response = instance

--- a/fuels-abigen-macro/tests/harness.rs
+++ b/fuels-abigen-macro/tests/harness.rs
@@ -3,7 +3,9 @@ use fuels_abigen_macro::abigen;
 use fuels_contract::contract::Contract;
 use fuels_contract::errors::Error;
 use fuels_contract::parameters::{CallParameters, TxParameters};
-use fuels_core::constants::NATIVE_ASSET_ID;
+use fuels_core::constants::{
+    NATIVE_ASSET_ID, DEFAULT_INITIAL_BALANCE
+};
 use fuels_core::Token;
 use fuels_signers::util::test_helpers::{
     setup_address_and_coins, setup_test_provider, setup_test_provider_and_wallet,
@@ -1274,12 +1276,12 @@ async fn test_gas_errors() {
     // Test for insufficient gas.
     let result = contract_instance
         .initialize_counter(42) // Build the ABI call
-        .tx_params(TxParameters::new(Some(1_000), Some(100), None))
+        .tx_params(TxParameters::new(Some(DEFAULT_INITIAL_BALANCE), Some(100), None))
         .call() // Perform the network call
         .await
         .expect_err("should error");
 
-    assert_eq!("Contract call error: Response errors; unexpected block execution error InsufficientGas { provided: 100, required: 100000 }", result.to_string());
+    assert_eq!("Contract call error: Response errors; unexpected block execution error InsufficientGas { provided: 1000000000, required: 100000000000 }", result.to_string());
 
     // Test for running out of gas. Gas price as `None` will be 0.
     // Gas limit will be 100, this call will use more than 100 gas.
@@ -1323,14 +1325,14 @@ async fn test_amount_and_asset_forwarding() {
         .unwrap();
     assert_eq!(balance_result.value, 0);
 
-    instance.mint_coins(11).call().await.unwrap();
+    instance.mint_coins(5_000_000).call().await.unwrap();
 
     balance_result = instance.get_balance(target, asset_id).call().await.unwrap();
-    assert_eq!(balance_result.value, 11);
+    assert_eq!(balance_result.value, 5_000_000);
 
     // Forward 1 coin of native asset_id
     let tx_params = TxParameters::new(None, Some(1_000_000), None);
-    let call_params = CallParameters::new(Some(1), None);
+    let call_params = CallParameters::new(Some(1_000_000), None);
 
     let response = instance
         .get_msg_amount()
@@ -1340,7 +1342,7 @@ async fn test_amount_and_asset_forwarding() {
         .await
         .unwrap();
 
-    assert_eq!(response.value, 1);
+    assert_eq!(response.value, 1_000_000);
 
     let call_response = response
         .receipts
@@ -1349,7 +1351,7 @@ async fn test_amount_and_asset_forwarding() {
 
     assert!(call_response.is_some());
 
-    assert_eq!(call_response.unwrap().amount().unwrap(), 1);
+    assert_eq!(call_response.unwrap().amount().unwrap(), 1_000_000);
     assert_eq!(
         call_response.unwrap().asset_id().unwrap(),
         &AssetId::from(NATIVE_ASSET_ID)

--- a/fuels-contract/src/contract.rs
+++ b/fuels-contract/src/contract.rs
@@ -89,9 +89,12 @@ impl Contract {
             data_offset,
             vec![
                 // Load call data to 0x10.
-                Opcode::MOVI(0x10, data_offset + 32),
+                Opcode::MOVI(0x10, data_offset + 40),
                 // Load gas forward to 0x11.
-                Opcode::MOVI(0x12, call_parameters.amount as Immediate18),
+                // Load word into 0x12
+                Opcode::MOVI(0x12, data_offset + 32),
+                // Load the amount into 0x12
+                Opcode::LW(0x12, 0x12, 0),
                 // Load the asset id to use to 0x13.
                 Opcode::MOVI(0x13, data_offset),
                 // Call the transfer contract.
@@ -104,15 +107,21 @@ impl Contract {
 
         // `script_data` consists of:
         // 1. Asset ID to be forwarded
-        // 2. Contract ID (ContractID::LEN);
-        // 3. Function selector (1 * WORD_SIZE);
-        // 4. Calldata offset, if it has structs as input,
+        // 2. Amount to be forwarded
+        // 3. Contract ID (ContractID::LEN);
+        // 4. Function selector (1 * WORD_SIZE);
+        // 5. Calldata offset, if it has structs as input,
         // computed as `script_data_offset` + ContractId::LEN
         //                                  + 2 * WORD_SIZE;
-        // 5. Encoded arguments.
+        // 6. Encoded arguments.
         let mut script_data: Vec<u8> = vec![];
 
+        // Insert assent_id to be forwarded
         script_data.extend(call_parameters.asset_id.to_vec());
+
+        // Insert amount to be forwarded
+        let amount = call_parameters.amount as Word;
+        script_data.extend(amount.to_be_bytes());
 
         // Insert contract_id
         script_data.extend(contract_id.as_ref());
@@ -128,7 +137,7 @@ impl Contract {
         // transaction. If it doesn't take any custom inputs, this isn't necessary.
         if compute_calldata_offset {
             // Offset of the script data relative to the call data
-            let call_data_offset = (offset + 32) as usize + ContractId::LEN + 2 * WORD_SIZE;
+            let call_data_offset = (offset + 40) as usize + ContractId::LEN + 2 * WORD_SIZE;
             let call_data_offset = call_data_offset as Word;
 
             script_data.extend(&call_data_offset.to_be_bytes());

--- a/fuels-contract/src/contract.rs
+++ b/fuels-contract/src/contract.rs
@@ -82,7 +82,7 @@ impl Contract {
         wallet: LocalWallet,
     ) -> Result<Vec<Receipt>, Error> {
         // Script to call the contract. The offset that points to the `script_data` is loaded at the
-        // register `0x12`. Note that we're picking `0x12` simply because it could be any
+        // register `0x13`. Note that we're picking `0x13` simply because it could be any
         // non-reserved register. Then, we use the Opcode to call a contract: `CALL` pointing at the
         // register that we loaded the `script_data` at.
         let (script, offset) = script_with_data_offset!(
@@ -116,7 +116,7 @@ impl Contract {
         // 6. Encoded arguments.
         let mut script_data: Vec<u8> = vec![];
 
-        // Insert assent_id to be forwarded
+        // Insert asset_id to be forwarded
         script_data.extend(call_parameters.asset_id.to_vec());
 
         // Insert amount to be forwarded

--- a/fuels-contract/src/contract.rs
+++ b/fuels-contract/src/contract.rs
@@ -81,10 +81,17 @@ impl Contract {
         external_contracts: Option<Vec<ContractId>>,
         wallet: LocalWallet,
     ) -> Result<Vec<Receipt>, Error> {
-        // Script to call the contract. The offset that points to the `script_data` is loaded at the
-        // register `0x13`. Note that we're picking `0x13` simply because it could be any
-        // non-reserved register. Then, we use the Opcode to call a contract: `CALL` pointing at the
-        // register that we loaded the `script_data` at.
+        // Script to call the contract.
+        // We use the Opcode to call a contract: `CALL` pointing at the
+        // following registers;
+        //
+        // 0x10 Script data offset
+        // TODO: 0x11 Gas price
+        // 0x12 Coin amount
+        // 0x13 Asset ID
+        //
+        // Note that these are soft rules as we're picking this addresses simply because they
+        // non-reserved register.
         let forward_data_offset = ContractId::LEN + WORD_SIZE;
         let (script, offset) = script_with_data_offset!(
             data_offset,

--- a/fuels-core/src/constants.rs
+++ b/fuels-core/src/constants.rs
@@ -9,6 +9,9 @@ pub const WORD_SIZE: usize = core::mem::size_of::<Word>();
 // This constant is used to determine the amount in the 1 UTXO
 // when initializing wallets for now.
 pub const DEFAULT_COIN_AMOUNT: u64 = 1_000_000;
+
+// This constant is used to set a initial balance on wallets
+// mainly used on tests
 pub const DEFAULT_INITIAL_BALANCE: u64 = 1_000_000_000;
 
 // This constant is the bytes representation of the asset ID of

--- a/fuels-core/src/constants.rs
+++ b/fuels-core/src/constants.rs
@@ -8,8 +8,8 @@ pub const WORD_SIZE: usize = core::mem::size_of::<Word>();
 
 // This constant is used to determine the amount in the 1 UTXO
 // when initializing wallets for now.
-pub const DEFAULT_COIN_AMOUNT: u64 = 1;
-pub const DEFAULT_INITIAL_BALANCE: u64 = 100;
+pub const DEFAULT_COIN_AMOUNT: u64 = 1_000_000;
+pub const DEFAULT_INITIAL_BALANCE: u64 = 1_000_000_000;
 
 // This constant is the bytes representation of the asset ID of
 // Ethereum right now, the "native" token used for gas fees.


### PR DESCRIPTION
### Summary

Enable forwarding amount of size up to `u64` in contract calls.

### Motivation

Before, we were forcing the amount to be an `Immediate12`, which doesn't work for many use cases where we would need a `u64`. Passing a bigger number to the amount being forwarded would cause an overflow. 

closes: #174 