### PR TITLE
Fix crypto dep random feature.

### DIFF
--- a/packages/fuels-signers/Cargo.toml
+++ b/packages/fuels-signers/Cargo.toml
@@ -16,7 +16,7 @@ coins-bip39 = "0.6.0"
 elliptic-curve = { version = "0.11.6", default-features = false }
 eth-keystore = { version = "0.3.0" }
 fuel-core = { version = "0.8", default-features = false, optional = true }
-fuel-crypto = "0.5"
+fuel-crypto = { version = "0.5", features = ["random"] }
 fuel-gql-client = { version = "0.8", default-features = false }
 fuels-core = { version = "0.14.0", path = "../fuels-core" }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }

--- a/packages/fuels-test-helpers/Cargo.toml
+++ b/packages/fuels-test-helpers/Cargo.toml
@@ -10,7 +10,6 @@ description = "Fuel Rust SDK test helpers."
 
 [dependencies]
 fuel-core = { version = "0.8", default-features = false }
-fuel-crypto = "0.5"
 fuel-gql-client = { version = "0.8", default-features = false }
 fuels-signers = { version = "0.14.0", path = "../fuels-signers", optional = true }
 rand = { version = "0.8.4", default-features = false }


### PR DESCRIPTION
Resolves this failing CI: https://github.com/FuelLabs/fuels-rs/actions/runs/2393556289

Adds the `random` feature for `fuel-crypto` in `fuels-signers` and removes unused `fuel-crypto` in `fuels-test-helpers`.