### PR TITLE
Add `TxParameters` to transfer functionality

### DIFF
--- a/packages/fuels-contract/src/contract.rs
+++ b/packages/fuels-contract/src/contract.rs
@@ -1,6 +1,5 @@
 use crate::abi_decoder::ABIDecoder;
 use crate::abi_encoder::ABIEncoder;
-use crate::parameters::{CallParameters, TxParameters};
 use crate::script::Script;
 use anyhow::Result;
 use fuel_asm::Opcode;
@@ -15,7 +14,10 @@ use fuel_vm::script_with_data_offset;
 use fuels_core::errors::Error;
 use fuels_core::ReturnLocation;
 use fuels_core::{
-    constants::DEFAULT_COIN_AMOUNT, constants::WORD_SIZE, Detokenize, Selector, Token,
+    constants::DEFAULT_COIN_AMOUNT,
+    constants::WORD_SIZE,
+    parameters::{CallParameters, TxParameters},
+    Detokenize, Selector, Token,
 };
 use fuels_core::{constants::NATIVE_ASSET_ID, ParamType};
 use fuels_signers::provider::Provider;

--- a/packages/fuels-contract/src/lib.rs
+++ b/packages/fuels-contract/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod contract;
 pub mod errors;
-pub mod parameters;
 pub mod script;
 
 pub mod abi_encoder {

--- a/packages/fuels-core/src/constants.rs
+++ b/packages/fuels-core/src/constants.rs
@@ -4,7 +4,7 @@ use fuel_types::AssetId;
 pub const DEFAULT_GAS_LIMIT: u64 = 1_000_000;
 pub const DEFAULT_GAS_PRICE: u64 = 0;
 pub const DEFAULT_BYTE_PRICE: u64 = 0;
-pub const DEFAULT_MATURITY: u32 = 0;
+pub const DEFAULT_MATURITY: u64 = 0;
 
 pub const WORD_SIZE: usize = core::mem::size_of::<Word>();
 

--- a/packages/fuels-core/src/lib.rs
+++ b/packages/fuels-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod code_gen;
 pub mod constants;
 pub mod errors;
 pub mod json_abi;
+pub mod parameters;
 pub mod rustfmt;
 pub mod source;
 pub mod types;

--- a/packages/fuels-core/src/parameters.rs
+++ b/packages/fuels-core/src/parameters.rs
@@ -1,14 +1,14 @@
-use fuel_tx::AssetId;
-use fuels_core::constants::{
+use crate::constants::{
     DEFAULT_BYTE_PRICE, DEFAULT_GAS_LIMIT, DEFAULT_GAS_PRICE, DEFAULT_MATURITY, NATIVE_ASSET_ID,
 };
+use fuel_tx::AssetId;
 
 #[derive(Debug)]
 pub struct TxParameters {
     pub gas_price: u64,
     pub gas_limit: u64,
     pub byte_price: u64,
-    pub maturity: u32,
+    pub maturity: u64,
 }
 
 #[derive(Debug)]
@@ -52,7 +52,7 @@ impl TxParameters {
         gas_price: Option<u64>,
         gas_limit: Option<u64>,
         byte_price: Option<u64>,
-        maturity: Option<u32>,
+        maturity: Option<u64>,
     ) -> Self {
         Self {
             gas_price: gas_price.unwrap_or(DEFAULT_GAS_PRICE),

--- a/packages/fuels-signers/src/lib.rs
+++ b/packages/fuels-signers/src/lib.rs
@@ -131,8 +131,8 @@ mod tests {
     #[tokio::test]
     async fn send_transaction() {
         // Setup two sets of coins, one for each wallet, each containing 1 coin with 1 amount.
-        let (pk_1, mut coins_1) = setup_address_and_coins(1, 1);
-        let (pk_2, coins_2) = setup_address_and_coins(1, 1);
+        let (pk_1, mut coins_1) = setup_address_and_coins(1, 1000000);
+        let (pk_2, coins_2) = setup_address_and_coins(1, 1000000);
 
         coins_1.extend(coins_2);
 
@@ -151,9 +151,9 @@ mod tests {
         assert_eq!(wallet_2_initial_coins.len(), 1);
 
         // Configure transaction parameters.
-        let gas_price = 0;
-        let gas_limit = 1_000_000;
-        let byte_price = 0;
+        let gas_price = 1;
+        let gas_limit = 500_000;
+        let byte_price = 1;
         let maturity = 0;
 
         let tx_params = TxParameters {
@@ -192,7 +192,7 @@ mod tests {
         let result = wallet_1
             .transfer(
                 &wallet_2.address(),
-                2,
+                2000000,
                 Default::default(),
                 TxParameters::default(),
             )

--- a/packages/fuels-signers/src/lib.rs
+++ b/packages/fuels-signers/src/lib.rs
@@ -36,6 +36,7 @@ pub trait Signer: std::fmt::Debug + Send + Sync {
 mod tests {
     use fuel_crypto::{Message, SecretKey};
     use fuel_tx::{AssetId, Bytes32, Input, Output, UtxoId};
+    use fuels_core::parameters::TxParameters;
     use fuels_test_helpers::{setup_address_and_coins, setup_test_client};
     use rand::{rngs::StdRng, RngCore, SeedableRng};
     use std::str::FromStr;
@@ -151,7 +152,12 @@ mod tests {
 
         // Transfer 1 from wallet 1 to wallet 2
         let _receipts = wallet_1
-            .transfer(&wallet_2.address(), 1, Default::default())
+            .transfer(
+                &wallet_2.address(),
+                1,
+                Default::default(),
+                TxParameters::default(),
+            )
             .await
             .unwrap();
 
@@ -164,7 +170,12 @@ mod tests {
 
         // Transferring more than balance should fail
         let result = wallet_1
-            .transfer(&wallet_2.address(), 2, Default::default())
+            .transfer(
+                &wallet_2.address(),
+                2,
+                Default::default(),
+                TxParameters::default(),
+            )
             .await;
 
         assert!(result.is_err());
@@ -194,7 +205,12 @@ mod tests {
 
         // Transfer 2 from wallet 1 to wallet 2.
         let _receipts = wallet_1
-            .transfer(&wallet_2.address(), 2, Default::default())
+            .transfer(
+                &wallet_2.address(),
+                2,
+                Default::default(),
+                TxParameters::default(),
+            )
             .await
             .unwrap();
 

--- a/packages/fuels-signers/src/provider.rs
+++ b/packages/fuels-signers/src/provider.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "fuel-core")]
 use fuel_core::service::{Config, FuelService};
 use fuel_gql_client::client::schema::coin::Coin;
+use fuel_gql_client::client::types::TransactionResponse;
 use fuel_gql_client::client::{FuelClient, PageDirection, PaginationRequest};
 use fuel_tx::Receipt;
 use fuel_tx::{Address, AssetId, Input, Output, Transaction};
@@ -128,6 +129,11 @@ impl Provider {
             witnesses: vec![],
             metadata: None,
         }
+    }
+
+    /// Get transaction by id.
+    pub async fn get_transaction_by_id(&self, tx_id: &str) -> io::Result<TransactionResponse> {
+        Ok(self.client.transaction(tx_id).await.unwrap().unwrap())
     }
 
     // @todo

--- a/packages/fuels-signers/src/provider.rs
+++ b/packages/fuels-signers/src/provider.rs
@@ -10,6 +10,7 @@ use std::net::SocketAddr;
 
 use fuel_vm::prelude::Opcode;
 use fuels_core::errors::Error;
+use fuels_core::parameters::TxParameters;
 use thiserror::Error;
 
 /// An error involving a signature.
@@ -105,15 +106,20 @@ impl Provider {
     }
 
     /// Craft a transaction used to transfer funds between two addresses.
-    pub fn build_transfer_tx(&self, inputs: &[Input], outputs: &[Output]) -> Transaction {
+    pub fn build_transfer_tx(
+        &self,
+        inputs: &[Input],
+        outputs: &[Output],
+        params: TxParameters,
+    ) -> Transaction {
         // This script contains a single Opcode that returns immediately (RET)
         // since all this transaction does is move Inputs and Outputs around.
         let script = Opcode::RET(REG_ONE).to_bytes().to_vec();
         Transaction::Script {
-            gas_price: 0,
-            gas_limit: 1_000_000,
-            byte_price: 0,
-            maturity: 0,
+            gas_price: params.gas_price,
+            gas_limit: params.gas_limit,
+            byte_price: params.byte_price,
+            maturity: params.maturity,
             receipts_root: Default::default(),
             script,
             script_data: vec![],

--- a/packages/fuels-signers/src/wallet.rs
+++ b/packages/fuels-signers/src/wallet.rs
@@ -5,6 +5,7 @@ use fuel_crypto::{Message, PublicKey, SecretKey, Signature};
 use fuel_gql_client::client::schema::coin::Coin;
 use fuel_tx::{Address, AssetId, Input, Output, Receipt, Transaction, UtxoId, Witness};
 use fuels_core::errors::Error;
+use fuels_core::parameters::TxParameters;
 use std::{fmt, io};
 use thiserror::Error;
 
@@ -129,7 +130,7 @@ impl Wallet {
     ///
     ///   // Transfer 1 from wallet 1 to wallet 2
     ///   let _receipts = wallet_1
-    ///        .transfer(&wallet_2.address(), 1, Default::default())
+    ///        .transfer(&wallet_2.address(), 1, Default::default(), TxParameters::default())
     ///        .await
     ///        .unwrap();
     ///
@@ -145,6 +146,7 @@ impl Wallet {
         to: &Address,
         amount: u64,
         asset_id: AssetId,
+        tx_parameters: TxParameters,
     ) -> Result<Vec<Receipt>, WalletError> {
         let inputs = self
             .get_asset_inputs_for_amount(asset_id, amount, 0)
@@ -157,7 +159,9 @@ impl Wallet {
         ];
 
         // Build transaction and sign it
-        let mut tx = self.provider.build_transfer_tx(&inputs, &outputs);
+        let mut tx = self
+            .provider
+            .build_transfer_tx(&inputs, &outputs, tx_parameters);
         let _sig = self.sign_transaction(&mut tx).await.unwrap();
 
         Ok(self.provider.send_transaction(&tx).await?)

--- a/packages/fuels/src/lib.rs
+++ b/packages/fuels/src/lib.rs
@@ -45,9 +45,9 @@ pub mod prelude {
     //! ```
 
     pub use super::contract::contract::Contract;
-    pub use super::contract::parameters::*;
     pub use super::core::constants::*;
     pub use super::core::errors::Error;
+    pub use super::core::parameters::*;
     pub use super::core::{Token, Tokenizable};
     pub use super::signers::provider::*;
     pub use super::signers::{LocalWallet, Signer};


### PR DESCRIPTION
This PR introduces the addition of `TxParameters` to the `wallet.transfer()` API. Enabling the user to configure the `TxParameters` in a transfer call, which was previously hardcoded.

Now, transfers look like this:

```Rust
let receipts = wallet
            .transfer(&target.address(), amount, Default::default(), /* new */ TxParameters::default())
            .await
            .unwrap();
```

Also, I've moved `parameters.rs` from `fuels-contract` to `fuels-core`, to avoid a cyclic dependency problem now that `fuels-signers` need `parameters`, the same for `fuels-contract` needing `parameters`.

Closes https://github.com/FuelLabs/fuels-rs/issues/270.