### PR TITLE
Disable feature unification in CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
             !packages/fuels-abigen-macro/tests/test_projects/**/Forc.lock
             !packages/fuels-abigen-macro/tests/test_projects/**/.gitignore
 
-  get_workspace_members:
+  get-workspace-members:
     needs: cancel-previous-runs
     runs-on: ubuntu-latest
     outputs:
@@ -102,7 +102,7 @@ jobs:
     needs:
       - setup-test-projects
       - verify-rust-version
-      - get_workspace_members
+      - get-workspace-members
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -113,7 +113,7 @@ jobs:
             args: --all-targets --all-features
           - command: check
             args: --all-features
-            package: ${{fromJSON(needs.set_workspace_members.outputs.members)}}
+            package: ${{fromJSON(needs.get-workspace-members.outputs.members)}}
           - command: test
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,11 @@ jobs:
           git config --global core.bigfilethreshold 100m
 
       - name: Install Forc
-        uses: actions-rs/cargo@v1
+        run: |
+          curl -sSLf https://github.com/FuelLabs/sway/releases/download/v${{ env.FORC_VERSION }}/forc-binaries-linux_amd64.tar.gz -L -o forc.tar.gz
+          tar -xvf forc.tar.gz
+          chmod +x forc-binaries/forc
+          mv forc-binaries/forc /usr/local/bin/forc
         with:
           command: install
           args: forc --version ${{ env.FORC_VERSION }}
@@ -87,6 +91,7 @@ jobs:
     needs: cancel-previous-runs
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       # Ensure CI is using the same minimum toolchain specified in fuels Cargo.toml
       - run: |
           curl -sSLf "$DASEL_VERSION" -L -o dasel && chmod +x dasel
@@ -100,6 +105,7 @@ jobs:
     needs:
       - setup-test-projects
       - verify-rust-version
+      - get_workspace_members
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   build:
@@ -71,13 +72,9 @@ jobs:
           command: fmt
           args: --all --verbose -- --check
 
+      - uses: davidB/rust-cargo-make@v1
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose --workspace --all-targets --all-features
-        env:
-          RUSTFLAGS: "-D warnings"
+        run: cargo make build
 
       - name: Run tests
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
           - command: clippy
             args: --all-targets --all-features
           - command: test
+            args: --all-targets --all-features
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,43 +12,32 @@ env:
   CARGO_TERM_COLOR: always
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
   RUSTFLAGS: "-D warnings"
+  RUST_VERSION: 1.61.0
+  FORC_VERSION: 0.13.0
 
 jobs:
-  build:
+  cancel-previous-runs:
     runs-on: ubuntu-latest
-
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
 
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
+  setup-test-projects:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.61.0
+          toolchain: ${{ env.RUST_VERSION }}
           override: true
-
-      # Ensure CI is using the same minimum toolchain specified in fuels Cargo.toml
-      - name: Verify Rust Version
-        run: |
-          curl -sSLf "$DASEL_VERSION" -L -o dasel && chmod +x dasel
-          mv ./dasel /usr/local/bin/dasel
-          MIN_VERSION=$(cat packages/fuels/Cargo.toml | dasel -r toml 'package.rust-version')
-          RUSTC_VERSION=$(rustc --version -v | grep "release" | cut -d " " -f 2)
-          echo "Comparing minimum supported toolchain ($MIN_VERSION) with ci toolchain ($RUSTC_VERSION)"
-          test "$MIN_VERSION" == "$RUSTC_VERSION"
-
         # selecting a toolchain either by action or manual `rustup` calls should happen
         # before the cache plugin, as it uses the current rustc version as its cache key
       - uses: Swatinem/rust-cache@v1
-
-      - name: Install rustfmt
-        run: rustup component add rustfmt
 
       - name: Set git config
         run: |
@@ -58,7 +47,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: forc --version 0.13.0
+          args: forc --version ${{ env.FORC_VERSION }}
 
       - name: Build Sway Examples
         uses: actions-rs/cargo@v1
@@ -66,25 +55,80 @@ jobs:
           command: run
           args: --bin build-test-projects
 
