### PR TITLE
Ahmedm/multi call refactor

### DIFF
--- a/packages/fuels-abigen-macro/tests/harness.rs
+++ b/packages/fuels-abigen-macro/tests/harness.rs
@@ -47,7 +47,7 @@ async fn compile_bindings_from_contract_file() {
     // Currently this prints `0000000003b568d4000000000000002a000000000000000a`
     // The encoded contract call. Soon it'll be able to perform the
     // actual call.
-    let contract_call = contract_instance.takes_ints_returns_bool(42);
+    let call_handler = contract_instance.takes_ints_returns_bool(42);
 
     // Then you'll be able to use `.call()` to actually call the contract with the
     // specified function:
@@ -56,8 +56,8 @@ async fn compile_bindings_from_contract_file() {
 
     let encoded = format!(
         "{}{}",
-        hex::encode(contract_call.encoded_selector),
-        hex::encode(contract_call.encoded_args)
+        hex::encode(call_handler.contract_call.encoded_selector),
+        hex::encode(call_handler.contract_call.encoded_args)
     );
 
     assert_eq!("000000009593586c000000000000002a", encoded);
@@ -95,12 +95,12 @@ async fn compile_bindings_from_inline_contract() {
     //`SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
-    let contract_call = contract_instance.takes_ints_returns_bool(42_u32);
+    let call_handler = contract_instance.takes_ints_returns_bool(42_u32);
 
     let encoded = format!(
         "{}{}",
-        hex::encode(contract_call.encoded_selector),
-        hex::encode(contract_call.encoded_args)
+        hex::encode(call_handler.contract_call.encoded_selector),
+        hex::encode(call_handler.contract_call.encoded_args)
     );
 
     assert_eq!("000000009593586c000000000000002a", encoded);
@@ -137,12 +137,12 @@ async fn compile_bindings_array_input() {
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
     let input: Vec<u16> = vec![1, 2, 3, 4];
-    let contract_call = contract_instance.takes_array(input);
+    let call_handler = contract_instance.takes_array(input);
 
     let encoded = format!(
         "{}{}",
-        hex::encode(contract_call.encoded_selector),
-        hex::encode(contract_call.encoded_args)
+        hex::encode(call_handler.contract_call.encoded_selector),
+        hex::encode(call_handler.contract_call.encoded_args)
     );
 
     assert_eq!(
@@ -182,12 +182,12 @@ async fn compile_bindings_bool_array_input() {
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
     let input: Vec<bool> = vec![true, false, true];
-    let contract_call = contract_instance.takes_array(input);
+    let call_handler = contract_instance.takes_array(input);
 
     let encoded = format!(
         "{}{}",
-        hex::encode(contract_call.encoded_selector),
-        hex::encode(contract_call.encoded_args)
+        hex::encode(call_handler.contract_call.encoded_selector),
+        hex::encode(call_handler.contract_call.encoded_args)
     );
 
     assert_eq!(
@@ -226,12 +226,12 @@ async fn compile_bindings_byte_input() {
     // `SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
-    let contract_call = contract_instance.takes_byte(10u8);
+    let call_handler = contract_instance.takes_byte(10u8);
 
     let encoded = format!(
         "{}{}",
-        hex::encode(contract_call.encoded_selector),
-        hex::encode(contract_call.encoded_args)
+        hex::encode(call_handler.contract_call.encoded_selector),
+        hex::encode(call_handler.contract_call.encoded_args)
     );
 
     assert_eq!("00000000a4bd3861000000000000000a", encoded);
@@ -267,12 +267,12 @@ async fn compile_bindings_string_input() {
     // `SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
-    let contract_call = contract_instance.takes_string("This is a full sentence".into());
+    let call_handler = contract_instance.takes_string("This is a full sentence".into());
 
     let encoded = format!(
         "{}{}",
-        hex::encode(contract_call.encoded_selector),
-        hex::encode(contract_call.encoded_args)
+        hex::encode(call_handler.contract_call.encoded_selector),
+        hex::encode(call_handler.contract_call.encoded_args)
     );
 
     assert_eq!(
@@ -316,12 +316,12 @@ async fn compile_bindings_b256_input() {
 
     let arg = hasher.finalize();
 
-    let contract_call = contract_instance.takes_b256(arg.into());
+    let call_handler = contract_instance.takes_b256(arg.into());
 
     let encoded = format!(
         "{}{}",
-        hex::encode(contract_call.encoded_selector),
-        hex::encode(contract_call.encoded_args)
+        hex::encode(call_handler.contract_call.encoded_selector),
+        hex::encode(call_handler.contract_call.encoded_args)
     );
 
     assert_eq!(
@@ -374,12 +374,12 @@ async fn compile_bindings_struct_input() {
     // `SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
-    let contract_call = contract_instance.takes_struct(input);
+    let call_handler = contract_instance.takes_struct(input);
 
     let encoded = format!(
         "{}{}",
-        hex::encode(contract_call.encoded_selector),
-        hex::encode(contract_call.encoded_args)
+        hex::encode(call_handler.contract_call.encoded_selector),
+        hex::encode(call_handler.contract_call.encoded_args)
     );
 
     assert_eq!(
@@ -439,12 +439,12 @@ async fn compile_bindings_nested_struct_input() {
     // `SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
-    let contract_call = contract_instance.takes_nested_struct(input);
+    let call_handler = contract_instance.takes_nested_struct(input);
 
     let encoded = format!(
         "{}{}",
-        hex::encode(contract_call.encoded_selector),
-        hex::encode(contract_call.encoded_args)
+        hex::encode(call_handler.contract_call.encoded_selector),
+        hex::encode(call_handler.contract_call.encoded_args)
     );
 
     assert_eq!("0000000088bf8a1b000000000000000a0000000000000001", encoded);
@@ -490,12 +490,12 @@ async fn compile_bindings_enum_input() {
     // `SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
-    let contract_call = contract_instance.takes_enum(variant);
+    let call_handler = contract_instance.takes_enum(variant);
 
     let encoded = format!(
         "{}{}",
-        hex::encode(contract_call.encoded_selector),
-        hex::encode(contract_call.encoded_args)
+        hex::encode(call_handler.contract_call.encoded_selector),
+        hex::encode(call_handler.contract_call.encoded_args)
     );
     let expected = "0000000021b2784f0000000000000000000000000000002a";
     assert_eq!(encoded, expected);
@@ -551,12 +551,12 @@ async fn create_struct_from_decoded_tokens() {
     // `SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
-    let contract_call = contract_instance.takes_struct(struct_from_tokens);
+    let call_handler = contract_instance.takes_struct(struct_from_tokens);
 
     let encoded = format!(
         "{}{}",
-        hex::encode(contract_call.encoded_selector),
-        hex::encode(contract_call.encoded_args)
+        hex::encode(call_handler.contract_call.encoded_selector),
+        hex::encode(call_handler.contract_call.encoded_args)
     );
 
     assert_eq!("00000000cb0b2f05000000000000000a0000000000000001", encoded);
@@ -622,12 +622,12 @@ async fn create_nested_struct_from_decoded_tokens() {
     // `SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
-    let contract_call = contract_instance.takes_nested_struct(nested_struct_from_tokens);
+    let call_handler = contract_instance.takes_nested_struct(nested_struct_from_tokens);
 
     let encoded = format!(
         "{}{}",
-        hex::encode(contract_call.encoded_selector),
-        hex::encode(contract_call.encoded_args)
+        hex::encode(call_handler.contract_call.encoded_selector),
+        hex::encode(call_handler.contract_call.encoded_args)
     );
 
     assert_eq!("0000000088bf8a1b000000000000000a0000000000000001", encoded);
@@ -979,7 +979,7 @@ async fn test_provider_launch_and_connect() {
 }
 
 #[tokio::test]
-async fn test_contract_calling_contract() {
+async fn test_call_handlering_contract() {
     // Tests a contract call that calls another contract (FooCaller calls FooContract underneath)
     abigen!(
         FooContract,

--- a/packages/fuels-contract/src/contract.rs
+++ b/packages/fuels-contract/src/contract.rs
@@ -2,24 +2,17 @@ use crate::{abi_decoder::ABIDecoder, abi_encoder::ABIEncoder, script::Script};
 use anyhow::Result;
 use fuel_gql_client::{
     client::FuelClient,
-    fuel_tx::{Contract as FuelContract, Input, Output, Receipt, StorageSlot, Transaction, UtxoId},
-    fuel_types::{Address, AssetId, Bytes32, ContractId, Salt, Word},
-    fuel_vm::{
-        consts::{REG_CGAS, REG_ONE},
-        prelude::Opcode,
-        script_with_data_offset,
-    },
+    fuel_tx::{Contract as FuelContract, Output, Receipt, StorageSlot, Transaction},
+    fuel_types::{Address, AssetId, ContractId, Salt},
 };
 use fuels_core::{
-    constants::{DEFAULT_SPENDABLE_COIN_AMOUNT, NATIVE_ASSET_ID, WORD_SIZE},
+    constants::{DEFAULT_SPENDABLE_COIN_AMOUNT, NATIVE_ASSET_ID},
     errors::Error,
     parameters::{CallParameters, TxParameters},
     Detokenize, ParamType, ReturnLocation, Selector, Token,
 };
 use fuels_signers::{provider::Provider, LocalWallet, Signer};
 use std::marker::PhantomData;
-
-use tracing::debug;
 
 #[derive(Debug, Clone, Default)]
 pub struct CompiledContract {
@@ -80,234 +73,6 @@ impl Contract {
         )
     }
 
-    /// Given the necessary arguments, create a script that will be submitted to the node to call
-    /// the contract. The script is the actual opcodes used to call the contract, and the script
-    /// data is for instance the function selector. (script, script_data) is returned as a tuple
-    /// of hex-encoded value vectors
-    pub fn build_script(
-        contract_id: &ContractId,
-        encoded_selector: &Option<Selector>,
-        encoded_args: &Option<Vec<u8>>,
-        call_parameters: &CallParameters,
-        compute_calldata_offset: bool,
-    ) -> Result<(Vec<u8>, Vec<u8>), Error> {
-        use fuel_gql_client::fuel_types;
-        // Script to call the contract.
-        // We use the Opcode to call a contract: `CALL` pointing at the
-        // following registers;
-        //
-        // 0x10 Script data offset
-        // 0x11 Gas price  TODO: https://github.com/FuelLabs/fuels-rs/issues/184
-        // 0x12 Coin amount
-        // 0x13 Asset ID
-        //
-        // Note that these are soft rules as we're picking this addresses simply because they
-        // non-reserved register.
-        let forward_data_offset = ContractId::LEN + WORD_SIZE;
-        let (script, offset) = script_with_data_offset!(
-            data_offset,
-            vec![
-                // Load call data to 0x10.
-                Opcode::MOVI(0x10, data_offset + forward_data_offset as Immediate18),
-                // Load gas forward to 0x11.
-                // Load word into 0x12
-                Opcode::MOVI(
-                    0x12,
-                    ((data_offset as usize) + ContractId::LEN) as Immediate18
-                ),
-                // Load the amount into 0x12
-                Opcode::LW(0x12, 0x12, 0),
-                // Load the asset id to use to 0x13.
-                Opcode::MOVI(0x13, data_offset),
-                // Call the transfer contract.
-                Opcode::CALL(0x10, 0x12, 0x13, REG_CGAS),
-                Opcode::RET(REG_ONE),
-            ]
-        );
-
-        #[allow(clippy::iter_cloned_collect)]
-        let script = script.iter().copied().collect::<Vec<u8>>();
-
-        // `script_data` consists of:
-        // 1. Asset ID to be forwarded
-        // 2. Amount to be forwarded
-        // 3. Contract ID (ContractID::LEN);
-        // 4. Function selector (1 * WORD_SIZE);
-        // 5. Calldata offset, if it has structs as input,
-        // computed as `script_data_offset` + ContractId::LEN
-        //                                  + 2 * WORD_SIZE;
-        // 6. Encoded arguments.
-        let mut script_data: Vec<u8> = vec![];
-
-        // Insert asset_id to be forwarded
-        script_data.extend(call_parameters.asset_id.to_vec());
-
-        // Insert amount to be forwarded
-        let amount = call_parameters.amount as Word;
-        script_data.extend(amount.to_be_bytes());
-
-        // Insert contract_id
-        script_data.extend(contract_id.as_ref());
-
-        // Insert encoded function selector, if any
-        if let Some(e) = encoded_selector {
-            script_data.extend(e)
-        }
-
-        // If the method call takes custom inputs or has more than
-        // one argument, we need to calculate the `call_data_offset`,
-        // which points to where the data for the custom types start in the
-        // transaction. If it doesn't take any custom inputs, this isn't necessary.
-        if compute_calldata_offset {
-            // Offset of the script data relative to the call data
-            let call_data_offset =
-                ((offset as usize) + forward_data_offset) + ContractId::LEN + 2 * WORD_SIZE;
-            let call_data_offset = call_data_offset as Word;
-
-            script_data.extend(&call_data_offset.to_be_bytes());
-        }
-
-        // Insert encoded arguments, if any
-        if let Some(e) = encoded_args {
-            script_data.extend(e)
-        }
-        Ok((script, script_data))
-    }
-
-    /// Calls a contract method with the given ABI function.
-    /// The wallet is here to pay for the transaction fees (even though they are 0 right now)
-    #[tracing::instrument]
-    #[allow(clippy::too_many_arguments)] // We need that many arguments for now
-    async fn call(
-        contract_id: ContractId,
-        encoded_selector: Option<Selector>,
-        encoded_args: Option<Vec<u8>>,
-        fuel_client: &FuelClient,
-        tx_parameters: TxParameters,
-        call_parameters: CallParameters,
-        variable_outputs: Option<Vec<Output>>,
-        maturity: Word,
-        compute_calldata_offset: bool,
-        external_contracts: Option<Vec<ContractId>>,
-        wallet: LocalWallet,
-        simulate: bool,
-    ) -> Result<Vec<Receipt>, Error> {
-        let (script, script_data) = Self::build_script(
-            &contract_id,
-            &encoded_selector,
-            &encoded_args,
-            &call_parameters,
-            compute_calldata_offset,
-        )?;
-        let mut inputs: Vec<Input> = vec![];
-        let mut outputs: Vec<Output> = vec![];
-
-        let self_contract_input = Input::contract(
-            UtxoId::new(Bytes32::zeroed(), 0),
-            Bytes32::zeroed(),
-            Bytes32::zeroed(),
-            contract_id,
-        );
-        inputs.push(self_contract_input);
-
-        let mut spendables = wallet
-            .get_spendable_coins(&AssetId::default(), DEFAULT_SPENDABLE_COIN_AMOUNT as u64)
-            .await
-            .unwrap();
-
-        // add default asset change if any inputs are being spent
-        if !spendables.is_empty() {
-            let change_output = Output::change(wallet.address(), 0, AssetId::default());
-            outputs.push(change_output);
-        }
-
-        if call_parameters.asset_id != AssetId::default() {
-            let alt_spendables = wallet
-                .get_spendable_coins(&call_parameters.asset_id, call_parameters.amount)
-                .await
-                .unwrap();
-
-            // add alt change if inputs are being spent
-            if !alt_spendables.is_empty() {
-                let change_output = Output::change(wallet.address(), 0, call_parameters.asset_id);
-                outputs.push(change_output);
-            }
-
-            // add alt coins to inputs
-            spendables.extend(alt_spendables.into_iter());
-        }
-
-        for coin in spendables {
-            let input_coin = Input::coin_signed(
-                UtxoId::from(coin.utxo_id),
-                coin.owner.into(),
-                coin.amount.0,
-                coin.asset_id.into(),
-                0,
-                0,
-            );
-
-            inputs.push(input_coin);
-        }
-
-        let n_inputs = inputs.len();
-
-        let self_contract_output = Output::contract(0, Bytes32::zeroed(), Bytes32::zeroed());
-        outputs.push(self_contract_output);
-
-        // Add external contract IDs to Input/Output pair, if applicable.
-        if let Some(external_contract_ids) = external_contracts {
-            for (idx, external_contract_id) in external_contract_ids.iter().enumerate() {
-                // We must associate the right external contract input to the corresponding external
-                // output index (TXO). We add the `n_inputs` offset because we added some inputs
-                // above.
-                let output_index: u8 = (idx + n_inputs) as u8;
-                let zeroes = Bytes32::zeroed();
-                let external_contract_input = Input::contract(
-                    UtxoId::new(Bytes32::zeroed(), output_index),
-                    zeroes,
-                    zeroes,
-                    *external_contract_id,
-                );
-
-                inputs.push(external_contract_input);
-
-                let external_contract_output = Output::contract(output_index, zeroes, zeroes);
-
-                outputs.push(external_contract_output);
-            }
-        }
-
-        // Add outputs to the transaction.
-        if let Some(v) = variable_outputs {
-            outputs.extend(v);
-        };
-
-        let mut tx = Transaction::script(
-            tx_parameters.gas_price,
-            tx_parameters.gas_limit,
-            tx_parameters.byte_price,
-            maturity,
-            script,
-            script_data,
-            inputs,
-            outputs,
-            vec![],
-        );
-        wallet.sign_transaction(&mut tx).await?;
-
-        let script = Script::new(tx);
-
-        if simulate {
-            let receipts = script.simulate(fuel_client).await;
-            debug!(target: "receipts", "{:?}", receipts);
-            return receipts;
-        }
-        let receipts = script.call(fuel_client).await;
-        debug!(target: "receipts", "{:?}", receipts);
-        receipts
-    }
-
     /// Creates an ABI call based on a function selector and
     /// the encoding of its call arguments, which is a slice of Tokens.
     /// It returns a prepared ContractCall that can further be used to
@@ -322,14 +87,14 @@ impl Contract {
     /// }
     /// For more details see `code_gen/functions_gen.rs`.
     /// Note that this needs a wallet because the contract instance needs a wallet for the calls
-    pub fn method_hash<D: Detokenize>(
+    pub fn method_hash<D: Detokenize + std::fmt::Debug>(
         provider: &Provider,
         contract_id: ContractId,
         wallet: &LocalWallet,
         signature: Selector,
         output_params: &[ParamType],
         args: &[Token],
-    ) -> Result<ContractCall<D>, Error> {
+    ) -> Result<ContractCallHandler<D>, Error> {
         let mut encoder = ABIEncoder::new();
 
         let encoded_args = encoder.encode(args).unwrap();
@@ -341,20 +106,26 @@ impl Contract {
         let compute_calldata_offset = Contract::should_compute_call_data_offset(args);
 
         let maturity = 0;
-        Ok(ContractCall {
-            contract_id,
+
+        let contract_call = ContractCall {
+            encoded_selector,
             encoded_args,
-            tx_parameters,
             call_parameters,
             maturity,
-            encoded_selector,
-            fuel_client: provider.client.clone(),
-            datatype: PhantomData,
-            output_params: output_params.to_vec(),
-            variable_outputs: None,
             compute_calldata_offset,
-            external_contracts: None,
+            variable_outputs: None,
+            output_params: output_params.to_vec(),
+            external_contracts: None
+        };
+
+        Ok(ContractCallHandler {
+            output_params: output_params.to_vec(),
+            contract_call,
+            tx_parameters,
+            contract_id,
+            fuel_client: provider.client.clone(),
             wallet: wallet.clone(),
+            datatype: PhantomData,
         })
     }
 
@@ -487,27 +258,33 @@ impl Contract {
 }
 
 #[derive(Debug)]
-#[must_use = "contract calls do nothing unless you `call` them"]
-/// Helper for managing a transaction before submitting it to a node
-pub struct ContractCall<D> {
-    pub fuel_client: FuelClient,
+pub struct ContractCall {
     pub encoded_args: Vec<u8>,
     pub encoded_selector: Selector,
-    pub contract_id: ContractId,
-    pub tx_parameters: TxParameters,
     pub call_parameters: CallParameters,
     pub maturity: u64,
-    pub datatype: PhantomData<D>,
-    pub output_params: Vec<ParamType>,
     pub compute_calldata_offset: bool,
-    pub wallet: LocalWallet,
     pub variable_outputs: Option<Vec<Output>>,
-    external_contracts: Option<Vec<ContractId>>,
+    pub output_params: Vec<ParamType>,
+    pub external_contracts: Option<Vec<ContractId>>,
 }
 
-impl<D> ContractCall<D>
+#[derive(Debug)]
+#[must_use = "contract calls do nothing unless you `call` them"]
+/// Helper for managing a transaction before submitting it to a node
+pub struct ContractCallHandler<D> {
+    pub contract_call: ContractCall,
+    pub fuel_client: FuelClient,
+    pub contract_id: ContractId,
+    pub tx_parameters: TxParameters,
+    pub datatype: PhantomData<D>,
+    pub wallet: LocalWallet,
+    pub output_params: Vec<ParamType>,
+}
+
+impl<D> ContractCallHandler<D>
 where
-    D: Detokenize,
+    D: Detokenize + std::fmt::Debug,
 {
     /// Sets external contracts as dependencies to this contract's call.
     /// Effectively, this will be used to create Input::Contract/Output::Contract
@@ -515,7 +292,7 @@ where
     /// Note that this is a builder method, i.e. use it as a chain:
     /// `my_contract_instance.my_method(...).set_contracts(&[another_contract_id]).call()`.
     pub fn set_contracts(mut self, contract_ids: &[ContractId]) -> Self {
-        self.external_contracts = Some(contract_ids.to_vec());
+        self.contract_call.external_contracts = Some(contract_ids.to_vec());
         self
     }
 
@@ -533,7 +310,7 @@ where
     /// let params = CallParameters { amount: 1, asset_id: NATIVE_ASSET_ID };
     /// `my_contract_instance.my_method(...).call_params(params).call()`.
     pub fn call_params(mut self, params: CallParameters) -> Self {
-        self.call_parameters = params;
+        self.contract_call.call_parameters = params;
         self
     }
 
@@ -549,9 +326,9 @@ where
             })
             .collect();
 
-        match self.variable_outputs {
+        match self.contract_call.variable_outputs {
             Some(ref mut outputs) => outputs.extend(new_outputs),
-            None => self.variable_outputs = Some(new_outputs),
+            None => self.contract_call.variable_outputs = Some(new_outputs),
         }
 
         self
@@ -563,29 +340,30 @@ where
     /// your method returns `bool`, it will be a bool, works also for structs thanks to the
     /// `abigen!()`). The other field of CallResponse, `receipts`, contains the receipts of the
     /// transaction.
+    #[tracing::instrument]
     async fn call_or_simulate(self, simulate: bool) -> Result<CallResponse<D>, Error> {
-        let receipts = Contract::call(
+        let script = Script::from_call(
+            self.contract_call,
             self.contract_id,
-            Some(self.encoded_selector),
-            Some(self.encoded_args),
-            &self.fuel_client,
             self.tx_parameters,
-            self.call_parameters,
-            self.variable_outputs,
-            self.maturity,
-            self.compute_calldata_offset,
-            self.external_contracts,
             self.wallet,
-            simulate,
         )
-        .await?;
+        .await;
+
+        let receipts = if simulate {
+            script.simulate(&self.fuel_client).await?
+        } else {
+            script.call(&self.fuel_client).await?
+        };
+        tracing::debug!(target: "receipts", "{:?}", receipts);
 
         // If it's an ABI method without a return value, exit early.
         if self.output_params.is_empty() {
             return Ok(CallResponse::new(D::from_tokens(vec![])?, receipts));
         }
 
-        let (decoded_value, receipts) = Self::get_decoded_output(receipts, &self.output_params)?;
+        let (decoded_value, receipts) =
+            Self::get_decoded_output(receipts, &self.output_params)?;
         Ok(CallResponse::new(D::from_tokens(decoded_value)?, receipts))
     }
 
@@ -645,3 +423,51 @@ where
         Ok((decoded_value, receipts))
     }
 }
+
+/*
+#[derive(Debug)]
+#[must_use = "contract calls do nothing unless you `call` them"]
+/// Helper for managing a transaction before submitting it to a node
+pub struct ContractMultiCallHandler<D> {
+    pub contract_calls: Vec<ContractCall>,
+    pub fuel_client: FuelClient,
+    pub contract_id: ContractId,
+    pub tx_parameters: TxParameters,
+    pub datatype: PhantomData<D>,
+    pub wallet: LocalWallet,
+    pub output_params: Vec<ParamType>,
+}
+
+impl<D> ContractMultiCallHandler<D>
+    where
+        D: Detokenize + std::fmt::Debug,
+{
+
+    #[tracing::instrument]
+    async fn call_or_simulate(self, simulate: bool) -> Result<CallResponse<D>, Error> {
+        let script = Script::from_call(
+            self.contract_calls,
+            self.contract_id,
+            self.tx_parameters,
+            self.wallet,
+        )
+        .await;
+
+        let receipts = if simulate {
+            script.simulate(&self.fuel_client).await?
+        } else {
+            script.call(&self.fuel_client).await?
+        };
+        tracing::debug!(target: "receipts", "{:?}", receipts);
+
+        // If it's an ABI method without a return value, exit early.
+        if self.output_params.is_empty() {
+            return Ok(CallResponse::new(D::from_tokens(vec![])?, receipts));
+        }
+
+        let (decoded_value, receipts) = Self::get_decoded_output(receipts, &self.output_params)?;
+        Ok(CallResponse::new(D::from_tokens(decoded_value)?, receipts))
+    }
+}
+
+ */

--- a/packages/fuels-contract/src/script.rs
+++ b/packages/fuels-contract/src/script.rs
@@ -1,9 +1,22 @@
 use anyhow::Result;
+use fuel_gql_client::fuel_tx::{Input, Output, UtxoId};
+use fuel_gql_client::fuel_types::{AssetId, Bytes32, ContractId, Word};
+use fuel_gql_client::fuel_vm::{
+    consts::{REG_CGAS, REG_ONE},
+    prelude::Opcode,
+    script_with_data_offset,
+};
 use fuel_gql_client::{
     client::{types::TransactionStatus, FuelClient},
     fuel_tx::{Receipt, Transaction},
 };
+use fuels_core::constants::{DEFAULT_SPENDABLE_COIN_AMOUNT, WORD_SIZE};
 use fuels_core::errors::Error;
+use fuels_core::parameters::{CallParameters, TxParameters};
+use fuels_core::Selector;
+
+use fuels_signers::{LocalWallet, Signer};
+use crate::contract::ContractCall;
 
 /// Script is a very thin layer on top of fuel-client with some
 /// extra functionalities needed and provided by the SDK.
@@ -20,6 +33,214 @@ pub struct CompiledScript {
 impl Script {
     pub fn new(tx: Transaction) -> Self {
         Self { tx }
+    }
+
+    pub async fn from_call(
+        call: ContractCall,
+        contract_id: ContractId,
+        tx_parameters: TxParameters,
+        wallet: LocalWallet,
+    ) -> Self {
+        let (script, script_data) = Self::build_script_contents(
+            &contract_id,
+            &Some(call.encoded_selector),
+            &Some(call.encoded_args),
+            &call.call_parameters,
+            call.compute_calldata_offset,
+            tx_parameters.gas_limit
+        )
+        .unwrap();
+
+        let mut inputs: Vec<Input> = vec![];
+        let mut outputs: Vec<Output> = vec![];
+
+        let self_contract_input = Input::contract(
+            UtxoId::new(Bytes32::zeroed(), 0),
+            Bytes32::zeroed(),
+            Bytes32::zeroed(),
+            contract_id,
+        );
+        inputs.push(self_contract_input);
+
+        let mut spendables = wallet
+            .get_spendable_coins(&AssetId::default(), DEFAULT_SPENDABLE_COIN_AMOUNT as u64)
+            .await
+            .unwrap();
+
+        // add default asset change if any inputs are being spent
+        if !spendables.is_empty() {
+            let change_output = Output::change(wallet.address(), 0, AssetId::default());
+            outputs.push(change_output);
+        }
+
+        if call.call_parameters.asset_id != AssetId::default() {
+            let alt_spendables = wallet
+                .get_spendable_coins(&call.call_parameters.asset_id, call.call_parameters.amount)
+                .await
+                .unwrap();
+
+            // add alt change if inputs are being spent
+            if !alt_spendables.is_empty() {
+                let change_output = Output::change(wallet.address(), 0, call.call_parameters.asset_id);
+                outputs.push(change_output);
+            }
+
+            // add alt coins to inputs
+            spendables.extend(alt_spendables.into_iter());
+        }
+
+        for coin in spendables {
+            let input_coin = Input::coin_signed(
+                UtxoId::from(coin.utxo_id),
+                coin.owner.into(),
+                coin.amount.0,
+                coin.asset_id.into(),
+                0,
+                0,
+            );
+
+            inputs.push(input_coin);
+        }
+
+        let n_inputs = inputs.len();
+
+        let self_contract_output = Output::contract(0, Bytes32::zeroed(), Bytes32::zeroed());
+        outputs.push(self_contract_output);
+
+        // Add external contract IDs to Input/Output pair, if applicable.
+        if let Some(external_contract_ids) = call.external_contracts {
+            for (idx, external_contract_id) in external_contract_ids.iter().enumerate() {
+                // We must associate the right external contract input to the corresponding external
+                // output index (TXO). We add the `n_inputs` offset because we added some inputs
+                // above.
+                let output_index: u8 = (idx + n_inputs) as u8;
+                let zeroes = Bytes32::zeroed();
+                let external_contract_input = Input::contract(
+                    UtxoId::new(Bytes32::zeroed(), output_index),
+                    zeroes,
+                    zeroes,
+                    *external_contract_id,
+                );
+
+                inputs.push(external_contract_input);
+
+                let external_contract_output = Output::contract(output_index, zeroes, zeroes);
+
+                outputs.push(external_contract_output);
+            }
+        }
+
+        // Add outputs to the transaction.
+        if let Some(v) = call.variable_outputs {
+            outputs.extend(v);
+        };
+
+        let mut tx = Transaction::script(
+            tx_parameters.gas_price,
+            tx_parameters.gas_limit,
+            tx_parameters.byte_price,
+            call.maturity,
+            script,
+            script_data,
+            inputs,
+            outputs,
+            vec![],
+        );
+        wallet.sign_transaction(&mut tx).await.unwrap();
+
+        Script::new(tx)
+    }
+
+    /// Given the necessary arguments, create a script that will be submitted to the node to call
+    /// the contract. The script is the actual opcodes used to call the contract, and the script
+    /// data is for instance the function selector. (script, script_data) is returned as a tuple
+    /// of hex-encoded value vectors
+    fn build_script_contents(
+        contract_id: &ContractId,
+        encoded_selector: &Option<Selector>,
+        encoded_args: &Option<Vec<u8>>,
+        call_parameters: &CallParameters,
+        compute_calldata_offset: bool,
+        gas_limit: u64
+    ) -> Result<(Vec<u8>, Vec<u8>), Error> {
+        use fuel_gql_client::fuel_types;
+        // Script to call the contract.
+        // We use the Opcode to call a contract: `CALL` pointing at the
+        // following registers;
+        //
+        // 0x10 Script data offset
+        // 0x11 Gas price  TODO: https://github.com/FuelLabs/fuels-rs/issues/184
+        // 0x12 Coin amount
+        // 0x13 Asset ID
+        //
+        // Note that these are soft rules as we're picking this addresses simply because they
+        // non-reserved register.
+        let forward_data_offset = AssetId::LEN + WORD_SIZE;
+        let (script, offset) = script_with_data_offset!(
+            data_offset,
+            vec![
+                // Load call data to 0x10.
+                Opcode::MOVI(0x10, data_offset + forward_data_offset as Immediate18),
+                // Load gas forward to 0x11.
+                Opcode::MOVI(0x11, gas_limit as Immediate18),
+                // Load word into 0x12
+                Opcode::MOVI(
+                    0x12,
+                    ((data_offset as usize) + AssetId::LEN) as Immediate18
+                ),
+                // Load the amount into 0x12
+                Opcode::LW(0x12, 0x12, 0),
+                // Load the asset id to use to 0x13.
+                Opcode::MOVI(0x13, data_offset),
+                // Call the transfer contract.
+                Opcode::CALL(0x10, 0x12, 0x13, REG_CGAS),
+                Opcode::RET(REG_ONE),
+            ]
+        );
+
+        #[allow(clippy::iter_cloned_collect)]
+        let script = script.iter().copied().collect::<Vec<u8>>();
+
+        // `script_data` consists of:
+        // 1. Asset ID to be forwarded
+        // 2. Amount to be forwarded
+        // 3. Contract ID (ContractID::LEN);
+        // 4. Function selector (1 * WORD_SIZE);
+        // 5. Calldata offset, if it has structs as input,
+        // computed as `script_data_offset` + ContractId::LEN
+        //                                  + 2 * WORD_SIZE;
+        // 6. Encoded arguments.
+        let mut script_data: Vec<u8> = vec![];
+
+        script_data.extend(call_parameters.asset_id.to_vec());
+
+        let amount = call_parameters.amount as Word;
+        script_data.extend(amount.to_be_bytes());
+
+        script_data.extend(contract_id.as_ref());
+
+        if let Some(e) = encoded_selector {
+            script_data.extend(e)
+        }
+
+        // If the method call takes custom inputs or has more than
+        // one argument, we need to calculate the `call_data_offset`,
+        // which points to where the data for the custom types start in the
+        // transaction. If it doesn't take any custom inputs, this isn't necessary.
+        if compute_calldata_offset {
+            // Offset of the script data relative to the call data
+            let call_data_offset =
+                ((offset as usize) + forward_data_offset) + ContractId::LEN + 2 * WORD_SIZE;
+            let call_data_offset = call_data_offset as Word;
+
+            script_data.extend(&call_data_offset.to_be_bytes());
+        }
+
+        // Insert encoded arguments, if any
+        if let Some(e) = encoded_args {
+            script_data.extend(e)
+        }
+        Ok((script, script_data))
     }
 
     // Calling the contract executes the transaction, and is thus state-modifying

--- a/packages/fuels-core/src/code_gen/abigen.rs
+++ b/packages/fuels-core/src/code_gen/abigen.rs
@@ -115,7 +115,7 @@ impl Abigen {
         } else {
             (
                 quote! {
-                    use fuels::contract::contract::{Contract, ContractCall};
+                    use fuels::contract::contract::{Contract, ContractCall, ContractCallHandler};
                     use fuels::prelude::InvalidOutputType;
                     use fuels::signers::LocalWallet;
                     use fuels::tx::{ContractId, Address};

--- a/packages/fuels-core/src/code_gen/functions_gen.rs
+++ b/packages/fuels-core/src/code_gen/functions_gen.rs
@@ -35,7 +35,7 @@ pub fn expand_function(
 
     let tokenized_signature = expand_selector(encoded);
     let tokenized_output = expand_fn_outputs(&function.outputs)?;
-    let result = quote! { ContractCall<#tokenized_output> };
+    let result = quote! { ContractCallHandler<#tokenized_output> };
 
     let (input, arg) = expand_function_arguments(function, custom_enums, custom_structs)?;
 
@@ -250,7 +250,7 @@ mod tests {
         let expected = TokenStream::from_str(
             r#"
 #[doc = "Calls the contract's `HelloWorld` (0x0000000097d4de45) function"]
-pub fn HelloWorld(&self, bimbam: bool) -> ContractCall<()> {
+pub fn HelloWorld(&self, bimbam: bool) -> ContractCallHandler<()> {
     Contract::method_hash(
         &self.wallet.get_provider().unwrap(),
         self.contract_id,
@@ -358,7 +358,7 @@ pub fn HelloWorld(&self, bimbam: bool) -> ContractCall<()> {
 pub fn hello_world(
     &self,
     the_only_allowed_input: SomeWeirdFrenchCuisine
-) -> ContractCall<(CoolIndieGame , EntropyCirclesEnum)> {
+) -> ContractCallHandler<(CoolIndieGame , EntropyCirclesEnum)> {
     Contract::method_hash(
         &self.wallet.get_provider().unwrap(),
         self.contract_id,


### PR DESCRIPTION
Closes #200

This PR is prep work for the multi call feature tracked in #211. 
It refactors the build process of the script that the SDK creates to execute contract calls. This is done by:
1. Renaming `ContractCall` to `ContractCallHandler` and creating a new `ContractCall` struct which holds all the data relevant to a contract call while `ContractCallHandler` is a wrapper to operate with it.
2. Moving script creation methods to `script.rs`
3. Splitting up script creation methods to separate concerns

The above changes satisfy the requirements of #200. An example workflow is provided in `harness.rs`.