### PR TITLE
Specify minimum supported Rust version in `fuels-rs` manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
 
 jobs:
   build:
@@ -24,15 +25,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-        # Build caching action
-      - uses: Swatinem/rust-cache@v1
-
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.58.0
           override: true
+
+      # Ensure CI is using the same minimum toolchain specified in fuels Cargo.toml
+      - name: Verify Rust Version
+        run: |
+          curl -sSLf "$DASEL_VERSION" -L -o dasel && chmod +x dasel
+          mv ./dasel /usr/local/bin/dasel
+          MIN_VERSION=$(cat packages/fuels/Cargo.toml | dasel -r toml 'package.rust-version')
+          RUSTC_VERSION=$(rustc --version -v | grep "release" | cut -d " " -f 2)
+          echo "Comparing minimum supported toolchain ($MIN_VERSION) with ci toolchain ($RUSTC_VERSION)"
+          test "$MIN_VERSION" == "$RUSTC_VERSION"
+
+        # selecting a toolchain either by action or manual `rustup` calls should happen
+        # before the cache plugin, as it uses the current rustc version as its cache key
+      - uses: Swatinem/rust-cache@v1
 
       - name: Install rustfmt
         run: rustup component add rustfmt

--- a/packages/fuels/Cargo.toml
+++ b/packages/fuels/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuels-rs"
+rust-version = "1.58.0"
 description = "Fuel Rust SDK."
 
 [dependencies]


### PR DESCRIPTION
This ensures that users are warned in the case that their installed Rust version predates the version required by `fuels-rs`.

This should be particularly useful for users building `forc`-generated test harnesses, as I believe we've already had a couple of reports of strange compile errors that just required a Rust version update.

You can find documentation on this field [here][1].

[1]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field

---

Originally I had planned on exposing this minimum required Rust version from a function in the crate root [like so](https://github.com/mitchmindtree/fuels-rs/commit/17ad3fd16d48f3c50d688e1333ac8eb8dc59dbac). The idea was that `forc` could use this function to specify the necessary `rust-version` field in the generated test harness manifest files.

However after thinking on this a little more, I realised it should be enough to simply specify the minimum required version here as `fuels` will be a dependency within the generated test harness anyway, meaning the user will be notified either way. As a result, I believe this closes https://github.com/FuelLabs/sway/issues/1239.