### PR TITLE
add import fix

### DIFF
--- a/packages/fuels-signers/src/lib.rs
+++ b/packages/fuels-signers/src/lib.rs
@@ -33,6 +33,7 @@ pub trait Signer: std::fmt::Debug + Send + Sync {
 }
 
 #[cfg(test)]
+#[cfg(feature = "test-helpers")]
 mod tests {
     use fuel_core::service::Config;
     use fuel_crypto::{Message, SecretKey};

--- a/packages/fuels-signers/src/wallet.rs
+++ b/packages/fuels-signers/src/wallet.rs
@@ -31,7 +31,7 @@ type W = English;
 /// then verified.
 ///
 /// ```
-/// use fuel_core::service::Config;
+///
 /// use fuel_crypto::Message;
 /// use fuels::prelude::*;
 ///
@@ -238,7 +238,7 @@ impl Wallet {
     /// use fuels::prelude::*;
     /// use fuel_tx::{Bytes32, AssetId, Input, Output, UtxoId};
     /// use std::str::FromStr;
-    /// use fuel_core::service::Config;
+    /// use fuels_test_helpers::{Config};
     ///
     /// async fn foo() -> Result<(), Box<dyn std::error::Error>> {
     ///  // Create the actual wallets/signers

--- a/packages/fuels-test-helpers/src/lib.rs
+++ b/packages/fuels-test-helpers/src/lib.rs
@@ -1,9 +1,10 @@
 //! Testing helpers/utilities for Fuel SDK.
 
+pub use fuel_core::service::Config;
 use fuel_core::{
     chain_config::{ChainConfig, CoinConfig, StateConfig},
     model::{Coin, CoinStatus},
-    service::{Config, DbType, FuelService},
+    service::{DbType, FuelService},
 };
 use fuel_gql_client::client::FuelClient;
 use fuel_tx::{Address, Bytes32, UtxoId};


### PR DESCRIPTION
I exported the Config from fuels-test-helpers so it could be used and added # [cfg (feature = "test-helpers")] above the tests they didn't have it.