### PR TITLE
Fix fuels core dependency

### DIFF
--- a/packages/fuels-core/src/code_gen/abigen.rs
+++ b/packages/fuels-core/src/code_gen/abigen.rs
@@ -119,6 +119,7 @@ impl Abigen {
                     use fuels::contract::contract::{Contract, ContractCall};
                     use fuels::signers::{provider::Provider, LocalWallet};
                     use std::str::FromStr;
+                    use fuels::prelude::InvalidOutputType;
                 },
                 quote! {
                     pub struct #name {

--- a/packages/fuels-core/src/code_gen/custom_types_gen.rs
+++ b/packages/fuels-core/src/code_gen/custom_types_gen.rs
@@ -149,8 +149,8 @@ pub fn expand_custom_struct(prop: &Property) -> Result<TokenStream, Error> {
 
         }
 
-        impl fuels_core::Detokenize for #struct_ident {
-            fn from_tokens(mut tokens: Vec<Token>) -> Result<Self, fuels_core::InvalidOutputType> {
+        impl Detokenize for #struct_ident {
+            fn from_tokens(mut tokens: Vec<Token>) -> Result<Self, InvalidOutputType> {
                 let token = match tokens.len() {
                     0 => Token::Struct(vec![]),
                     1 => tokens.remove(0),
@@ -160,7 +160,7 @@ pub fn expand_custom_struct(prop: &Property) -> Result<TokenStream, Error> {
                 if let Token::Struct(tokens) = token.clone() {
                     Ok(#struct_ident::new_from_tokens(&tokens))
                 } else {
-                    Err(fuels_core::InvalidOutputType("Struct token doesn't contain inner tokens. This shouldn't happen.".to_string()))
+                    Err(InvalidOutputType("Struct token doesn't contain inner tokens. This shouldn't happen.".to_string()))
                 }
             }
         }
@@ -304,8 +304,8 @@ pub fn expand_custom_enum(name: &str, prop: &Property) -> Result<TokenStream, Er
 
         }
 
-        impl fuels_core::Detokenize for #enum_ident {
-            fn from_tokens(mut tokens: Vec<Token>) -> Result<Self, fuels_core::InvalidOutputType> {
+        impl Detokenize for #enum_ident {
+            fn from_tokens(mut tokens: Vec<Token>) -> Result<Self, InvalidOutputType> {
                 let token = match tokens.len() {
                     1 => tokens.remove(0),
                     _ => panic!("Received invalid number of tokens for creating {} enum (got {} expected 1)", #enum_name, tokens.len()),
@@ -313,7 +313,7 @@ pub fn expand_custom_enum(name: &str, prop: &Property) -> Result<TokenStream, Er
                 if let Token::Enum(_) = token {
                     Ok(#enum_ident::new_from_tokens(&[token]))
                 } else {
-                    Err(fuels_core::InvalidOutputType("Enum token doesn't contain inner tokens."
+                    Err(InvalidOutputType("Enum token doesn't contain inner tokens."
                         .to_string()))
                 }
             }
@@ -487,8 +487,8 @@ impl MatchaTea {
         }
     }
 }
-impl fuels_core::Detokenize for MatchaTea{
-    fn from_tokens(mut tokens: Vec<Token>) -> Result<Self, fuels_core::InvalidOutputType> {
+impl Detokenize for MatchaTea{
+    fn from_tokens(mut tokens: Vec<Token>) -> Result<Self, InvalidOutputType> {
         let token = match tokens.len() {
             1 => tokens.remove(0),
             _ => panic!("Received invalid number of tokens for creating {} enum (got {} expected 1)", "MatchaTea", tokens.len()),
@@ -496,7 +496,7 @@ impl fuels_core::Detokenize for MatchaTea{
         if let Token::Enum(_) = token {
             Ok(MatchaTea::new_from_tokens(&[token]))
         } else {
-            Err(fuels_core::InvalidOutputType("Enum token doesn't contain inner tokens."
+            Err(InvalidOutputType("Enum token doesn't contain inner tokens."
                 .to_string()))
         }
     }
@@ -594,8 +594,8 @@ impl Amsterdam {
         }
     }
 }
-impl fuels_core::Detokenize for Amsterdam{
-    fn from_tokens(mut tokens: Vec<Token>) -> Result<Self, fuels_core::InvalidOutputType> {
+impl Detokenize for Amsterdam{
+    fn from_tokens(mut tokens: Vec<Token>) -> Result<Self, InvalidOutputType> {
         let token = match tokens.len() {
             1 => tokens.remove(0),
             _ => panic!("Received invalid number of tokens for creating {} enum (got {} expected 1)", "Amsterdam", tokens.len()),
@@ -603,7 +603,7 @@ impl fuels_core::Detokenize for Amsterdam{
         if let Token::Enum(_) = token {
             Ok(Amsterdam::new_from_tokens(&[token]))
         } else {
-            Err(fuels_core::InvalidOutputType("Enum token doesn't contain inner tokens."
+            Err(InvalidOutputType("Enum token doesn't contain inner tokens."
                 .to_string()))
         }
     }
@@ -685,8 +685,8 @@ impl Cocktail {
         long_island : < bool > :: from_token (tokens [0usize] . clone ()) . expect ("Failed to run `new_from_tokens()` for custom Cocktail struct (tokens have wrong order and/or wrong types)") , cosmopolitan : < u64 > :: from_token (tokens [1usize] . clone ()) . expect ("Failed to run `new_from_tokens()` for custom Cocktail struct (tokens have wrong order and/or wrong types)") , mojito : < u32 > :: from_token (tokens [2usize] . clone ()) . expect ("Failed to run `new_from_tokens()` for custom Cocktail struct (tokens have wrong order and/or wrong types)") }
     }
 }
-impl fuels_core::Detokenize for Cocktail {
-    fn from_tokens(mut tokens: Vec<Token>) -> Result<Self, fuels_core::InvalidOutputType> {
+impl Detokenize for Cocktail {
+    fn from_tokens(mut tokens: Vec<Token>) -> Result<Self, InvalidOutputType> {
         let token = match tokens.len() {
             0 => Token::Struct(vec![]),
             1 => tokens.remove(0),
@@ -695,7 +695,7 @@ impl fuels_core::Detokenize for Cocktail {
         if let Token::Struct(tokens) = token.clone() {
             Ok(Cocktail::new_from_tokens(&tokens))
         } else {
-            Err(fuels_core::InvalidOutputType("Struct token doesn't contain inner tokens. This shouldn't happen.".to_string()))
+            Err(InvalidOutputType("Struct token doesn't contain inner tokens. This shouldn't happen.".to_string()))
         }
     }
 }
@@ -760,8 +760,8 @@ impl Cocktail {
         long_island : Shaker :: new_from_tokens (& tokens [0usize ..]) , mojito : < u32 > :: from_token (tokens [1usize] . clone ()) . expect ("Failed to run `new_from_tokens()` for custom Cocktail struct (tokens have wrong order and/or wrong types)") }
     }
 }
-impl fuels_core::Detokenize for Cocktail {
-    fn from_tokens(mut tokens: Vec<Token>) -> Result<Self, fuels_core::InvalidOutputType> {
+impl Detokenize for Cocktail {
+    fn from_tokens(mut tokens: Vec<Token>) -> Result<Self, InvalidOutputType> {
         let token = match tokens.len() {
             0 => Token::Struct(vec![]),
             1 => tokens.remove(0),
@@ -770,7 +770,7 @@ impl fuels_core::Detokenize for Cocktail {
         if let Token::Struct(tokens) = token.clone() {
             Ok(Cocktail::new_from_tokens(&tokens))
         } else {
-            Err(fuels_core::InvalidOutputType("Struct token doesn't contain inner tokens. This shouldn't happen.".to_string()))
+            Err(InvalidOutputType("Struct token doesn't contain inner tokens. This shouldn't happen.".to_string()))
         }
     }
 }

--- a/packages/fuels/src/lib.rs
+++ b/packages/fuels/src/lib.rs
@@ -48,6 +48,7 @@ pub mod prelude {
     pub use super::core::constants::*;
     pub use super::core::errors::Error;
     pub use super::core::parameters::*;
+    pub use super::core::{Detokenize, InvalidOutputType};
     pub use super::core::{Token, Tokenizable};
     pub use super::signers::provider::*;
     pub use super::signers::{LocalWallet, Signer};


### PR DESCRIPTION
This fixes the issue:

```
Error[E0433]: failed to resolve: use of undeclared crate or module `fuels_core`
 --> tests/harness.rs:7:1
  |
7 | abigen!(MyContract, "out/debug/bimbam-abi.json");
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared crate or module `fuels_core
```

This was happening because the trait `Detokenize` and one of the errors were being pulled from `fuels_core` without actually pulling `fuels_core` as a dependency. This PR adds both `Detokenize` and the mentioned error in the prelude and solves the issue above.