### PR TITLE
fix(examples): add Config from fuel-core to prelude

### DIFF
--- a/packages/fuels/src/lib.rs
+++ b/packages/fuels/src/lib.rs
@@ -61,6 +61,7 @@ pub mod prelude {
     pub use super::core::parameters::*;
     pub use super::core::{Detokenize, InvalidOutputType};
     pub use super::core::{Token, Tokenizable};
+    pub use super::node::service::Config;
     pub use super::signers::provider::*;
     pub use super::signers::{LocalWallet, Signer};
     pub use super::test_helpers::*;


### PR DESCRIPTION
Should fix some build problems on #355. Investigating why CI was green in the first place.
Re @Salka1988 