### PR TITLE
feat: log receipts when contract call panics or reverts

### DIFF
--- a/docs/src/getting-started/basics.md
+++ b/docs/src/getting-started/basics.md
@@ -284,8 +284,8 @@ If the contract call succeeded, getting the receipts and logs is done this way:
 
 ```rust,ignore
 let response = contract_instance.my_method(args).call().await?;
-logs : Vec<String> = response.logs // This gives out the decoded hex LOGD logs
-receipts : Vec<Receipt> =  response.receipts // This gives out all the receipts of the transaction
+let logs: Vec<String> = response.logs // This gives out the decoded hex LOGD logs
+let receipts: Vec<Receipt> =  response.receipts // This gives out all the receipts of the transaction
 ```
 
 > Note that for this to work, because of the `?`, it means the call has to have succeded.

--- a/docs/src/getting-started/basics.md
+++ b/docs/src/getting-started/basics.md
@@ -299,7 +299,7 @@ match response {
 }
 ```
 
-> **Note** Is is generally considered good practice, when you expect the call to succeed, to unwrap the response with `?`, this way:
+> **Note:** It is generally considered good practice when you expect the call to succeed, to unwrap the response with `?`, this way:
 > ```rust, ignore
 > let response = contract_instance.my_method(args).call().await?;
 > ```

--- a/docs/src/getting-started/basics.md
+++ b/docs/src/getting-started/basics.md
@@ -294,17 +294,6 @@ let receipts: Vec<Receipt> =  response.receipts // This gives out all the receip
 
 - If the contract call creates an error, the reason and the receipts of the transaction will be displayed in the Rust `panic`.
 
-- If you want to use the receipts in the case of a `ContractCallError`, you can do:
-
-```rust,ignore
-let contract_call_error = contract_instance.my_error_method(args).call().unwrap_err();
-
-if let ContractCallError(reason, receipts) = contract_call_error {
-    // Do things with `reason` and `receipts`
-}
-```
-> **Note**: It is generally not considered good practice to use `unwrap_err`.
-
 ## More examples
 
 You can find runnable examples under [`fuels-abigen-macro/tests/harness.rs`](https://github.com/FuelLabs/fuels-rs/blob/master/packages/fuels-abigen-macro/tests/harness.rs).

--- a/docs/src/getting-started/basics.md
+++ b/docs/src/getting-started/basics.md
@@ -276,6 +276,35 @@ let contract_id = "0x0123..." // Your contract ID as a string.
 let connected_contract_instance = MyContract::new(contract_id, wallet);
 ```
 
