### PR TITLE
Turn on UTXO validation in tests

### DIFF
--- a/fuels-contract/src/contract.rs
+++ b/fuels-contract/src/contract.rs
@@ -371,8 +371,18 @@ impl Contract {
             // For now we use the NATIVE_ASSET_ID constant
             Output::change(wallet.address(), 0, AssetId::from(NATIVE_ASSET_ID)),
         ];
+
+        // The first witness is the bytecode we're deploying.
+        // So, the signature will be appended at position 1 of
+        // the witness list.
+        let coin_witness_index = 1;
+
         let inputs = wallet
-            .get_asset_inputs_for_amount(AssetId::default(), DEFAULT_COIN_AMOUNT)
+            .get_asset_inputs_for_amount(
+                AssetId::default(),
+                DEFAULT_COIN_AMOUNT,
+                coin_witness_index,
+            )
             .await?;
 
         let tx = Transaction::create(

--- a/fuels-signers/src/util.rs
+++ b/fuels-signers/src/util.rs
@@ -4,15 +4,14 @@
 pub mod test_helpers {
     use crate::provider::Provider;
     use crate::LocalWallet;
-    use fuel_core::service::{Config, FuelService};
     use fuel_core::{
-        database::Database,
+        chain_config::{ChainConfig, CoinConfig, StateConfig},
         model::coin::{Coin, CoinStatus},
+        service::{Config, DbType, FuelService},
     };
     use fuel_crypto::Hasher;
     use fuel_gql_client::client::FuelClient;
     use fuel_tx::{Address, Bytes32, Bytes64, UtxoId};
-    use fuel_vm::prelude::Storage;
     use fuels_core::constants::DEFAULT_INITIAL_BALANCE;
     use rand::{Fill, Rng};
     use secp256k1::{PublicKey, Secp256k1, SecretKey};
@@ -70,16 +69,34 @@ pub mod test_helpers {
     // Setup a test provider with the given coins. We return the SocketAddr so the launched node
     // client can be connected to more easily (even though it is often ignored).
     pub async fn setup_test_provider(coins: Vec<(UtxoId, Coin)>) -> (Provider, SocketAddr) {
-        let mut db = Database::default();
-        for (utxo_id, coin) in coins {
-            Storage::<UtxoId, Coin>::insert(&mut db, &utxo_id, &coin).unwrap();
-        }
+        let coin_configs = coins
+            .into_iter()
+            .map(|(utxo_id, coin)| CoinConfig {
+                tx_id: Some(*utxo_id.tx_id()),
+                output_index: Some(utxo_id.output_index() as u64),
+                block_created: Some(coin.block_created),
+                maturity: Some(coin.maturity),
+                owner: coin.owner,
+                amount: coin.amount,
+                asset_id: coin.asset_id,
+            })
+            .collect();
 
-        // Turn on UTXO validation.
-        let mut config = Config::local_node();
-        config.utxo_validation = true;
+        // Setup node config with genesis coins and utxo_validation enabled
+        let config = Config {
+            chain_conf: ChainConfig {
+                initial_state: Some(StateConfig {
+                    coins: Some(coin_configs),
+                    ..StateConfig::default()
+                }),
+                ..ChainConfig::local_testnet()
+            },
+            database_type: DbType::InMemory,
+            utxo_validation: true,
+            ..Config::local_node()
+        };
 
-        let srv = FuelService::from_database(db, config).await.unwrap();
+        let srv = FuelService::new_node(config).await.unwrap();
         let client = FuelClient::from(srv.bound_address);
 
         (Provider::new(client), srv.bound_address)

--- a/fuels-signers/src/util.rs
+++ b/fuels-signers/src/util.rs
@@ -75,9 +75,11 @@ pub mod test_helpers {
             Storage::<UtxoId, Coin>::insert(&mut db, &utxo_id, &coin).unwrap();
         }
 
-        let srv = FuelService::from_database(db, Config::local_node())
-            .await
-            .unwrap();
+        // Turn on UTXO validation.
+        let mut config = Config::local_node();
+        config.utxo_validation = true;
+
+        let srv = FuelService::from_database(db, config).await.unwrap();
         let client = FuelClient::from(srv.bound_address);
 
         (Provider::new(client), srv.bound_address)


### PR DESCRIPTION
This PR turns on the UTXO validation flag (from the `fuel-core` node), which enables full validation of transactions. 

So far, the only thing that broke due to this flag was the contract deployment, which was easily fixed by correcting the witness index. 

Shockingly, nothing else seemed to break. Though we've been working on adding proper signatures to the transaction for a while now. However, up until now, it had never been actually tested. But with the UTXO validation flag, [the signatures are actually tested](https://github.com/FuelLabs/fuel-tx/blob/master/src/transaction/validation.rs#L32).

Closes https://github.com/FuelLabs/fuels-rs/issues/188.