-      - name: Check formatting
-        uses: actions-rs/cargo@v1
+      - uses: actions/upload-artifact@v2
         with:
-          command: fmt
-          args: --all --verbose -- --check
+          retention-days: 2
+          name: sway-examples
+          # cache only the sway build artifacts, skip all test_project src files
+          path: |
+            packages/fuels-abigen-macro/tests/test_projects
+            !packages/fuels-abigen-macro/tests/test_projects/**/*.sw
+            !packages/fuels-abigen-macro/tests/test_projects/**/Forc.toml
+            !packages/fuels-abigen-macro/tests/test_projects/**/Forc.lock
+            !packages/fuels-abigen-macro/tests/test_projects/**/.gitignore
 
-      - uses: davidB/rust-cargo-make@v1
+  get_workspace_members:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+    outputs:
+      members: ${{ steps.set-members.outputs.members }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - id: set-members
+        run: |
+          # install dasel
+          curl -sSLf "$DASEL_VERSION" -L -o dasel && chmod +x dasel
+          mv ./dasel /usr/local/bin/dasel
+          members=$(cat Cargo.toml | dasel -r toml -w json 'workspace.members' | jq -c)
+          echo "::set-output name=members::$members"
+
+  verify-rust-version:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+    steps:
+      # Ensure CI is using the same minimum toolchain specified in fuels Cargo.toml
+      - run: |
+        curl -sSLf "$DASEL_VERSION" -L -o dasel && chmod +x dasel
+        mv ./dasel /usr/local/bin/dasel
+        MIN_VERSION=$(cat packages/fuels/Cargo.toml | dasel -r toml 'package.rust-version')
+        RUST_VERSION=$(${{ env.RUST_VERSION }})
+        echo "Comparing minimum supported toolchain ($MIN_VERSION) with ci toolchain (RUST_VERSION)"
+        test "$MIN_VERSION" == "$RUST_VERSION"
+
+  cargo-verifications:
+    needs:
+      - setup-test-projects
+      - verify-rust-version
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - command: fmt
+            args: --all --verbose -- --check
+          - command: clippy
+            args: --all-targets --all-features
+          - command: check
+            args: --all-features
+            package: ${{fromJSON(needs.set_workspace_members.outputs.members)}}
+          - command: test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          override: true
+        # selecting a toolchain either by action or manual `rustup` calls should happen
+        # before the cache plugin, as it uses the current rustc version as its cache key
+      - uses: Swatinem/rust-cache@v1
       - name: Build
-        run: cargo make build
-
-      - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --all-features --verbose
+        run: echo "${{ matrix.command }} ${{ matrix.args }} ${{ matrix.package }}"
 
   publish:
+    needs: cargo-verifications
     # Only do this job if publishing a release
-    needs: build
     if: github.event_name == 'release' && github.event.action == 'published'
     runs-on: ubuntu-latest
 
@@ -100,7 +144,8 @@ jobs:
 
       - name: Verify tag version
         run: |
-          cargo install toml-cli
+          curl -sSLf "$DASEL_VERSION" -L -o dasel && chmod +x dasel
+          mv ./dasel /usr/local/bin/dasel
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} packages/fuels-contract/Cargo.toml
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} packages/fuels-core/Cargo.toml
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} packages/fuels-abigen-macro/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,12 +89,12 @@ jobs:
     steps:
       # Ensure CI is using the same minimum toolchain specified in fuels Cargo.toml
       - run: |
-        curl -sSLf "$DASEL_VERSION" -L -o dasel && chmod +x dasel
-        mv ./dasel /usr/local/bin/dasel
-        MIN_VERSION=$(cat packages/fuels/Cargo.toml | dasel -r toml 'package.rust-version')
-        RUST_VERSION=$(${{ env.RUST_VERSION }})
-        echo "Comparing minimum supported toolchain ($MIN_VERSION) with ci toolchain (RUST_VERSION)"
-        test "$MIN_VERSION" == "$RUST_VERSION"
+          curl -sSLf "$DASEL_VERSION" -L -o dasel && chmod +x dasel
+          mv ./dasel /usr/local/bin/dasel
+          MIN_VERSION=$(cat packages/fuels/Cargo.toml | dasel -r toml 'package.rust-version')
+          RUST_VERSION=$(${{ env.RUST_VERSION }})
+          echo "Comparing minimum supported toolchain ($MIN_VERSION) with ci toolchain (RUST_VERSION)"
+          test "$MIN_VERSION" == "$RUST_VERSION"
 
   cargo-verifications:
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,6 @@ jobs:
           tar -xvf forc.tar.gz
           chmod +x forc-binaries/forc
           mv forc-binaries/forc /usr/local/bin/forc
