### PR TITLE
feat: support unit type variants in `Enum`

### DIFF
--- a/packages/fuels-abigen-macro/tests/harness.rs
+++ b/packages/fuels-abigen-macro/tests/harness.rs
@@ -1401,3 +1401,29 @@ async fn test_logd_receipts() {
     let result = contract_instance.dont_use_logd().call().await.unwrap();
     assert_eq!(result.logs, None);
 }
+
+#[tokio::test]
+async fn unit_type_enums() {
+    abigen!(
+        MyContract,
+        "packages/fuels-abigen-macro/tests/test_projects/use_enum_input/out/debug/use_enum_input-abi.json"
+    );
+
+    let wallet = launch_provider_and_get_wallet().await;
+    let id = Contract::deploy(
+        "tests/test_projects/use_enum_input/out/debug/use_enum_input.bin",
+        &wallet,
+        TxParameters::default(),
+    )
+    .await
+    .unwrap();
+
+    let instance = MyContract::new(id.to_string(), wallet.clone());
+    let unit_type_enum = BimBamBoum::Bim();
+    let result = instance
+        .use_unit_type_enum(unit_type_enum)
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(result.value, BimBamBoum::Boum());
+}

--- a/packages/fuels-abigen-macro/tests/test_projects/use_enum_input/src/main.sw
+++ b/packages/fuels-abigen-macro/tests/test_projects/use_enum_input/src/main.sw
@@ -9,13 +9,23 @@ enum Shaker {
     Mojito:u8,
 }
 
+enum BimBamBoum {
+    Bim: (),
+    Bam: (),
+    Boum: (),
+}
+
 abi TestContract {
     fn use_enum_as_input(s: Shaker) -> u64;
+    fn use_unit_type_enum(w: BimBamBoum) -> BimBamBoum;
 }
 
 
 impl TestContract for Contract {
     fn use_enum_as_input(s: Shaker) -> u64{
         9876
+    }
+    fn use_unit_type_enum(w: BimBamBoum) -> BimBamBoum{
+        BimBamBoum::Boum
     }
 }

--- a/packages/fuels-core/src/abi_decoder.rs
+++ b/packages/fuels-core/src/abi_decoder.rs
@@ -46,6 +46,13 @@ impl ABIDecoder {
         offset: usize,
     ) -> Result<DecodeResult, CodecError> {
         match &*param {
+            ParamType::Unit => {
+                let result = DecodeResult {
+                    token: Token::Unit,
+                    new_offset: offset,
+                };
+                Ok(result)
+            }
             ParamType::U8 => {
                 let slice = peek_word(data, offset)?;
 

--- a/packages/fuels-core/src/abi_encoder.rs
+++ b/packages/fuels-core/src/abi_encoder.rs
@@ -58,6 +58,7 @@ impl ABIEncoder {
                 Token::Tuple(arg_tuple) => {
                     self.encode(arg_tuple)?;
                 }
+                Token::Unit => {}
             };
         }
         Ok(self.encoded_args.clone())

--- a/packages/fuels-core/src/code_gen/custom_types_gen.rs
+++ b/packages/fuels-core/src/code_gen/custom_types_gen.rs
@@ -230,6 +230,17 @@ pub fn expand_custom_enum(name: &str, prop: &Property) -> Result<TokenStream, Er
                     },
                 );
             }
