### PR TITLE
Wasm support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,12 @@ jobs:
           chmod +x forc-binaries/forc
           mv forc-binaries/forc /usr/local/bin/forc
 
+      - name: Install WebAssembly Test harness
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: webassembly-test-runner
+
       - name: Build Sway Examples
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Test WASM package
         if: ${{ matrix.command == 'test' }}
         run: |
-          cd packages/wasm-test
+          cd packages/wasm-tests
           cargo test --target wasm32-unknown-unknown --all-targets --all-features
           cargo test --target wasm32-unknown-unknown --all-targets --no-default-features
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,17 @@ jobs:
         with:
           key: "${{ matrix.command }} ${{ matrix.args }} ${{ matrix.package }}"
 
+      - name: Add WASM target
+        if: ${{ matrix.command == 'test' }}
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Test WASM package
+        if: ${{ matrix.command == 'test' }}
+        run: |
+          cd packages/wasm-test
+          cargo test --target wasm32-unknown-unknown --all-targets --all-features
+          cargo test --target wasm32-unknown-unknown --all-targets --no-default-features
+
       - name: Install rustfmt
         if: ${{ matrix.command == 'fmt' }}
         run: rustup component add rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,6 @@ jobs:
           chmod +x forc-binaries/forc
           mv forc-binaries/forc /usr/local/bin/forc
 
-      - name: Install WebAssembly Test harness
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: webassembly-test-runner
-
       - name: Build Sway Examples
         uses: actions-rs/cargo@v1
         with:
@@ -140,6 +134,13 @@ jobs:
       - name: Add WASM target
         if: ${{ matrix.command == 'test' }}
         run: rustup target add wasm32-unknown-unknown
