### PR TITLE
Ensure minimum supported rust version is verified in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.58.0
           override: true
 
       - name: Install rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
 
 jobs:
   build:
@@ -34,7 +35,7 @@ jobs:
       # Ensure CI is using the same minimum toolchain specified in fuels Cargo.toml
       - name: Verify Rust Version
         run: |
-          curl -sSLf "https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64" -L -o dasel && chmod +x dasel
+          curl -sSLf "$DASEL_VERSION" -L -o dasel && chmod +x dasel
           mv ./dasel /usr/local/bin/dasel
           MIN_VERSION=$(cat packages/fuels/Cargo.toml | dasel -r toml 'package.rust-version')
           RUSTC_VERSION=$(rustc --version -v | grep "release" | cut -d " " -f 2)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,18 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.58.0
+          toolchain: stable
           override: true
+
+      # Ensure CI is using the same minimum toolchain specified in fuels Cargo.toml
+      - name: Verify Rust Version
+      - run: |
+          curl -sSLf "https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64" -L -o dasel && chmod +x dasel
+          mv ./dasel /usr/local/bin/dasel
+          MIN_VERSION=$(cat packages/fuels/Cargo.toml | dasel -r toml 'package.rust-version')
+          RUSTC_VERSION=$(rustc --version -v | grep "release" | cut -d " " -f 2)
+          echo "Comparing minimum supported toolchain ($MIN_VERSION) with ci toolchain $(RUSTC_VERSION)"
+          test "$MIN_VERSION" == "$RUSTC_VERSION"
 
       - name: Install rustfmt
         run: rustup component add rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.58.0
           override: true
 
       # Ensure CI is using the same minimum toolchain specified in fuels Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-        # Build caching action
-      - uses: Swatinem/rust-cache@v1
-
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -34,9 +31,13 @@ jobs:
           toolchain: stable
           override: true
 
+        # selecting a toolchain either by action or manual `rustup` calls should happen
+        # before the cache plugin, as it uses the current rustc version as its cache key
+      - uses: Swatinem/rust-cache@v1
+
       # Ensure CI is using the same minimum toolchain specified in fuels Cargo.toml
       - name: Verify Rust Version
-      - run: |
+        run: |
           curl -sSLf "https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64" -L -o dasel && chmod +x dasel
           mv ./dasel /usr/local/bin/dasel
           MIN_VERSION=$(cat packages/fuels/Cargo.toml | dasel -r toml 'package.rust-version')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,6 @@ jobs:
           toolchain: stable
           override: true
 
-        # selecting a toolchain either by action or manual `rustup` calls should happen
-        # before the cache plugin, as it uses the current rustc version as its cache key
-      - uses: Swatinem/rust-cache@v1
-
       # Ensure CI is using the same minimum toolchain specified in fuels Cargo.toml
       - name: Verify Rust Version
         run: |
@@ -42,8 +38,12 @@ jobs:
           mv ./dasel /usr/local/bin/dasel
           MIN_VERSION=$(cat packages/fuels/Cargo.toml | dasel -r toml 'package.rust-version')
           RUSTC_VERSION=$(rustc --version -v | grep "release" | cut -d " " -f 2)
-          echo "Comparing minimum supported toolchain ($MIN_VERSION) with ci toolchain $(RUSTC_VERSION)"
+          echo "Comparing minimum supported toolchain ($MIN_VERSION) with ci toolchain ($RUSTC_VERSION)"
           test "$MIN_VERSION" == "$RUSTC_VERSION"
+
+        # selecting a toolchain either by action or manual `rustup` calls should happen
+        # before the cache plugin, as it uses the current rustc version as its cache key
+      - uses: Swatinem/rust-cache@v1
 
       - name: Install rustfmt
         run: rustup component add rustfmt


### PR DESCRIPTION
Addresses @mitchmindtree's concern about ensuring backwards compatibility with the rust-version specified in the fuels Cargo.toml.

If the rust-version gets updated in fuels, ci will break unless its version is also updated.