### PR TITLE
Reorder cache action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-        # Build caching action
-      - uses: Swatinem/rust-cache@v1
-
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v1
 
       - name: Install rustfmt
         run: rustup component add rustfmt


### PR DESCRIPTION
As per [docs](https://github.com/Swatinem/rust-cache/tree/cb2cf0cc7c5198d3364b9630e2c3d457f160790c#example-usage), the cache action should be after the toolchain install.