### PR TITLE
Rename `fuels-rs` crate to `fuels`

### DIFF
--- a/packages/fuels-abigen-macro/Cargo.toml
+++ b/packages/fuels-abigen-macro/Cargo.toml
@@ -22,7 +22,7 @@ syn = "1.0.12"
 [dev-dependencies]
 fuel-core = { version = "0.5", default-features = false }
 fuel-gql-client = { version = "0.5", default-features = false }
-fuels-rs = { version = "0.9.1", path = "../fuels-rs" }
+fuels = { version = "0.9.1", path = "../fuels-rs" }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 sha2 = "0.9.5"
 tokio = "1.15.0"

--- a/packages/fuels-abigen-macro/tests/harness.rs
+++ b/packages/fuels-abigen-macro/tests/harness.rs
@@ -1,6 +1,6 @@
 use fuel_tx::{AssetId, ContractId, Receipt, Salt};
-use fuels_abigen_macro::abigen;
 use fuels::prelude::*;
+use fuels_abigen_macro::abigen;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use sha2::{Digest, Sha256};

--- a/packages/fuels-abigen-macro/tests/harness.rs
+++ b/packages/fuels-abigen-macro/tests/harness.rs
@@ -1,6 +1,6 @@
 use fuel_tx::{AssetId, ContractId, Receipt, Salt};
 use fuels_abigen_macro::abigen;
-use fuels_rs::prelude::*;
+use fuels::prelude::*;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use sha2::{Digest, Sha256};

--- a/packages/fuels-core/src/code_gen/abigen.rs
+++ b/packages/fuels-core/src/code_gen/abigen.rs
@@ -116,8 +116,8 @@ impl Abigen {
             (
                 quote! {
                     use fuel_tx::{ContractId, Address};
-                    use fuels_rs::contract::contract::{Contract, ContractCall};
-                    use fuels_rs::signers::{provider::Provider, LocalWallet};
+                    use fuels::contract::contract::{Contract, ContractCall};
+                    use fuels::signers::{provider::Provider, LocalWallet};
                     use std::str::FromStr;
                 },
                 quote! {
@@ -149,7 +149,7 @@ impl Abigen {
                 #![allow(unused_imports)]
 
                 #includes
-                use fuels_rs::core::{Detokenize, EnumSelector, ParamType, Tokenizable, Token};
+                use fuels::core::{Detokenize, EnumSelector, ParamType, Tokenizable, Token};
 
                 #code
 

--- a/packages/fuels-rs/Cargo.toml
+++ b/packages/fuels-rs/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fuels-rs"
+name = "fuels"
 version = "0.9.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"

--- a/packages/fuels-rs/src/lib.rs
+++ b/packages/fuels-rs/src/lib.rs
@@ -6,11 +6,11 @@
 //!
 //! ```no_run
 //! # #[allow(unused)]
-//! use fuels_rs::prelude::*;
+//! use fuels::prelude::*;
 //! use fuels_abigen_macro::abigen;
 //! ```
 //!
-//! Note that `fuels_abigen_macro` isn't included in the `fuels_rs` crate because
+//! Note that `fuels_abigen_macro` isn't included in the `fuels` crate because
 //! it is a `proc_macro` package.
 //!
 //! Examples on how you can use the types imported by the prelude can be found in
@@ -41,7 +41,7 @@ pub mod prelude {
     //!
     //! ```
     //! # #![allow(unused_imports)]
-    //! use fuels_rs::prelude::*;
+    //! use fuels::prelude::*;
     //! ```
 
     pub use super::contract::contract::Contract;


### PR DESCRIPTION
If you're up for this @digorithm, I'm thinking we should land this sooner than later in case someone snatches up `fuels` on crates.io.

Closes #225