### PR TITLE
docs(examples): add instantiate_client example

### DIFF
--- a/docs/src/getting-started/basics.md
+++ b/docs/src/getting-started/basics.md
@@ -14,15 +14,10 @@ For application building, you probably want to go with the second option.
 ## Instantiating a Fuel client
 
 You can instantiate a Fuel client, pointing to a local Fuel node by
-using [Fuel Core](https://github.com/FuelLabs/fuel-core):
+using [`FuelClient`](https://docs.rs/fuels/*/fuels/client/struct.FuelClient.html):
 
 ```rust,ignore
-use fuel_core::service::{Config, FuelService};
-use fuel_gql_client::client::FuelClient;
-
-let server = FuelService::new_node(Config::local_node()).await.unwrap();
-
-let client = FuelClient::from(srv.bound_address);
+{{#include ../../../examples/contracts/src/lib.rs:instantiate_client}}
 ```
 
 Alternatively, if you have a Fuel node running separately, you can pass in the `SocketAddr` to `FuelClient::from()`.

--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -1,4 +1,16 @@
 #[tokio::test]
+// ANCHOR: instantiate_client
+async fn instantiate_client() {
+    use fuels::client::FuelClient;
+    use fuels::node::service::{Config, FuelService};
+
+    let server = FuelService::new_node(Config::local_node()).await.unwrap();
+    let client = FuelClient::from(server.bound_address);
+    assert!(client.health().await.unwrap());
+}
+// ANCHOR_END: instantiate_client
+
+#[tokio::test]
 // ANCHOR: deploy_contract
 async fn deploy_contract() {
     use fuels::prelude::*;

--- a/packages/fuels/Cargo.toml
+++ b/packages/fuels/Cargo.toml
@@ -10,6 +10,8 @@ rust-version = "1.61.0"
 description = "Fuel Rust SDK."
 
 [dependencies]
+fuel-core = { version = "0.8", default-features = false }
+fuel-gql-client = { version = "0.8", default-features = false }
 fuels-abigen-macro = { version = "0.14.1", path = "../fuels-abigen-macro" }
 fuels-contract = { version = "0.14.1", path = "../fuels-contract" }
 fuels-core = { version = "0.14.1", path = "../fuels-core" }

--- a/packages/fuels/src/lib.rs
+++ b/packages/fuels/src/lib.rs
@@ -16,12 +16,21 @@
 //! Examples on how you can use the types imported by the prelude can be found in
 //! the [main test suite](https://github.com/FuelLabs/fuels-rs/blob/master/fuels-abigen-macro/tests/harness.rs)
 
+pub mod client {
+    pub use fuel_gql_client::client::*;
+}
+
 pub mod contract {
     pub use fuels_contract::*;
 }
 
 pub mod core {
     pub use fuels_core::*;
+}
+
+pub mod node {
+    #[doc(no_inline)]
+    pub use fuel_core::*;
 }
 
 pub mod signers {


### PR DESCRIPTION
Related: #342.

- re-export `fuel_core` and `fuel_gql_client` from `fuels`
- create `instantiate_client` test in `examples/contracts` (could be moved later)
- include `instantiate_client` code in `getting-started/basics.md`

> Issue
> - [fuellabs.github.io/fuels-rs](https://fuellabs.github.io/fuels-rs/latest/index.html) is linked as the fuels-rs homepage on Github
> - In the [Getting Started section](https://fuellabs.github.io/fuels-rs/latest/getting-started/setup.html) of the book, only fuel-tx, fuels-abigen-macro, and fuels are referenced as dependencies
> - However, when looking at the [Basic Usage](https://fuellabs.github.io/fuels-rs/latest/getting-started/basics.html) section, the example includes fuel_core
> 
> Expected result
> - A proper fuel-core dependency is specified in the "Getting Started" section