### PR TITLE
fuel-core 0.8 upgrade (predicates)

### DIFF
--- a/docs/src/getting-started/basics.md
+++ b/docs/src/getting-started/basics.md
@@ -73,7 +73,7 @@ let contract = MyContract::new(contract_id.to_string(), wallet.clone());
 Alternatively, if you want multiple instances of the same contract then use `deploy_with_salt`
 
 ```Rust
-use fuel_tx::Salt;
+use fuels::tx::Salt;
 use fuels::prelude::*;
 use fuels_abigen_macro::abigen;
 

--- a/docs/src/getting-started/setup.md
+++ b/docs/src/getting-started/setup.md
@@ -25,7 +25,6 @@ Now you're up and ready to develop with the Fuel Rust SDK!
 all you need is to declare these three dependencies on your `Cargo.toml`:
 
 ```toml
-fuel-tx = "0.10"
 fuels-abigen-macro = "0.13"
 fuels = "0.13"
 ```

--- a/packages/fuels-abigen-macro/Cargo.toml
+++ b/packages/fuels-abigen-macro/Cargo.toml
@@ -12,7 +12,6 @@ description = "Fuel Rust SDK marcros to generate types from ABI."
 proc-macro = true
 
 [dependencies]
-fuel-tx = "0.10"
 fuels-core = { version = "0.13.0", path = "../fuels-core" }
 proc-macro2 = "1.0"
 quote = "1.0"
@@ -20,8 +19,8 @@ rand = "0.8"
 syn = "1.0.12"
 
 [dev-dependencies]
-fuel-core = { version = "0.7", default-features = false }
-fuel-gql-client = { version = "0.7", default-features = false }
+fuel-core = { version = "0.8", default-features = false }
+fuel-gql-client = { version = "0.8", default-features = false }
 fuels = { path = "../fuels" }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 sha2 = "0.9.5"

--- a/packages/fuels-abigen-macro/tests/harness.rs
+++ b/packages/fuels-abigen-macro/tests/harness.rs
@@ -1,14 +1,15 @@
 use fuel_core::service::Config;
-use fuel_tx::{AssetId, ContractId, Receipt, Salt};
-use fuels::prelude::{
-    launch_provider_and_get_single_wallet, launch_provider_and_get_wallets, setup_coins,
-    setup_test_provider, CallParameters, Contract, Error, LocalWallet, Provider, Signer,
-    TxParameters, DEFAULT_COIN_AMOUNT, DEFAULT_NUM_COINS,
+use fuel_gql_client::fuel_tx::{AssetId, ContractId, Receipt, Salt};
+use fuels::{
+    prelude::{
+        launch_provider_and_get_single_wallet, launch_provider_and_get_wallets, setup_coins,
+        setup_test_provider, CallParameters, Contract, Error, LocalWallet, Provider, Signer,
+        TxParameters, DEFAULT_COIN_AMOUNT, DEFAULT_NUM_COINS,
+    },
+    test_helpers::WalletsConfig,
 };
-use fuels::test_helpers::WalletsConfig;
 use fuels_abigen_macro::abigen;
-use fuels_core::constants::NATIVE_ASSET_ID;
-use fuels_core::Token;
+use fuels_core::{constants::NATIVE_ASSET_ID, Token};
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
 use sha2::{Digest, Sha256};

--- a/packages/fuels-contract/Cargo.toml
+++ b/packages/fuels-contract/Cargo.toml
@@ -11,11 +11,7 @@ description = "Fuel Rust SDK contracts."
 [dependencies]
 anyhow = "1"
 bytes = { version = "1.0.1", features = ["serde"] }
-fuel-asm = { version = "0.4", features = ["serde-types"] }
-fuel-gql-client = { version = "0.7", default-features = false }
-fuel-tx = "0.10"
-fuel-types = "0.5"
-fuel-vm = "0.9"
+fuel-gql-client = { version = "0.8", default-features = false }
 fuels-core = { version = "0.13.0", path = "../fuels-core" }
 fuels-signers = { version = "0.13.0", path = "../fuels-signers" }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }

--- a/packages/fuels-contract/src/script.rs
+++ b/packages/fuels-contract/src/script.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
-use fuel_gql_client::client::{types::TransactionStatus, FuelClient};
-use fuel_tx::{Receipt, Transaction};
+use fuel_gql_client::{
+    client::{types::TransactionStatus, FuelClient},
+    fuel_tx::{Receipt, Transaction},
+};
 use fuels_core::errors::Error;
 
 /// Script is a very thin layer on top of fuel-client with some

--- a/packages/fuels-core/Cargo.toml
+++ b/packages/fuels-core/Cargo.toml
@@ -11,9 +11,8 @@ description = "Fuel Rust SDK core."
 [dependencies]
 Inflector = "0.11"
 anyhow = "1"
-fuel-tx = "0.10"
+fuel-tx = "0.12"
 fuel-types = "0.5"
-fuel-vm = "0.9"
 fuels-types = { version = "0.13.0", path = "../fuels-types" }
 hex = { version = "0.4.3", features = ["std"] }
 itertools = "0.10"

--- a/packages/fuels-core/src/code_gen/abigen.rs
+++ b/packages/fuels-core/src/code_gen/abigen.rs
@@ -115,11 +115,11 @@ impl Abigen {
         } else {
             (
                 quote! {
-                    use fuel_tx::{ContractId, Address};
                     use fuels::contract::contract::{Contract, ContractCall};
-                    use fuels::signers::LocalWallet;
-                    use std::str::FromStr;
                     use fuels::prelude::InvalidOutputType;
+                    use fuels::signers::LocalWallet;
+                    use fuels::tx::{ContractId, Address};
+                    use std::str::FromStr;
                 },
                 quote! {
                     pub struct #name {

--- a/packages/fuels-signers/Cargo.toml
+++ b/packages/fuels-signers/Cargo.toml
@@ -15,12 +15,9 @@ coins-bip32 = "0.6.0"
 coins-bip39 = "0.6.0"
 elliptic-curve = { version = "0.11.6", default-features = false }
 eth-keystore = { version = "0.3.0" }
-fuel-core = { version = "0.7", default-features = false, optional = true }
+fuel-core = { version = "0.8", default-features = false, optional = true }
 fuel-crypto = "0.5"
-fuel-gql-client = { version = "0.7", default-features = false }
-fuel-tx = "0.10"
-fuel-types = { version = "0.5", default-features = false }
-fuel-vm = "0.9"
+fuel-gql-client = { version = "0.8", default-features = false }
 fuels-core = { version = "0.13.0", path = "../fuels-core" }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 rand = { version = "0.8.4", default-features = false }

--- a/packages/fuels-signers/src/lib.rs
+++ b/packages/fuels-signers/src/lib.rs
@@ -6,7 +6,7 @@ pub use fuel_crypto;
 
 use async_trait::async_trait;
 use fuel_crypto::Signature;
-use fuel_tx::{Address, Transaction};
+use fuel_gql_client::{fuel_tx::Transaction, fuel_types::Address};
 use std::error::Error;
 
 /// A wallet instantiated with a locally stored private key
@@ -37,8 +37,10 @@ pub trait Signer: std::fmt::Debug + Send + Sync {
 mod tests {
     use fuel_core::service::Config;
     use fuel_crypto::{Message, SecretKey};
-    use fuel_tx::{AssetId, Bytes32, Input, Output, UtxoId};
-    use fuels_core::parameters::TxParameters;
+    use fuels_core::{
+        parameters::TxParameters,
+        tx::{AssetId, Bytes32, Input, Output, UtxoId},
+    };
     use fuels_test_helpers::{setup_coins, setup_test_client};
     use rand::{rngs::StdRng, RngCore, SeedableRng};
     use std::str::FromStr;
@@ -81,7 +83,7 @@ mod tests {
                 .unwrap();
         let wallet = Wallet::new_from_private_key(secret, None);
 
-        let input_coin = Input::coin(
+        let input_coin = Input::coin_signed(
             UtxoId::new(Bytes32::zeroed(), 0),
             Address::from_str("0xf1e92c42b90934aa6372e30bc568a326f6e66a1a0288595e6e3fbd392a4f3e6e")
                 .unwrap(),
@@ -89,8 +91,6 @@ mod tests {
             AssetId::from([0u8; 32]),
             0,
             0,
-            vec![],
-            vec![],
         );
 
         let output_coin = Output::coin(

--- a/packages/fuels-signers/src/provider.rs
+++ b/packages/fuels-signers/src/provider.rs
@@ -3,13 +3,15 @@ use std::net::SocketAddr;
 
 #[cfg(feature = "fuel-core")]
 use fuel_core::service::{Config, FuelService};
-use fuel_gql_client::client::schema::coin::Coin;
-use fuel_gql_client::client::types::TransactionResponse;
-use fuel_gql_client::client::{FuelClient, PageDirection, PaginatedResult, PaginationRequest};
-use fuel_tx::Receipt;
-use fuel_tx::{Address, AssetId, Input, Output, Transaction};
-use fuel_vm::consts::REG_ONE;
-use fuel_vm::prelude::Opcode;
+use fuel_gql_client::{
+    client::{
+        schema::coin::Coin, types::TransactionResponse, FuelClient, PageDirection, PaginatedResult,
+        PaginationRequest,
+    },
+    fuel_tx::{Input, Output, Receipt, Transaction},
+    fuel_types::{Address, AssetId},
+    fuel_vm::{consts::REG_ONE, prelude::Opcode},
+};
 use std::collections::HashMap;
 use thiserror::Error;
 

--- a/packages/fuels-signers/src/wallet.rs
+++ b/packages/fuels-signers/src/wallet.rs
@@ -6,17 +6,13 @@ use coins_bip39::{English, Mnemonic, MnemonicError};
 use elliptic_curve::rand_core;
 use eth_keystore::KeystoreError;
 use fuel_crypto::{Message, PublicKey, SecretKey, Signature};
-use fuel_gql_client::client::schema::coin::Coin;
-use fuel_gql_client::client::types::TransactionResponse;
-use fuel_gql_client::client::{PaginatedResult, PaginationRequest};
-use fuel_tx::{Address, AssetId, Input, Output, Receipt, Transaction, UtxoId, Witness};
-use fuels_core::errors::Error;
-use fuels_core::parameters::TxParameters;
+use fuel_gql_client::{
+    client::{schema::coin::Coin, types::TransactionResponse, PaginatedResult, PaginationRequest},
+    fuel_tx::{Address, AssetId, Input, Output, Receipt, Transaction, UtxoId, Witness},
+};
+use fuels_core::{errors::Error, parameters::TxParameters};
 use rand::{CryptoRng, Rng};
-use std::collections::HashMap;
-use std::path::Path;
-use std::str::FromStr;
-use std::{fmt, io};
+use std::{collections::HashMap, fmt, io, path::Path, str::FromStr};
 use thiserror::Error;
 
 const DEFAULT_DERIVATION_PATH_PREFIX: &str = "m/44'/60'/0'/0/";
@@ -237,7 +233,7 @@ impl Wallet {
     /// # Examples
     /// ```
     /// use fuels::prelude::*;
