### PR TITLE
make fuel-core optional in fuels-signers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,6 @@
 [workspace]
+# Use the new resolver to prevent dev-deps and build-deps from enabling debugging or test features in production.
+resolver = "2"
 members = [
     "packages/fuels",
     "packages/fuels-abigen-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,9 @@
 [workspace]
 # Use the new resolver to prevent dev-deps and build-deps from enabling debugging or test features in production.
+#
+# > If you are using a virtual workspace, you will still need to explicitly set the resolver field in the [workspace]
+#   definition if you want to opt-in to the new resolver.
+# https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html#details
 resolver = "2"
 members = [
     "packages/fuels",

--- a/packages/fuels-contract/Cargo.toml
+++ b/packages/fuels-contract/Cargo.toml
@@ -17,7 +17,7 @@ fuel-tx = "0.9"
 fuel-types = "0.3"
 fuel-vm = "0.8"
 fuels-core = { version = "0.10.1", path = "../fuels-core" }
-fuels-signers = { version = "0.10.1", path = "../fuels-signers", features = ["test-helpers"] }
+fuels-signers = { version = "0.10.1", path = "../fuels-signers" }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/packages/fuels-signers/Cargo.toml
+++ b/packages/fuels-signers/Cargo.toml
@@ -11,7 +11,7 @@ description = "Fuel Rust SDK signers."
 [dependencies]
 async-trait = { version = "0.1.50", default-features = false }
 bytes = { version = "1.1.0", features = ["serde"] }
-fuel-core = { version = "0.6", default-features = false }
+fuel-core = { version = "0.6", default-features = false, optional = true }
 fuel-crypto = "0.4"
 fuel-gql-client = { version = "0.6", default-features = false }
 fuel-tx = "0.9"
@@ -32,4 +32,4 @@ fuel-types = { version = "0.3", default-features = false, features = ["random"] 
 fuels-test-helpers = { path = "../fuels-test-helpers", default-features = false }
 
 [features]
-test-helpers = ["fuel-core/test-helpers"]
+test-helpers = ["fuel-core/test-helpers", "fuel-core"]

--- a/packages/fuels-signers/src/provider.rs
+++ b/packages/fuels-signers/src/provider.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "fuel-core")]
 use fuel_core::service::{Config, FuelService};
 use fuel_gql_client::client::schema::coin::Coin;
 use fuel_gql_client::client::{FuelClient, PageDirection, PaginationRequest};
@@ -40,6 +41,7 @@ impl Provider {
         Ok(self.client.receipts(&tx_id.0.to_string()).await?)
     }
 
+    #[cfg(feature = "fuel-core")]
     /// Launches a local `fuel-core` network based on provided config.
     pub async fn launch(config: Config) -> Result<FuelClient, Error> {
         let srv = FuelService::new_node(config).await.unwrap();


### PR DESCRIPTION
fixes: #250 

Running a local copy of fuel-core from fuel-signers::Provider is purely a convenience function for local testing. However, when using the SDK in production services, we shouldn't be including the extra dependencies from fuel-core as they're unnecessary when calling a remote fuel-core node.