### PR TITLE
Add `fuels-types` minimal crate for declaring serializable ABI types. Resolves the cycle between `fuels-rs` and `sway` repos.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
         ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} packages/fuels-core/Cargo.toml
         ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} packages/fuels-abigen-macro/Cargo.toml
         ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} packages/fuels-rs/Cargo.toml
+        ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} packages/fuels-types/Cargo.toml
         ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} tools/fuels-abi-cli/Cargo.toml
     - name: Publish crate
       uses: katyo/publish-crates@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ members = [
     "packages/fuels-contract",
     "packages/fuels-core",
     "packages/fuels-signers",
+    "packages/fuels-types",
     "tools/fuels-abi-cli",
 ]

--- a/packages/fuels-contract/Cargo.toml
+++ b/packages/fuels-contract/Cargo.toml
@@ -28,7 +28,5 @@ serde_json = { version = "1.0.64", default-features = true }
 sha2 = "0.9.5"
 strum = "0.21"
 strum_macros = "0.21"
-sway-types = { version = "0.8" }
-sway-utils = { version = "0.8" }
 thiserror = { version = "1.0.26", default-features = false }
 tokio = "1.12"

--- a/packages/fuels-core/Cargo.toml
+++ b/packages/fuels-core/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1"
 fuel-tx = "0.7"
 fuel-types = "0.3"
 fuel-vm = "0.6"
+fuels-types = { version = "0.9.1", path = "../fuels-types" }
 hex = { version = "0.4.3", features = ["std"] }
 itertools = "0.10.1"
 proc-macro2 = "1.0"
@@ -24,7 +25,5 @@ serde_json = { version = "1.0.64", default-features = true }
 sha2 = "0.9.5"
 strum = "0.21"
 strum_macros = "0.21"
-sway-types = { version = "0.8" }
-sway-utils = { version = "0.8" }
 syn = "1.0.12"
 thiserror = "1.0.30"

--- a/packages/fuels-core/src/code_gen/abigen.rs
+++ b/packages/fuels-core/src/code_gen/abigen.rs
@@ -9,7 +9,7 @@ use crate::errors::Error;
 use crate::json_abi::ABIParser;
 use crate::source::Source;
 use crate::utils::ident;
-use sway_types::{JsonABI, Property};
+use fuels_types::{JsonABI, Property};
 
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
@@ -432,7 +432,7 @@ mod tests {
                 ],
                 "name":"takes_nested_struct",
                 "outputs":[
-                
+
                 ]
             }
         ]

--- a/packages/fuels-core/src/code_gen/custom_types_gen.rs
+++ b/packages/fuels-core/src/code_gen/custom_types_gen.rs
@@ -3,11 +3,11 @@ use crate::json_abi::parse_param;
 use crate::types::expand_type;
 use crate::utils::ident;
 use crate::ParamType;
+use fuels_types::Property;
 use inflector::Inflector;
 use proc_macro2::TokenStream;
 use quote::quote;
 use strum_macros::ToString;
-use sway_types::Property;
 
 /// Functions used by the Abigen to expand custom types defined in an ABI spec.
 

--- a/packages/fuels-core/src/code_gen/functions_gen.rs
+++ b/packages/fuels-core/src/code_gen/functions_gen.rs
@@ -6,9 +6,8 @@ use crate::json_abi::{parse_param, ABIParser};
 use crate::types::expand_type;
 use crate::utils::{ident, safe_ident};
 use crate::{ParamType, Selector};
+use fuels_types::{Function, Property};
 use inflector::Inflector;
-use sway_types::{Function, Property};
-
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
 use std::collections::HashMap;
@@ -371,7 +370,7 @@ pub fn hello_world(
         [0, 0, 0, 0, 118, 178, 90, 36],
         &[
             ParamType::Struct(vec![ParamType::Bool, ParamType::U64]),
-            ParamType::Enum([Bool , U64])] , 
+            ParamType::Enum([Bool , U64])] ,
             &[the_only_allowed_input . into_token () ,]
     )
     .expect("method not found (this should never happen)")

--- a/packages/fuels-core/src/json_abi.rs
+++ b/packages/fuels-core/src/json_abi.rs
@@ -1,14 +1,12 @@
 use crate::Token;
 use crate::{abi_decoder::ABIDecoder, abi_encoder::ABIEncoder, errors::Error, ParamType};
