### PR TITLE
Move to 2021 Rust #137

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace]
-resolver = "2"
 members = [
     "packages/fuels-abigen-macro",
     "packages/fuels-contract",

--- a/packages/fuels-abigen-macro/Cargo.toml
+++ b/packages/fuels-abigen-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fuels-abigen-macro"
 version = "0.9.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
-edition = "2018"
+edition = "2021"
 homepage = "https://fuel.network/"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuels-rs"

--- a/packages/fuels-contract/Cargo.toml
+++ b/packages/fuels-contract/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fuels-contract"
 version = "0.9.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
-edition = "2018"
+edition = "2021"
 homepage = "https://fuel.network/"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuels-rs"

--- a/packages/fuels-core/src/json_abi.rs
+++ b/packages/fuels-core/src/json_abi.rs
@@ -4,7 +4,6 @@ use fuels_types::{JsonABI, Property};
 use hex::FromHex;
 use itertools::Itertools;
 use serde_json;
-use std::convert::TryInto;
 use std::str;
 use std::str::FromStr;
 

--- a/tools/fuels-abi-cli/Cargo.toml
+++ b/tools/fuels-abi-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fuels-abi-cli"
 version = "0.9.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
-edition = "2018"
+edition = "2021"
 homepage = "https://fuel.network/"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuels-rs"


### PR DESCRIPTION
Closes #137

Tested with `rustfix`, i.e. `cargo fix --edition`, as well as `cargo test --all-targets --all-features`. Removed unnecessary code for 2021 edition.

Trying to look around all the repos to see how stuff works before I can make any useful contributions lol