### PR TITLE
Update type handling and add support for forc `0.12.x`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: forc --version 0.12.0
+          args: forc --version 0.12.1
 
       - name: Build Sway Examples
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: forc --version 0.11.0
+          args: forc --version 0.12.0
 
       - name: Build Sway Examples
         uses: actions-rs/cargo@v1

--- a/packages/fuels-abigen-macro/tests/harness.rs
+++ b/packages/fuels-abigen-macro/tests/harness.rs
@@ -1152,7 +1152,7 @@ async fn test_contract_calling_contract() {
     // Calls the contract that calls the `FooContract` contract, also just
     // flips the bool value passed to it.
     let res = foo_caller_contract_instance
-        .call_foo_contract(true)
+        .call_foo_contract(*foo_contract_id, true)
         .set_contracts(&[foo_contract_id]) // Sets the external contract
         .call()
         .await

--- a/packages/fuels-abigen-macro/tests/test_projects/foo_caller_contract/src/main.sw
+++ b/packages/fuels-abigen-macro/tests/test_projects/foo_caller_contract/src/main.sw
@@ -2,14 +2,15 @@ contract;
 
 use foo::FooContract;
 use std::constants::NATIVE_ASSET_ID;
+use std::contract_id::ContractId;
 
 abi FooCaller {
-    fn call_foo_contract(value: bool) -> bool;
+    fn call_foo_contract(target: b256, value: bool) -> bool;
 }
 
 impl FooCaller for Contract {
-    fn call_foo_contract(value: bool) -> bool {
-        let foo_contract = abi(FooContract, 0xfe98f602add19c4b2d0c8be2929e4300f9f154eda43457b8b9ea02ef2c7b2d3c);
+    fn call_foo_contract(target: b256, value: bool) -> bool {
+        let foo_contract = abi(FooContract, target);
         let response = foo_contract.foo {
             gas: 10000, coins: 0, asset_id: NATIVE_ASSET_ID
         }

--- a/packages/fuels-core/src/lib.rs
+++ b/packages/fuels-core/src/lib.rs
@@ -44,36 +44,20 @@ impl Default for ParamType {
     }
 }
 
+pub enum ReturnLocation {
+    Return,
+    ReturnData,
+}
+
 impl ParamType {
-    // Checks if the `ParamType` is bigger than a `WORD`.
-    // This is important because, depending on whether it's
-    // bigger or smaller than a `WORD`, the returned data
-    // will be inside a `ReturnData` receipt or a `Return` receipt.
-    pub fn is_bigger_than_word(&self) -> bool {
+    // Depending on the type, the returned value will be stored
+    // either in `Return` or `ReturnData`. For more information,
+    // see https://github.com/FuelLabs/sway/issues/1368.
+    pub fn get_return_location(&self) -> ReturnLocation {
         match &*self {
-            // Bits256 Always bigger than one `WORD`.
-            Self::B256 => true,
-            // Strings are bigger than one `WORD` when its size > 8.
-            Self::String(size) => size > &8,
-            Self::Struct(params) => match params.len() {
-                // If only one component in this struct
-                // check if this element itself is bigger than a `WORD`.
-                1 => params[0].is_bigger_than_word(),
-                _ => true,
-            },
-            // Enums are always in `ReturnData`.
-            Self::Enum(_params) => true,
-            // Arrays seem to always be inside `ReturnData`.
-            Self::Array(_params, _l) => true,
-            // The other primitive types are inside `Return`,
-            // thus smaller than one `WORD`.
-            Self::Tuple(params) => {
-                if params.len() > 1 {
-                    return true;
-                }
-                false
-            }
-            _ => false,
+            Self::U8 | Self::U16 | Self::U32 | Self::U64 | Self::Bool => ReturnLocation::Return,
+
+            _ => ReturnLocation::ReturnData,
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuels-rs/issues/239.

`forc` `0.12` made some updates to the way different data types are handled, as seen on the above issue. 

This PR makes the necessary changes to support these updates. This also includes updating the CI to use `forc` `0.12`. 