-    /// use fuel_tx::{Bytes32, AssetId, Input, Output, UtxoId};
+    /// use fuels::tx::{Bytes32, AssetId, Input, Output, UtxoId};
     /// use std::str::FromStr;
     /// use fuels_test_helpers::Config;
     ///
@@ -315,15 +311,13 @@ impl Wallet {
         let spendable = self.get_spendable_coins(&asset_id, amount).await?;
         let mut inputs = vec![];
         for coin in spendable {
-            let input_coin = Input::coin(
+            let input_coin = Input::coin_signed(
                 UtxoId::from(coin.utxo_id),
                 coin.owner.into(),
                 coin.amount.0,
                 asset_id,
                 witness_index,
                 0,
-                vec![],
-                vec![],
             );
             inputs.push(input_coin);
         }

--- a/packages/fuels-test-helpers/Cargo.toml
+++ b/packages/fuels-test-helpers/Cargo.toml
@@ -9,12 +9,10 @@ repository = "https://github.com/FuelLabs/fuels-rs"
 description = "Fuel Rust SDK test helpers."
 
 [dependencies]
-fuel-core = { version = "0.7", default-features = false }
+fuel-core = { version = "0.8", default-features = false }
 fuel-crypto = "0.5"
-fuel-gql-client = { version = "0.7", default-features = false }
-fuel-types = { version = "0.5", default-features = false }
+fuel-gql-client = { version = "0.8", default-features = false }
 fuels-signers = { version = "0.13.0", path = "../fuels-signers", optional = true }
-fuel-tx = "0.10"
 rand = { version = "0.8.4", default-features = false }
 tokio = "1.15"
 

--- a/packages/fuels-test-helpers/src/lib.rs
+++ b/packages/fuels-test-helpers/src/lib.rs
@@ -6,8 +6,10 @@ use fuel_core::{
     model::{Coin, CoinStatus},
     service::{DbType, FuelService},
 };
-use fuel_gql_client::client::FuelClient;
-use fuel_tx::{Address, Bytes32, UtxoId};
+use fuel_gql_client::{
+    client::FuelClient,
+    fuel_tx::{Address, Bytes32, UtxoId},
+};
 use rand::Fill;
 use std::net::SocketAddr;
 

--- a/packages/fuels-test-helpers/src/signers.rs
+++ b/packages/fuels-test-helpers/src/signers.rs
@@ -2,11 +2,9 @@ use crate::{
     setup_coins, setup_test_client, wallets_config::WalletsConfig, DEFAULT_COIN_AMOUNT,
     DEFAULT_NUM_COINS,
 };
-use fuel_core::model::Coin;
-use fuel_core::service::Config;
-use fuel_tx::UtxoId;
-use fuels_signers::provider::Provider;
-use fuels_signers::{LocalWallet, Signer};
+use fuel_core::{model::Coin, service::Config};
+use fuel_gql_client::fuel_tx::UtxoId;
+use fuels_signers::{provider::Provider, LocalWallet, Signer};
 use std::net::SocketAddr;
 
 #[cfg(feature = "fuels-signers")]


### PR DESCRIPTION
- Updated fuel-core to 0.8, dealing with any breaking API changes related to `Input::coin` becoming `Input::coin_signed`. This will make the SDK compatible with the new UTXO predicate feature in fuel-core.

- Reduced the number of direct deps fuels-rs has to manage by leveraging re-exported types wherever possible.
  - This resolved an issue where some fuels packages depended on different major versions of fuel-asm. Using re-exported types will prevent missed version bumps in the future.
  - It also simplifies the number of dependencies that SDK consumers (sway apps) need to maintain, allowing them to simply import `fuels` for all their needs. 
  - The only place where a direct dependency above fuel-gql-client couldn't be removed was in fuels-core. This is because it's meant to be a lightweight package, and doesn't require the overhead of the client. The fuel-gql-client also isn't WASM friendly, so not including it into fuels-core will make it easier for that package to support no-std usage of the ABI macros.