+use fuels_types::{JsonABI, Property};
 use hex::FromHex;
 use itertools::Itertools;
+use serde_json;
 use std::convert::TryInto;
 use std::str;
 use std::str::FromStr;
-
-use sway_types::{JsonABI, Property};
-
-use serde_json;
 
 pub struct ABIParser {
     fn_selector: Option<Vec<u8>>,

--- a/packages/fuels-types/Cargo.toml
+++ b/packages/fuels-types/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "fuels-types"
+version = "0.9.1"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+edition = "2021"
+homepage = "https://fuel.network/"
+license = "Apache-2.0"
+repository = "https://github.com/FuelLabs/fuels-rs"
+description = "Serializable type representation for working with the Fuel VM ABI."
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }

--- a/packages/fuels-types/src/lib.rs
+++ b/packages/fuels-types/src/lib.rs
@@ -1,0 +1,33 @@
+//! Defines a set of serializable types required for the Fuel VM ABI.
+//!
+//! We declare these in a dedicated, minimal crate in order to allow for downstream projects to
+//! consume or generate these ABI-compatible types without needing to pull in the rest of the SDK.
+
+use serde::{Deserialize, Serialize};
+
+/// Fuel/Sway ABI representation in JSON, originally specified here:
+///
+/// https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md
+///
+/// This type is used by the compiler and the tooling around it convert an ABI representation into
+/// native Rust structs and vice-versa.
+pub type JsonABI = Vec<Function>;
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Function {
+    #[serde(rename = "type")]
+    pub type_field: String,
+    pub inputs: Vec<Property>,
+    pub name: String,
+    pub outputs: Vec<Property>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Property {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_field: String,
+    pub components: Option<Vec<Property>>, // Used for custom types
+}

--- a/packages/fuels-types/src/lib.rs
+++ b/packages/fuels-types/src/lib.rs
@@ -5,12 +5,12 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Fuel/Sway ABI representation in JSON, originally specified here:
+/// Fuel ABI representation in JSON, originally specified here:
 ///
 /// https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md
 ///
-/// This type is used by the compiler and the tooling around it convert an ABI representation into
-/// native Rust structs and vice-versa.
+/// This type may be used by compilers (e.g. Sway) and related tooling to convert an ABI
+/// representation into native Rust structs and vice-versa.
 pub type JsonABI = Vec<Function>;
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/tools/fuels-abi-cli/Cargo.toml
+++ b/tools/fuels-abi-cli/Cargo.toml
@@ -12,7 +12,7 @@ description = "Fuel Rust SDK CLI tool to parse ABI."
 anyhow = "1"
 fuels-contract = { version = "0.9.1", path = "../../packages/fuels-contract" }
 fuels-core = { version = "0.9.1", path = "../../packages/fuels-core" }
+fuels-types = { version = "0.9.1", path = "../../packages/fuels-types" }
 hex = "0.4"
 itertools = "0.10"
 structopt = "0.3"
-sway-types = { version = "0.8" }

--- a/tools/fuels-abi-cli/src/main.rs
+++ b/tools/fuels-abi-cli/src/main.rs
@@ -2,7 +2,7 @@ use fuels_core::code_gen::abigen::Abigen;
 use fuels_core::json_abi::parse_param;
 use fuels_core::json_abi::ABIParser;
 use fuels_core::ParamType;
-use sway_types::Property;
+use fuels_types::Property;
 
 use std::fs;
 use std::path::PathBuf;


### PR DESCRIPTION
This moves the `JsonABI` type along with the associated `Function` and `Property` types from `sway-types` into a new minimal `fuels-types` crate.

By moving these from `sway-types` upstream to the `fuels-rs` repo, we can resolve the remainder of the cyclic dependency between the `sway` and `fuels-rs` repositories.

I think also semantically it makes a little more sense for the Rust representation of these ABI-specific types to be declared under the Rust SDK, and for Sway to depend on these rather than vice versa.

The `fuels-core` crate now depends on these types via the new `fuels-types` crate. The unused `sway-utils` dependency has been removed.

As an immediate follow-up to `fuels-types` landing and getting published to crates.io, we should remove these types from the `sway-types` crate and instead depend on `fuels-types` as necessary throughout the `sway` repo.

This is one of the blockers for https://github.com/FuelLabs/sway/pull/1321.