-        with:
-          command: install
-          args: forc --version ${{ env.FORC_VERSION }}
 
       - name: Build Sway Examples
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
         # selecting a toolchain either by action or manual `rustup` calls should happen
         # before the cache plugin, as it uses the current rustc version as its cache key
       - uses: Swatinem/rust-cache@v1
+        continue-on-error: true
         with:
           key: "${{ matrix.command }} ${{ matrix.args }} ${{ matrix.package }}"
 
@@ -142,6 +143,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: sway-examples
+          path: packages/fuels-abigen-macro/tests/test_projects/
 
       - name: Cargo (workspace) ${{ matrix.command }} ${{ matrix.args }}
         if: ${{ !matrix.package }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,14 +106,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        command: [check]
+        args: [--all-features]
+        package: ${{fromJSON(needs.get-workspace-members.outputs.members)}}
         include:
           - command: fmt
             args: --all --verbose -- --check
           - command: clippy
             args: --all-targets --all-features
-          - command: check
-            args: --all-features
-            package: ${{fromJSON(needs.get-workspace-members.outputs.members)}}
           - command: test
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,20 +139,20 @@ jobs:
         run: rustup component add clippy
 
       - name: Download sway example artifacts
-        if: ${{ matrix.command == 'test' }}
+        if: ${{ matrix.command == 'test' || matrix.command == 'clippy' }}
         uses: actions/download-artifact@v3
         with:
           name: sway-examples
           path: packages/fuels-abigen-macro/tests/test_projects/
 
-      - name: Cargo (workspace) ${{ matrix.command }} ${{ matrix.args }}
+      - name: Cargo (workspace-level)
         if: ${{ !matrix.package }}
         uses: actions-rs/cargo@v1
         with:
           command: ${{ matrix.command }}
           args: ${{ matrix.args }}
 
-      - name: Cargo (package) ${{ matrix.command }} ${{ matrix.args }} -p ${{ matrix.package }}
+      - name: Cargo (package-level)
         if: ${{ matrix.package }}
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           curl -sSLf "$DASEL_VERSION" -L -o dasel && chmod +x dasel
           mv ./dasel /usr/local/bin/dasel
           MIN_VERSION=$(cat packages/fuels/Cargo.toml | dasel -r toml 'package.rust-version')
-          RUST_VERSION=$(${{ env.RUST_VERSION }})
+          RUST_VERSION="${{ env.RUST_VERSION }}"
           echo "Comparing minimum supported toolchain ($MIN_VERSION) with ci toolchain (RUST_VERSION)"
           test "$MIN_VERSION" == "$RUST_VERSION"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,20 @@ jobs:
         with:
           key: "${{ matrix.command }} ${{ matrix.args }} ${{ matrix.package }}"
 
+      - name: Install rustfmt
+        if: ${{ matrix.command == 'fmt' }}
+        run: rustup component add rustfmt
+
+      - name: Install clippy
+        if: ${{ matrix.command == 'clippy' }}
+        run: rustup component add clippy
+
+      - name: Download sway example artifacts
+        if: ${{ matrix.command == 'test' }}
+        uses: actions/download-artifact@v3
+        with:
+          name: sway-examples
+
       - name: Cargo (workspace) ${{ matrix.command }} ${{ matrix.args }}
         if: ${{ !matrix.package }}
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           # install dasel
           curl -sSLf "$DASEL_VERSION" -L -o dasel && chmod +x dasel
           mv ./dasel /usr/local/bin/dasel
-          members=$(cat Cargo.toml | dasel -r toml -w json 'workspace.members' | jq -c)
+          members=$(cat Cargo.toml | dasel -r toml -w json 'workspace.members' | jq -r ".[]" | xargs -L 1 basename | jq -R '[.]' | jq -s -c 'add')
           echo "::set-output name=members::$members"
 
   verify-rust-version:
@@ -126,8 +126,22 @@ jobs:
         # selecting a toolchain either by action or manual `rustup` calls should happen
         # before the cache plugin, as it uses the current rustc version as its cache key
       - uses: Swatinem/rust-cache@v1
-      - name: Build
-        run: echo "${{ matrix.command }} ${{ matrix.args }} ${{ matrix.package }}"
+        with:
+          key: "${{ matrix.command }} ${{ matrix.args }} ${{ matrix.package }}"
+
+      - name: Cargo (workspace) ${{ matrix.command }} ${{ matrix.args }}
+        if: ${{ !matrix.package }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: ${{ matrix.command }}
+          args: ${{ matrix.args }}
+
+      - name: Cargo (package) ${{ matrix.command }} ${{ matrix.args }} -p ${{ matrix.package }}
+        if: ${{ matrix.package }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: ${{ matrix.command }}
+          args: ${{ matrix.args }}
 
   publish:
     needs: cargo-verifications

--- a/.github/workflows/scripts/verify_tag.sh
+++ b/.github/workflows/scripts/verify_tag.sh
@@ -25,7 +25,7 @@ fi
 
 # strip preceeding 'v' if it exists on tag
 REF=${REF/#v}
-TOML_VERSION=$(toml get $MANIFEST package.version | tr -d '"')
+TOML_VERSION=$(cat $MANIFEST | dasel -r toml 'package.version')
 
 if [ "$TOML_VERSION" != "$REF" ]; then
     err "Crate version $TOML_VERSION, doesn't match tag version $REF"

--- a/packages/fuels-abigen-macro/tests/harness.rs
+++ b/packages/fuels-abigen-macro/tests/harness.rs
@@ -231,7 +231,7 @@ async fn compile_bindings_byte_input() {
     // `SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
-    let contract_call = contract_instance.takes_byte(10 as u8);
+    let contract_call = contract_instance.takes_byte(10u8);
 
     let encoded = format!(
         "{}{}",
@@ -506,6 +506,7 @@ async fn compile_bindings_enum_input() {
     assert_eq!(encoded, expected);
 }
 
+#[allow(clippy::blacklisted_name)]
 #[tokio::test]
 async fn create_struct_from_decoded_tokens() {
     // Generates the bindings from the an ABI definition inline.

--- a/packages/fuels-core/src/json_abi.rs
+++ b/packages/fuels-core/src/json_abi.rs
@@ -1476,7 +1476,7 @@ mod tests {
             components: Some(vec![inner_foo.clone(), inner_custom.clone()]),
         };
 
-        let params = vec![p.clone()];
+        let params = vec![p];
         let selector = abi.build_fn_selector("my_func", &params).unwrap();
 
         assert_eq!(selector, "my_func(s(bool,e(u64,u32)))");

--- a/packages/fuels-signers/src/wallet.rs
+++ b/packages/fuels-signers/src/wallet.rs
@@ -433,13 +433,8 @@ mod tests {
         let provider = setup().await;
 
         // Create a wallet to be stored in the keystore.
-        let (wallet, uuid) = Wallet::new_from_keystore(
-            &dir,
-            &mut rng,
-            "password".to_string(),
-            Some(provider.clone()),
-        )
-        .unwrap();
+        let (wallet, uuid) =
+            Wallet::new_from_keystore(&dir, &mut rng, "password", Some(provider.clone())).unwrap();
 
         // sign a message using the above key.
         let message = "Hello there!";


### PR DESCRIPTION
We were having build failures during cargo publish dry-run that weren't caught earlier in CI since the build command was unifying features across all crates (including test-helpers). [`cargo make`](https://github.com/sagiegurari/cargo-make) comes with sane default configurations for building the repo in a way that will prevent this from happening in the future.


edit: while cargo make works, we can speed things up a lot by using cargo check on each package in parallel to skip linking. Updated the PR to that approach which cuts the CI pipeline time in half.