### PR TITLE
feat: add context to InvalidData error

### DIFF
--- a/packages/fuels-contract/src/errors.rs
+++ b/packages/fuels-contract/src/errors.rs
@@ -10,8 +10,8 @@ use std::net;
 pub enum Error {
     #[error("Invalid name: {0}")]
     InvalidName(String),
-    #[error("Invalid data")]
-    InvalidData,
+    #[error("Invalid data: {0}")]
+    InvalidData(String),
     #[error("Missing data: {0}")]
     MissingData(String),
     #[error("Serialization error: {0}")]
@@ -43,7 +43,7 @@ pub enum Error {
 impl From<CodecError> for Error {
     fn from(err: CodecError) -> Error {
         match err {
-            CodecError::InvalidData => Error::InvalidData,
+            CodecError::InvalidData(s) => Error::InvalidData(s),
             CodecError::Utf8Error(e) => Error::Utf8Error(e),
         }
     }

--- a/packages/fuels-core/src/abi_decoder.rs
+++ b/packages/fuels-core/src/abi_decoder.rs
@@ -219,7 +219,9 @@ impl Default for ABIDecoder {
 
 fn peek(data: &[u8], offset: usize, len: usize) -> Result<&[u8], CodecError> {
     if offset + len > data.len() {
-        Err(CodecError::InvalidData)
+        Err(CodecError::InvalidData(
+            "requested data out of bounds".into(),
+        ))
     } else {
         Ok(&data[offset..(offset + len)])
     }

--- a/packages/fuels-core/src/errors.rs
+++ b/packages/fuels-core/src/errors.rs
@@ -10,7 +10,7 @@ use crate::InvalidOutputType;
 
 #[derive(Debug)]
 pub enum CodecError {
-    InvalidData,
+    InvalidData(String),
     Utf8Error(Utf8Error),
 }
 
@@ -30,8 +30,8 @@ impl From<Utf8Error> for CodecError {
 pub enum Error {
     #[error("Invalid name: {0}")]
     InvalidName(String),
-    #[error("Invalid data")]
-    InvalidData,
+    #[error("Invalid data: {0}")]
+    InvalidData(String),
     #[error("Missing data: {0}")]
     MissingData(String),
     #[error("Serialization error: {0}")]
@@ -63,7 +63,7 @@ pub enum Error {
 impl From<CodecError> for Error {
     fn from(err: CodecError) -> Error {
         match err {
-            CodecError::InvalidData => Error::InvalidData,
+            CodecError::InvalidData(s) => Error::InvalidData(s),
             CodecError::Utf8Error(e) => Error::Utf8Error(e),
         }
     }

--- a/packages/fuels-core/src/types.rs
+++ b/packages/fuels-core/src/types.rs
@@ -23,7 +23,7 @@ pub fn expand_type(kind: &ParamType) -> Result<TokenStream, Error> {
         }
         ParamType::Struct(members) => {
             if members.is_empty() {
-                return Err(Error::InvalidData);
+                return Err(Error::InvalidData("struct members can not be empty".into()));
             }
             let members = members
                 .iter()
@@ -33,7 +33,7 @@ pub fn expand_type(kind: &ParamType) -> Result<TokenStream, Error> {
         }
         ParamType::Enum(members) => {
             if members.is_empty() {
-                return Err(Error::InvalidData);
+                return Err(Error::InvalidData("enum members can not be empty".into()));
             }
             let members = members
                 .iter()
@@ -43,7 +43,7 @@ pub fn expand_type(kind: &ParamType) -> Result<TokenStream, Error> {
         }
         ParamType::Tuple(members) => {
             if members.is_empty() {
-                return Err(Error::InvalidData);
+                return Err(Error::InvalidData("tuple members can not be empty".into()));
             }
 
             let members = members


### PR DESCRIPTION
This commit should resolve https://github.com/FuelLabs/fuels-rs/issues/204

The InvalidData error type now provides more context. I have gone through all instances and updated the error messages accordingly.

Additionally, I have found a bug where the functions
 `pub fn tokenize_struct(&self, value: &str, params: &[ParamType]) -> Result<Token, Error> {`
 and 
  `pub fn tokenize_array<'a>(&self, value: &'a str, param: &ParamType) -> Result<Token, Error> {`
would not return an error if there were excess opening brackets. For example: 
`let values: Vec<String> = vec!["((42, true)".to_string()];`
would previously pass through the tokenize_struct function and return an error only at the end assertion in the test.

Now both functions return appropriate error messages.

Could somebody please go through the error messages and confirm that they reflect the errors accordingly ?
Should we have test cases to cover cases where the values string is not ok and we are sure that we return the right errors?