+
+      - name: Install WebAssembly Test harness
+        if: ${{ matrix.command == 'test' }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: webassembly-test-runner
 
       - name: Test WASM package
         if: ${{ matrix.command == 'test' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "packages/fuels-signers",
     "packages/fuels-test-helpers",
     "packages/fuels-types",
+    "packages/wasm-tests",
     "tools/fuels-abi-cli",
     "scripts/build-test-projects",
     "examples/contracts",

--- a/packages/fuels-core/src/code_gen/abigen.rs
+++ b/packages/fuels-core/src/code_gen/abigen.rs
@@ -109,6 +109,7 @@ impl Abigen {
             (
                 quote! {
                     use alloc::{vec, vec::Vec};
+                    use fuels_core::{Detokenize, EnumSelector, InvalidOutputType, ParamType, Tokenizable, Token};
                 },
                 quote! {},
             )
@@ -118,6 +119,7 @@ impl Abigen {
                     use fuels::contract::contract::{Contract, ContractCall};
                     use fuels::signers::LocalWallet;
                     use fuels::tx::{ContractId, Address};
+                    use fuels::core::{Detokenize, EnumSelector, InvalidOutputType, ParamType, Tokenizable, Token};
                     use std::str::FromStr;
                 },
                 quote! {
@@ -148,7 +150,6 @@ impl Abigen {
                 #![allow(unused_imports)]
 
                 #includes
-                use fuels_core::{Detokenize, EnumSelector, InvalidOutputType, ParamType, Tokenizable, Token};
 
                 #code
 

--- a/packages/fuels-core/src/code_gen/abigen.rs
+++ b/packages/fuels-core/src/code_gen/abigen.rs
@@ -149,7 +149,7 @@ impl Abigen {
                 #![allow(unused_imports)]
 
                 #includes
-                use fuels::core::{Detokenize, EnumSelector, ParamType, Tokenizable, Token};
+                use fuels_core::{Detokenize, EnumSelector, InvalidOutputType, ParamType, Tokenizable, Token};
 
                 #code
 

--- a/packages/fuels-core/src/code_gen/abigen.rs
+++ b/packages/fuels-core/src/code_gen/abigen.rs
@@ -116,7 +116,6 @@ impl Abigen {
             (
                 quote! {
                     use fuels::contract::contract::{Contract, ContractCall};
-                    use fuels::prelude::InvalidOutputType;
                     use fuels::signers::LocalWallet;
                     use fuels::tx::{ContractId, Address};
                     use std::str::FromStr;

--- a/packages/wasm-tests/.cargo/config.toml
+++ b/packages/wasm-tests/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-unknown-unknown"

--- a/packages/wasm-tests/.cargo/config.toml
+++ b/packages/wasm-tests/.cargo/config.toml
@@ -1,2 +1,5 @@
 [build]
 target = "wasm32-unknown-unknown"
+
+[target.wasm32-unknown-unknown]
+runner = "webassembly-test-runner"

--- a/packages/wasm-tests/Cargo.toml
+++ b/packages/wasm-tests/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ['cdylib']
 fuels-abigen-macro = { path = "../fuels-abigen-macro" }
 fuels-core = { path = "../fuels-core" }
 getrandom = { version = "0.2", features = ["js"] }
+
+[dev-dependencies]
+webassembly-test = "0.1"

--- a/packages/wasm-tests/Cargo.toml
+++ b/packages/wasm-tests/Cargo.toml
@@ -10,3 +10,4 @@ crate-type = ['cdylib']
 [dependencies]
 fuels-abigen-macro = { path = "../fuels-abigen-macro" }
 fuels-core = { path = "../fuels-core" }
+getrandom = { version = "0.2", features = ["js"] }

--- a/packages/wasm-tests/Cargo.toml
+++ b/packages/wasm-tests/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "wasm-tests"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ['cdylib']
+
+[dependencies]
+fuels-abigen-macro = { path = "../fuels-abigen-macro" }
+fuels-core = { path = "../fuels-core" }

--- a/packages/wasm-tests/Cargo.toml
+++ b/packages/wasm-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tests"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 publish = false
 

--- a/packages/wasm-tests/src/lib.rs
+++ b/packages/wasm-tests/src/lib.rs
@@ -1,0 +1,58 @@
+extern crate alloc;
+use fuels_abigen_macro::wasm_abigen;
+
+wasm_abigen!(
+    no_name,
+    r#"[
+        {
+            "type":"contract",
+            "inputs":[
+                {
+                    "name":"SomeEvent",
+                    "type":"struct SomeEvent",
+                    "components": [
+                        {
+                            "name": "id",
+                            "type": "u64"
+                        },
+                        {
+                            "name": "account",
+                            "type": "b256"
+                        }
+                    ]
+                },
+                {
+                    "name":"AnotherEvent",
+                    "type":"struct AnotherEvent",
+                    "components": [
+                        {
+                            "name": "id",
+                            "type": "u64"
+                        },
+                        {
+                            "name": "hash",
+                            "type": "b256"
+                        },
+                        {
+                            "name": "bar",
+                            "type": "bool"
+                        }
+                    ]
+                }
+            ],
+            "name":"takes_struct",
+            "outputs":[]
+        }
+    ]
+    "#
+);
+
+
+fn main() {
+    let a_struct = SomeEvent {
+        id: 20,
+        account: Default::default(),
+    };
+
+    println!("It works! {}", a_struct.id);
+}

--- a/packages/wasm-tests/src/lib.rs
+++ b/packages/wasm-tests/src/lib.rs
@@ -48,7 +48,7 @@ wasm_abigen!(
 );
 
 
-fn main() {
+pub fn the_fn() {
     let a_struct = SomeEvent {
         id: 20,
         account: Default::default(),

--- a/packages/wasm-tests/src/lib.rs
+++ b/packages/wasm-tests/src/lib.rs
@@ -47,11 +47,34 @@ wasm_abigen!(
     "#
 );
 
-pub fn the_fn() {
-    let a_struct = SomeEvent {
-        id: 20,
-        account: Default::default(),
-    };
 
-    println!("It works! {}", a_struct.id);
+pub fn the_fn() {
+    use fuels_core::{abi_decoder::ABIDecoder, ParamType};
+    let data = vec![
+        0, 0, 0, 0, 0, 0, 3, 252, 175, 175, 175, 175, 175, 175, 175, 175, 175, 175, 175, 175, 175,
+        175, 175, 175, 175, 175, 175, 175, 175, 175, 175, 175, 175, 175, 175, 175, 175, 175, 175,
+        175,
+    ];
+
+    let mut decoder = ABIDecoder::new();
+
+    let obj = decoder
+        .decode(&[ParamType::U64, ParamType::B256], &data)
+        .expect("Failed to decode");
+
+    let a_struct = SomeEvent::new_from_tokens(&obj);
+
+    assert_eq!(1020, a_struct.id);
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use webassembly_test::webassembly_test;
+
+    #[webassembly_test]
+    fn test() {
+        the_fn();
+    }
 }

--- a/packages/wasm-tests/src/lib.rs
+++ b/packages/wasm-tests/src/lib.rs
@@ -47,7 +47,6 @@ wasm_abigen!(
     "#
 );
 
-
 pub fn the_fn() {
     let a_struct = SomeEvent {
         id: 20,

--- a/packages/wasm-tests/src/lib.rs
+++ b/packages/wasm-tests/src/lib.rs
@@ -47,7 +47,6 @@ wasm_abigen!(
     "#
 );
 
-
 pub fn the_fn() {
     use fuels_core::{abi_decoder::ABIDecoder, ParamType};
     let data = vec![
@@ -66,7 +65,6 @@ pub fn the_fn() {
 
     assert_eq!(1020, a_struct.id);
 }
-
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Opening as a draft for now to get some eyes on it. There were some build issues on my machine that looked like they may be config related, so I wanted to see if it passes CI.

It looks like this is about all I need in order to make things work in WASM. As long as the codegen output `use` statements that are from `fuels_core`, I think it will compile fine.

I've added a separate directory for WASM tests, since I have to override the default build target. I added the `.cargo/config.toml` to set it to wasm32-unknown-unkown.

I believe this will address #317 and #318 