### PR TITLE
feat: setup multiple assets

### DIFF
--- a/docs/src/getting-started/basics.md
+++ b/docs/src/getting-started/basics.md
@@ -73,6 +73,30 @@ let config = WalletsConfig::new(
 let wallets = launch_provider_and_get_wallets(WalletsConfig::default()).await;
 ```
 
+## Setting up a test wallet with multiple assets
+
+You can create a test wallet which contains multiple different assets (including the native asset to pay for gas!)
+
+```rust,ignore
+    let mut wallet = LocalWallet::new_random(None);
+    let num_assets = 5; // 7 different assets
+    let coins_per_asset = 10; // For 1 asset id, 10 coins in the wallet
+    let amount_per_coin = 15; // For each coin (UTXO) of the asset, amount of 15
+
+    let (coins, asset_ids) = setup_multiple_assets_coins(
+        wallet.address(),
+        num_assets,
+        coins_per_asset,
+        amount_per_coin,
+    );
+    let (provider, _) = setup_test_provider(coins.clone(), Config::local_node()).await;
+    wallet.set_provider(provider);
+```
+
+- `coins: Vec<(UtxoId,Coin)>` has `num_assets`*`coins_per_assets` coins (UTXOs)
+- `asset_ids: Vec<AssetId>` contains the `num_assets` randomly generated`AssetId` (including the native asset id)
+
+
 ## Calling and configuring contract calls
 
 Once you've deployed your contract, as seen in the previous section, you'll likely want to call contract methods and configure some parameters such as gas price, byte price, gas limit, and forward coins in your contract call.

--- a/packages/fuels-abigen-macro/tests/harness.rs
+++ b/packages/fuels-abigen-macro/tests/harness.rs
@@ -1,9 +1,9 @@
 use fuel_core::service::Config;
 use fuel_gql_client::fuel_tx::{AssetId, ContractId, Receipt};
 use fuels::prelude::{
-    launch_provider_and_get_single_wallet, setup_coins, setup_test_provider, CallParameters,
-    Contract, Error, LocalWallet, Provider, Signer, TxParameters, DEFAULT_COIN_AMOUNT,
-    DEFAULT_NUM_COINS,
+    launch_provider_and_get_single_wallet, setup_single_asset_coins, setup_test_provider,
+    CallParameters, Contract, Error, LocalWallet, Provider, Signer, TxParameters,
+    DEFAULT_COIN_AMOUNT, DEFAULT_NUM_COINS,
 };
 use fuels_abigen_macro::abigen;
 use fuels_core::{constants::NATIVE_ASSET_ID, Token};
@@ -937,7 +937,12 @@ async fn test_provider_launch_and_connect() {
 
     let mut wallet = LocalWallet::new_random(None);
 
-    let coins = setup_coins(wallet.address(), DEFAULT_NUM_COINS, DEFAULT_COIN_AMOUNT);
+    let coins = setup_single_asset_coins(
+        wallet.address(),
+        NATIVE_ASSET_ID,
+        DEFAULT_NUM_COINS,
+        DEFAULT_COIN_AMOUNT,
+    );
     let (launched_provider, address) = setup_test_provider(coins, Config::local_node()).await;
     let connected_provider = Provider::connect(address).await.unwrap();
 
@@ -1421,7 +1426,7 @@ async fn unit_type_enums() {
 // This does not currently test for multiple assets, this is tracked in #321.
 async fn test_wallet_balance_api() {
     let mut wallet = LocalWallet::new_random(None);
-    let coins = setup_coins(wallet.address(), 21, 11);
+    let coins = setup_single_asset_coins(wallet.address(), NATIVE_ASSET_ID, 21, 11);
     let (provider, _) = setup_test_provider(coins.clone(), Config::local_node()).await;
     wallet.set_provider(provider);
     for (_utxo_id, coin) in coins {

--- a/packages/fuels-signers/src/lib.rs
+++ b/packages/fuels-signers/src/lib.rs
@@ -37,11 +37,12 @@ pub trait Signer: std::fmt::Debug + Send + Sync {
 mod tests {
     use fuel_core::service::Config;
     use fuel_crypto::{Message, SecretKey};
+    use fuels_core::constants::NATIVE_ASSET_ID;
     use fuels_core::{
         parameters::TxParameters,
         tx::{AssetId, Bytes32, Input, Output, UtxoId},
     };
-    use fuels_test_helpers::{setup_coins, setup_test_client};
+    use fuels_test_helpers::{setup_single_asset_coins, setup_test_client};
     use rand::{rngs::StdRng, RngCore, SeedableRng};
     use std::str::FromStr;
 
@@ -133,8 +134,8 @@ mod tests {
         let mut wallet_1 = LocalWallet::new_random(None);
         let mut wallet_2 = LocalWallet::new_random(None);
 
-        let mut coins_1 = setup_coins(wallet_1.address, 1, 1000000);
-        let coins_2 = setup_coins(wallet_2.address, 1, 1000000);
+        let mut coins_1 = setup_single_asset_coins(wallet_1.address, NATIVE_ASSET_ID, 1, 1000000);
+        let coins_2 = setup_single_asset_coins(wallet_2.address, NATIVE_ASSET_ID, 1, 1000000);
 
         coins_1.extend(coins_2);
 
@@ -212,8 +213,8 @@ mod tests {
         let mut wallet_1 = LocalWallet::new_random(None);
         let mut wallet_2 = LocalWallet::new_random(None);
 
-        let mut coins_1 = setup_coins(wallet_1.address, 1, 5);
-        let coins_2 = setup_coins(wallet_2.address, 1, 5);
+        let mut coins_1 = setup_single_asset_coins(wallet_1.address, NATIVE_ASSET_ID, 1, 5);
+        let coins_2 = setup_single_asset_coins(wallet_2.address, NATIVE_ASSET_ID, 1, 5);
 
         coins_1.extend(coins_2);
 

--- a/packages/fuels-signers/src/wallet.rs
+++ b/packages/fuels-signers/src/wallet.rs
@@ -243,8 +243,8 @@ impl Wallet {
     ///  let mut wallet_2 = LocalWallet::new_random(None);
     ///
     ///   // Setup a coin for each wallet
-    ///   let mut coins_1 = setup_coins(wallet_1.address(), 1, 1);
-    ///   let coins_2 = setup_coins(wallet_2.address(), 1, 1);
+    ///   let mut coins_1 = setup_single_asset_coins(wallet_1.address(),NATIVE_ASSET_ID, 1, 1);
+    ///   let coins_2 = setup_single_asset_coins(wallet_2.address(),NATIVE_ASSET_ID, 1, 1);
     ///   coins_1.extend(coins_2);
     ///
     ///   // Setup a provider and node with both set of coins

--- a/packages/fuels-test-helpers/Cargo.toml
+++ b/packages/fuels-test-helpers/Cargo.toml
@@ -12,6 +12,7 @@ description = "Fuel Rust SDK test helpers."
 fuel-core = { version = "0.8", default-features = false }
 fuel-gql-client = { version = "0.8", default-features = false }
 fuels-signers = { version = "0.14.1", path = "../fuels-signers", optional = true }
+fuels-core = { version = "0.14.1", path = "../fuels-core" }
 rand = { version = "0.8.4", default-features = false }
 tokio = "1.15"
 

--- a/packages/fuels-test-helpers/src/signers.rs
+++ b/packages/fuels-test-helpers/src/signers.rs
@@ -1,6 +1,6 @@
 use crate::{
-    setup_coins, setup_test_client, wallets_config::WalletsConfig, DEFAULT_COIN_AMOUNT,
-    DEFAULT_NUM_COINS,
+    setup_single_asset_coins, setup_test_client, wallets_config::WalletsConfig,
+    DEFAULT_COIN_AMOUNT, DEFAULT_NUM_COINS,
 };
 use fuel_core::{model::Coin, service::Config};
 use fuel_gql_client::fuel_tx::UtxoId;
@@ -18,8 +18,12 @@ pub async fn launch_provider_and_get_single_wallet() -> LocalWallet {
 pub async fn launch_custom_provider_and_get_single_wallet(node_config: Config) -> LocalWallet {
     let mut wallet = LocalWallet::new_random(None);
 
-    let coins: Vec<(UtxoId, Coin)> =
-        setup_coins(wallet.address(), DEFAULT_NUM_COINS, DEFAULT_COIN_AMOUNT);
+    let coins: Vec<(UtxoId, Coin)> = setup_single_asset_coins(
+        wallet.address(),
+        Default::default(),
+        DEFAULT_NUM_COINS,
+        DEFAULT_COIN_AMOUNT,
+    );
 
     let (provider, _) = setup_test_provider(coins, node_config).await;
 
@@ -35,8 +39,9 @@ pub async fn launch_provider_and_get_wallets(config: WalletsConfig) -> Vec<Local
 
     let mut all_coins: Vec<(UtxoId, Coin)> = Vec::with_capacity(config.num_wallets as usize);
     for wallet in &wallets {
-        let coins: Vec<(UtxoId, Coin)> = setup_coins(
+        let coins: Vec<(UtxoId, Coin)> = setup_single_asset_coins(
             wallet.address(),
+            Default::default(),
             config.coins_per_wallet,
             config.coin_amount,
         );


### PR DESCRIPTION
This PR closes #344 by implementing setting up wallets with multiple assets.
It also closes #321 by testing the balance API on multiple assets.

Some work remains to be done regarding wallets management and node set-up, will be part of https://github.com/FuelLabs/fuels-rs/issues/312.
The book examples  will be moved inside `examples` as part of #342.
