### PR TITLE
feat: decode `LOGD` data in `CallResponse`

### DIFF
--- a/packages/fuels-abigen-macro/tests/test_projects/contract_logdata/.gitignore
+++ b/packages/fuels-abigen-macro/tests/test_projects/contract_logdata/.gitignore
@@ -1,0 +1,3 @@
+out
+target
+Forc.lock

--- a/packages/fuels-abigen-macro/tests/test_projects/contract_logdata/Forc.toml
+++ b/packages/fuels-abigen-macro/tests/test_projects/contract_logdata/Forc.toml
@@ -1,0 +1,5 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "contract_logdata"

--- a/packages/fuels-abigen-macro/tests/test_projects/contract_logdata/src/main.sw
+++ b/packages/fuels-abigen-macro/tests/test_projects/contract_logdata/src/main.sw
@@ -1,0 +1,21 @@
+contract;
+
+abi MyContract {
+    fn use_logd_opcode(value: b256, len1: u8, len2: u8) -> u64;
+    fn dont_use_logd() -> u64;
+}
+
+impl MyContract for Contract {
+    fn use_logd_opcode(value: b256, len1: u8, len2: u8) -> u64 {
+        asm(r1: value, r2: len1, r3: len2, r4: 22, r5: 11) {
+            // Log $r2 bytes of value `value`
+            logd r4 r5 r1 r2;
+            // Log $r3 bytes of value `value`
+            logd r5 r4 r1 r3;
+        };
+        42
+    }
+    fn dont_use_logd() -> u64 {
+        24
+    }
+}

--- a/packages/fuels-contract/src/contract.rs
+++ b/packages/fuels-contract/src/contract.rs
@@ -43,6 +43,25 @@ pub struct Contract {
 pub struct CallResponse<D> {
     pub value: D,
     pub receipts: Vec<Receipt>,
+    pub logs: Option<Vec<String>>,
+}
+impl<D> CallResponse<D> {
+    pub fn new(value: D, receipts: Vec<Receipt>) -> Self {
+        // Get all the logs from LogData receipts and put them in the `logs` property
+        let logs_vec = receipts
+            .iter()
+            .filter(|r| matches!(r, Receipt::LogData { .. }))
+            .map(|r| hex::encode(r.data().unwrap()))
+            .collect::<Vec<String>>();
+        Self {
+            value,
+            receipts,
+            logs: match logs_vec.is_empty() {
+                true => None,
+                false => Some(logs_vec),
+            },
+        }
+    }
 }
 
 impl Contract {
@@ -524,17 +543,11 @@ where
 
         // If it's an ABI method without a return value, exit early.
         if self.output_params.is_empty() {
-            return Ok(CallResponse {
-                value: D::from_tokens(vec![])?,
-                receipts,
-            });
+            return Ok(CallResponse::new(D::from_tokens(vec![])?, receipts));
         }
 
         let (decoded_value, receipts) = Self::get_decoded_output(receipts, &self.output_params)?;
-        Ok(CallResponse {
-            value: D::from_tokens(decoded_value)?,
-            receipts,
-        })
+        Ok(CallResponse::new(D::from_tokens(decoded_value)?, receipts))
     }
 
     /// Call a contract's method on the node, in a state-modifying manner.
@@ -558,10 +571,10 @@ where
         // Right now we only support methods with a single return type.
         // Soon we'll support tuple as a return type and we'll have to update the logic in here.
         let output_param = output_params[0].clone();
-        // If the method's return type is bigger than a single `WORD`, the returned value
-        // is stored in `ReturnData.data`, otherwise, it's stored in `Return.val`.
-        // Here we're checking for that.
-        let (encoded_value, index) = match output_param.bigger_than_word() {
+        // If the method's return type is bigger than a single `WORD`, the returned value is stored
+        // in `ReturnData.data`, otherwise, it's stored in `Return.val`. Here we're checking for
+        // that. There is only one receipt that has non-None `data` or `val`.
+        let (encoded_value, index) = match output_param.is_bigger_than_word() {
             true => match receipts.iter().find(|&receipt| receipt.data().is_some()) {
                 Some(r) => {
                     let index = receipts.iter().position(|elt| elt == r).unwrap();

--- a/packages/fuels-core/src/lib.rs
+++ b/packages/fuels-core/src/lib.rs
@@ -49,7 +49,7 @@ impl ParamType {
     // This is important because, depending on whether it's
     // bigger or smaller than a `WORD`, the returned data
     // will be inside a `ReturnData` receipt or a `Return` receipt.
-    pub fn bigger_than_word(&self) -> bool {
+    pub fn is_bigger_than_word(&self) -> bool {
         match &*self {
             // Bits256 Always bigger than one `WORD`.
             Self::B256 => true,
@@ -58,7 +58,7 @@ impl ParamType {
             Self::Struct(params) => match params.len() {
                 // If only one component in this struct
                 // check if this element itself is bigger than a `WORD`.
-                1 => params[0].bigger_than_word(),
+                1 => params[0].is_bigger_than_word(),
                 _ => true,
             },
             // Enums are always in `ReturnData`.


### PR DESCRIPTION
This PR closes #214.
- feat: decode log data as hex strings in `CallResponse` property
- test: add contract for testing `logd` opcode
- test: add test for `LOGD` decoding in harness
