### PR TITLE
Fix examples cargo TOML

### DIFF
--- a/examples/contracts/Cargo.toml
+++ b/examples/contracts/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "fuels-example-contracts"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
+publish = false
+authors = ["Fuel Labs <contact@fuel.sh>"]
+homepage = "https://fuel.network/"
+license = "Apache-2.0"
+repository = "https://github.com/FuelLabs/fuels-rs"
+description = "Fuel Rust SDK contract examples."
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/wallets/Cargo.toml
+++ b/examples/wallets/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "fuels-example-wallets"
 publish = false
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuels-rs"
+description = "Fuel Rust SDK wallet examples."
 
 [dependencies]
 fuels = { version = "0.15.0", path = "../../packages/fuels" }


### PR DESCRIPTION
Context: https://github.com/FuelLabs/fuels-rs/runs/6780831010?check_suite_focus=true

The CI is trying to publish one of the examples -- it shouldn't. Plus some extra metadata.