+            // Unit type
+            ParamType::Unit => {
+                // Enum variant declaration
+                enum_variants.push(quote! {#variant_name()});
+                // Token creation
+                enum_selector_builder.push(quote! {
+                    #enum_ident::#variant_name() => (#dis, Token::Unit)
+                });
+                param_types.push(quote! { types.push(ParamType::Unit) });
+                args.push(quote! {(#dis, token) => #enum_ident::#variant_name(),});
+            }
             // Elementary type
             _ => {
                 let ty = expand_type(&param_type)?;

--- a/packages/fuels-core/src/json_abi.rs
+++ b/packages/fuels-core/src/json_abi.rs
@@ -210,6 +210,7 @@ impl ABIParser {
     pub fn tokenize(&self, param: &ParamType, value: String) -> Result<Token, Error> {
         let trimmed_value = value.trim();
         match &*param {
+            ParamType::Unit => Ok(Token::Unit),
             ParamType::U8 => Ok(Token::U8(trimmed_value.parse::<u8>()?)),
             ParamType::U16 => Ok(Token::U16(trimmed_value.parse::<u16>()?)),
             ParamType::U32 => Ok(Token::U32(trimmed_value.parse::<u32>()?)),
@@ -526,6 +527,9 @@ pub fn parse_param(param: &Property) -> Result<ParamType, Error> {
         // Simple case (primitive types, no arrays, including string)
         Ok(param_type) => Ok(param_type),
         Err(_) => {
+            if param.type_field == "()" {
+                return Ok(ParamType::Unit);
+            }
             if param.is_custom_type() {
                 return parse_custom_type_param(param);
             }

--- a/packages/fuels-core/src/lib.rs
+++ b/packages/fuels-core/src/lib.rs
@@ -29,6 +29,7 @@ pub enum ParamType {
     Bool,
     Byte,
     B256,
+    Unit,
     Array(Box<ParamType>, usize),
     #[strum(serialize = "str")]
     String(usize),
@@ -56,7 +57,9 @@ impl ParamType {
     // see https://github.com/FuelLabs/sway/issues/1368.
     pub fn get_return_location(&self) -> ReturnLocation {
         match &*self {
-            Self::U8 | Self::U16 | Self::U32 | Self::U64 | Self::Bool => ReturnLocation::Return,
+            Self::Unit | Self::U8 | Self::U16 | Self::U32 | Self::U64 | Self::Bool => {
+                ReturnLocation::Return
+            }
 
             _ => ReturnLocation::ReturnData,
         }
@@ -96,6 +99,7 @@ impl fmt::Display for ParamType {
                 let s = format!("Tuple(vec![{}])", inner_strings.join(","));
                 write!(f, "{}", s)
             }
+            ParamType::Unit => write! {f, "Unit"},
             _ => {
                 write!(f, "{:?}", self)
             }
@@ -107,6 +111,7 @@ impl fmt::Display for ParamType {
 #[derive(Debug, Clone, PartialEq, EnumString)]
 #[strum(ascii_case_insensitive)]
 pub enum Token {
+    Unit,
     U8(u8),
     U16(u16),
     U32(u32),

--- a/packages/fuels-core/src/lib.rs
+++ b/packages/fuels-core/src/lib.rs
@@ -29,6 +29,8 @@ pub enum ParamType {
     Bool,
     Byte,
     B256,
+    // The Unit paramtype is used for unit variants in Enums. The corresponding type field is `()`,
+    // similar to Rust.
     Unit,
     Array(Box<ParamType>, usize),
     #[strum(serialize = "str")]
@@ -111,6 +113,8 @@ impl fmt::Display for ParamType {
 #[derive(Debug, Clone, PartialEq, EnumString)]
 #[strum(ascii_case_insensitive)]
 pub enum Token {
+    // Used for unit type variants in Enum. An "empty" enum is not represented as Enum<empty box>,
+    // because this way we can have both unit and non-unit type variants.
     Unit,
     U8(u8),
     U16(u16),

--- a/packages/fuels-core/src/types.rs
+++ b/packages/fuels-core/src/types.rs
@@ -9,6 +9,7 @@ use crate::ParamType;
 /// Used to expand functions when generating type-safe bindings of a JSON ABI.
 pub fn expand_type(kind: &ParamType) -> Result<TokenStream, Error> {
     match kind {
+        ParamType::Unit => Ok(quote! {}),
         ParamType::U8 | ParamType::Byte => Ok(quote! { u8 }),
         ParamType::U16 => Ok(quote! { u16 }),
         ParamType::U32 => Ok(quote! { u32 }),


### PR DESCRIPTION
This PR closes #231 by implementing support for unit type variants in `Enums`.
