### PR TITLE
Clarify appending variable outputs

### DIFF
--- a/docs/src/getting-started/basics.md
+++ b/docs/src/getting-started/basics.md
@@ -254,7 +254,7 @@ contract_instance
 
 `append_variable_outputs` effectively appends a given amount of `Output::Variable`s to the transaction's list of outputs. This output type indicates that the output's amount and owner may vary based on transaction execution.
 
-Note that the Sway `lib-std` function `mint_to_address` calls `transfer_to_output` under the hood, and so, you need to call `append_variable_outputs` in the Rust SDK tests just like you would for transfer_to_output.
+Note that the Sway `lib-std` function `mint_to_address` calls `transfer_to_output` under the hood, and so you need to call `append_variable_outputs` in the Rust SDK tests just like you would for `transfer_to_output`.
 
 ### Contract calls calling other contracts
 

--- a/docs/src/getting-started/basics.md
+++ b/docs/src/getting-started/basics.md
@@ -254,6 +254,8 @@ contract_instance
 
 `append_variable_outputs` effectively appends a given amount of `Output::Variable`s to the transaction's list of outputs. This output type indicates that the output's amount and owner may vary based on transaction execution.
 
+Note that the Sway `lib-std` function `mint_to_address` calls `transfer_to_output` under the hood, and so, you need to call `append_variable_outputs` in the Rust SDK tests just like you would for transfer_to_output.
+
 ### Contract calls calling other contracts
 
 Sometimes, you might need to call your contract, which calls other contracts. To do so, you must feed the external contract IDs that your contract depends on to the method you're calling. You do it by chaining `.set_contracts(&[external_contract_id, ...])` to the method you want to call. For instance:


### PR DESCRIPTION
Updated basics.md for documenting that append_variable_outputs is also needed for mint_to_address #300