### PR TITLE
refactor: add an argument builder for `Contract::call` method

### DIFF
--- a/packages/fuels-contract/src/contract.rs
+++ b/packages/fuels-contract/src/contract.rs
@@ -55,6 +55,7 @@ pub struct ContractCallArguments {
     external_contracts: Option<Vec<ContractId>>,
     simulate: bool,
 }
+
 impl ContractCallArguments {
     pub fn new(
         contract_id: ContractId,


### PR DESCRIPTION
This PR closes #190 by implementing a `ContractCallArguments` struct that holds
the arguments for for the `Contract::call` method. Fields which are often
repetitive are abstracted away, but can be set using a `set_*` method on the struct.