+## Getting the contract call outputs
+
+### Contract call success
+
+If the contract call succeeded, getting the receipts and logs is done this way:
+
+```rust,ignore
+let result = contract_instance.my_method(args).call().await?;
+logs = result.logs.unwrap() // This gives out the decoded hex LOGD logs
+receipts = result.receipts // This gives out all the receipts of the transaction
+```
+
+> Note that for this to work, because of the `?`, it means the call has to have succeded.
+
+### `ContractCallError`
+
+- If the contract call creates an error, the reason and the receipts of the transaction will be displayed in the Rust `panic`.
+
+- If you want to use the receipts in the case of a `ContractCallError`, you can do:
+
+```rust,ignore
+let contract_call_error = contract_instance.my_error_method(args).call().unwrap_err();
+
+if let ContractCallError(reason, receipts) = contract_call_error {
+    // Do things with `reason` and `receipts`
+}
+```
+> It is generally not considered good practice to use `unwrap_err`.
+
 ## More examples
 
 You can find runnable examples under [`fuels-abigen-macro/tests/harness.rs`](https://github.com/FuelLabs/fuels-rs/blob/master/packages/fuels-abigen-macro/tests/harness.rs).

--- a/docs/src/getting-started/basics.md
+++ b/docs/src/getting-started/basics.md
@@ -283,11 +283,15 @@ let connected_contract_instance = MyContract::new(contract_id, wallet);
 ```rust,ignore
 let response = contract_instance.my_method(args).call().await;
 match response {
+   // The transaction is valid and executes to completion
     Ok(call_response) => {
         let logs: Vec<String> = call_response.logs;
         let receipts: Vec<Receipt> = call_response.receipts;
         // Do things with logs and receipts
     }
+    
+    // - The transaction is invalid or node is offline
+    // - The transaction is valid but reverts
     ContractCallError(reason, receipts) => {
         println!("ContractCall failed with reason: {}", reason);
         println!("Transaction receipts are: {:?}", receipts);

--- a/docs/src/getting-started/basics.md
+++ b/docs/src/getting-started/basics.md
@@ -278,21 +278,27 @@ let connected_contract_instance = MyContract::new(contract_id, wallet);
 
 ## Getting the contract call outputs
 
-### Contract call success
-
-If the contract call succeeded, getting the receipts and logs is done this way:
+- Getting the contract call outputs is done this way:
 
 ```rust,ignore
-let response = contract_instance.my_method(args).call().await?;
-let logs: Vec<String> = response.logs // This gives out the decoded hex LOGD logs
-let receipts: Vec<Receipt> =  response.receipts // This gives out all the receipts of the transaction
+let response = contract_instance.my_method(args).call().await;
+match response {
+    Ok(call_response) => {
+        let logs: Vec<String> = call_response.logs;
+        let receipts: Vec<Receipt> = call_response.receipts;
+        // Do things with logs and receipts
+    }
+    ContractCallError(reason, receipts) => {
+        println!("ContractCall failed with reason: {}", reason);
+        println!("Transaction receipts are: {:?}", receipts);
+    }
+}
 ```
 
-> **Note**: For this to work, because of the `?`, it means the call has to have succeded.
-
-### `ContractCallError`
-
-- If the contract call creates an error, the reason and the receipts of the transaction will be displayed in the Rust `panic`.
+> **Note** Is is generally considered good practice, when you expect the call to succeed, to unwrap the response with `?`, this way:
+> ```rust, ignore
+> let response = contract_instance.my_method(args).call().await?;
+> ```
 
 ## More examples
 

--- a/docs/src/getting-started/basics.md
+++ b/docs/src/getting-started/basics.md
@@ -288,7 +288,7 @@ let logs: Vec<String> = response.logs // This gives out the decoded hex LOGD log
 let receipts: Vec<Receipt> =  response.receipts // This gives out all the receipts of the transaction
 ```
 
-> Note that for this to work, because of the `?`, it means the call has to have succeded.
+> **Note**: For this to work, because of the `?`, it means the call has to have succeded.
 
 ### `ContractCallError`
 

--- a/docs/src/getting-started/basics.md
+++ b/docs/src/getting-started/basics.md
@@ -283,9 +283,9 @@ let connected_contract_instance = MyContract::new(contract_id, wallet);
 If the contract call succeeded, getting the receipts and logs is done this way:
 
 ```rust,ignore
-let result = contract_instance.my_method(args).call().await?;
-logs = result.logs.unwrap() // This gives out the decoded hex LOGD logs
-receipts = result.receipts // This gives out all the receipts of the transaction
+let response = contract_instance.my_method(args).call().await?;
+logs : Vec<String> = response.logs // This gives out the decoded hex LOGD logs
+receipts : Vec<Receipt> =  response.receipts // This gives out all the receipts of the transaction
 ```
 
 > Note that for this to work, because of the `?`, it means the call has to have succeded.

--- a/docs/src/getting-started/basics.md
+++ b/docs/src/getting-started/basics.md
@@ -303,7 +303,7 @@ if let ContractCallError(reason, receipts) = contract_call_error {
     // Do things with `reason` and `receipts`
 }
 ```
-> It is generally not considered good practice to use `unwrap_err`.
+> **Note**: It is generally not considered good practice to use `unwrap_err`.
 
 ## More examples
 

--- a/packages/fuels-abigen-macro/tests/harness.rs
+++ b/packages/fuels-abigen-macro/tests/harness.rs
@@ -802,7 +802,7 @@ async fn test_reverting_transaction() {
     let contract_instance = RevertingContract::new(contract_id.to_string(), wallet);
     println!("Contract deployed @ {:x}", contract_id);
     let result = contract_instance.make_transaction_fail(0).call().await;
-    assert!(matches!(result, Err(Error::ContractCallError(_))));
+    assert!(matches!(result, Err(Error::ContractCallError(..))));
 }
 
 #[tokio::test]
@@ -1065,7 +1065,9 @@ async fn test_gas_errors() {
         .await
         .expect_err("should error");
 
-    assert_eq!("Contract call error: Response errors; unexpected block execution error InsufficientFeeAmount { provided: 1000000000, required: 100000000000 }", result.to_string());
+    let expected = "Contract call error: Response errors; unexpected block execution error \
+    InsufficientFeeAmount { provided: 1000000000, required: 100000000000 }, receipts:";
+    assert!(result.to_string().starts_with(expected));
 
     // Test for running out of gas. Gas price as `None` will be 0.
     // Gas limit will be 100, this call will use more than 100 gas.
@@ -1076,7 +1078,8 @@ async fn test_gas_errors() {
         .await
         .expect_err("should error");
 
-    assert_eq!("Contract call error: OutOfGas", result.to_string());
+    let expected = "Contract call error: OutOfGas, receipts:";
+    assert!(result.to_string().starts_with(expected));
 }
 
 #[tokio::test]

--- a/packages/fuels-abigen-macro/tests/harness.rs
+++ b/packages/fuels-abigen-macro/tests/harness.rs
@@ -1374,21 +1374,21 @@ async fn test_logd_receipts() {
         .call()
         .await
         .unwrap();
-    assert_eq!(result.logs.unwrap(), vec!["ffeedd", "ffeedd000000"]);
+    assert_eq!(result.logs, vec!["ffeedd", "ffeedd000000"]);
     let result = contract_instance
         .use_logd_opcode(value, 14, 15)
         .call()
         .await
         .unwrap();
     assert_eq!(
-        result.logs.unwrap(),
+        result.logs,
         vec![
             "ffeedd000000000000000000aabb",
             "ffeedd000000000000000000aabbcc"
         ]
     );
     let result = contract_instance.dont_use_logd().call().await.unwrap();
-    assert_eq!(result.logs, None);
+    assert!(result.logs.is_empty());
 }
 
 #[tokio::test]

--- a/packages/fuels-contract/src/contract.rs
+++ b/packages/fuels-contract/src/contract.rs
@@ -43,7 +43,7 @@ pub struct Contract {
 pub struct CallResponse<D> {
     pub value: D,
     pub receipts: Vec<Receipt>,
-    pub logs: Option<Vec<String>>,
+    pub logs: Vec<String>,
 }
 
 impl<D> CallResponse<D> {
@@ -57,10 +57,7 @@ impl<D> CallResponse<D> {
         Self {
             value,
             receipts,
-            logs: match logs_vec.is_empty() {
-                true => None,
-                false => Some(logs_vec),
-            },
+            logs: logs_vec,
         }
     }
 }

--- a/packages/fuels-contract/src/script.rs
+++ b/packages/fuels-contract/src/script.rs
@@ -28,7 +28,9 @@ impl Script {
         let receipts = fuel_client.receipts(&tx_id).await?;
         let status = fuel_client.transaction_status(&tx_id).await?;
         match status {
-            TransactionStatus::Failure { reason, .. } => Err(Error::ContractCallError(reason)),
+            TransactionStatus::Failure { reason, .. } => {
+                Err(Error::ContractCallError(reason, receipts))
+            }
             _ => Ok(receipts),
         }
     }

--- a/packages/fuels-core/src/errors.rs
+++ b/packages/fuels-core/src/errors.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 use core::str::Utf8Error;
 pub type Result<T> = core::result::Result<T, Error>;
+use fuel_tx::Receipt;
 use std::net;
 use strum::ParseError;
 use thiserror::Error;
@@ -53,8 +54,8 @@ pub enum Error {
     TransactionError(String),
     #[error("Infrastructure error: {0}")]
     InfrastructureError(String),
-    #[error("Contract call error: {0}")]
-    ContractCallError(String),
+    #[error("Contract call error: {}, receipts: {:?}", .0, .1)]
+    ContractCallError(String, Vec<Receipt>),
     #[error("Wallet error: {0}")]
     WalletError(String),
 }
@@ -76,11 +77,11 @@ impl From<ParseError> for Error {
 
 impl From<InvalidOutputType> for Error {
     fn from(err: InvalidOutputType) -> Error {
-        Error::ContractCallError(err.0)
+        Error::ContractCallError(err.0, vec![])
     }
 }
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Error {
-        Error::ContractCallError(err.to_string())
+        Error::ContractCallError(err.to_string(), vec![])
     }
 }


### PR DESCRIPTION
This PR closes #295 by changing the `ContractCallError` variant to log the
receipts in case of reverting or panicking contract calls.
