### PR TITLE
Accept Sway-native types directly and without wrappers

### DIFF
--- a/fuels-core/src/lib.rs
+++ b/fuels-core/src/lib.rs
@@ -302,6 +302,29 @@ impl<T: Tokenizable> Detokenize for T {
     }
 }
 
+impl Detokenize for fuel_tx::ContractId {
+    fn from_tokens(t: Vec<Token>) -> std::result::Result<Self, InvalidOutputType>
+    where
+        Self: Sized,
+    {
+        if let Token::Struct(tokens) = &t[0] {
+            if let Token::B256(id) = &tokens[0] {
+                Ok(fuel_tx::ContractId::from(*id))
+            } else {
+                Err(InvalidOutputType(format!(
+                    "Expected `b256`, got {:?}",
+                    tokens[0]
+                )))
+            }
+        } else {
+            Err(InvalidOutputType(format!(
+                "Expected `ContractId`, got {:?}",
+                t
+            )))
+        }
+    }
+}
+
 /// Converts a u8 to a right aligned array of 8 bytes.
 pub fn pad_u8(value: &u8) -> ByteArray {
     let mut padded = ByteArray::default();


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuels-rs/issues/99 (you can also find more context in that issue).

This PR enables support for the Sway-native types `ContractId` and `Address` in the ABI methods. This means no need to create unergonomic wrappers. 

Before:

```Rust
// This is the contract id we want to pass around.
let id = Contract::deploy(&compiled, &provider, &wallet, TxParameters::default())
  .await
  .unwrap();
  
// We have to create these ugly wrappers to make it work.
let target = testfuelcoincontract_mod::ContractId { value: id.into() };
let asset_id = testfuelcoincontract_mod::ContractId { value: id.into() };

// ...

let mut balance_result = instance
    .get_balance(target.clone(), asset_id.clone())
    .call()
    .await
    .unwrap();
```

Now:

```Rust
// This is the contract id we want to pass around.
let id = Contract::deploy(&compiled, &provider, &wallet, TxParameters::default())
    .await
    .unwrap();

// ... 

// Can use `id` (which is a `fuel_tx::ContractId`) directly in the generated ABI method.
let mut balance_result = instance.get_balance(id, id).call().await.unwrap();
```