### PR TITLE
feat: extend abi json cli tests to cover expected errors

### DIFF
--- a/packages/fuels-core/src/json_abi.rs
+++ b/packages/fuels-core/src/json_abi.rs
@@ -1861,7 +1861,7 @@ mod tests {
     }
 
     #[test]
-    fn tokenize_errors_built_in_types() {
+    fn tokenize_uint_types_expected_error() {
         let abi = ABIParser::new();
 
         // We test only on U8 as it is the same error on all other unsigned int types
@@ -1874,6 +1874,11 @@ mod tests {
             "Parse integer error: invalid digit found in string",
             error_message
         );
+    }
+
+    #[test]
+    fn tokenize_bool_expected_error() {
+        let abi = ABIParser::new();
 
         let error_message = abi
             .tokenize(&ParamType::Bool, "True".to_string())
@@ -1884,6 +1889,11 @@ mod tests {
             "Parse boolean error: provided string was not `true` or `false`",
             error_message
         );
+    }
+
+    #[test]
+    fn tokenize_b256_invalid_length_expected_error() {
+        let abi = ABIParser::new();
 
         let value = "d57a9c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e90b".to_string();
         let error_message = abi
@@ -1895,6 +1905,11 @@ mod tests {
             "Invalid data: the hex encoding of the b256 must have 64 characters",
             error_message
         );
+    }
+
+    #[test]
+    fn tokenize_b256_invalid_character_expected_error() {
+        let abi = ABIParser::new();
 
         let value = "Hd57a9c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e90b".to_string();
         let error_message = abi
@@ -1906,7 +1921,8 @@ mod tests {
     }
 
     #[test]
-    fn tokenize_errors_tuple() {
+    fn tokenize_tuple_invalid_start_end_bracket_expected_error() {
+        let abi = ABIParser::new();
         let params = Property {
             name: "input".to_string(),
             type_field: "(u64, [u64; 3])".to_string(),
@@ -1924,8 +1940,6 @@ mod tests {
             ]),
         };
 
-        let abi = ABIParser::new();
-
         if let ParamType::Tuple(tuple_params) = parse_tuple_param(&params).unwrap() {
             let error_message = abi
                 .tokenize_tuple("0, [0,0,0])", &tuple_params)
@@ -1936,7 +1950,30 @@ mod tests {
                 "Invalid data: tuple value string must start and end with round brackets",
                 error_message
             );
+        }
+    }
 
+    #[test]
+    fn tokenize_tuple_excess_opening_bracket_expected_error() {
+        let abi = ABIParser::new();
+        let params = Property {
+            name: "input".to_string(),
+            type_field: "(u64, [u64; 3])".to_string(),
+            components: Some(vec![
+                Property {
+                    name: "__tuple_element".to_string(),
+                    type_field: "u64".to_string(),
+                    components: None,
+                },
+                Property {
+                    name: "__tuple_element".to_string(),
+                    type_field: "[u64; 3]".to_string(),
+                    components: None,
+                },
+            ]),
+        };
+
+        if let ParamType::Tuple(tuple_params) = parse_tuple_param(&params).unwrap() {
             let error_message = abi
                 .tokenize_tuple("((0, [0,0,0])", &tuple_params)
                 .unwrap_err()
@@ -1946,7 +1983,30 @@ mod tests {
                 "Invalid data: tuple value string has excess opening brackets",
                 error_message
             );
+        }
+    }
 
+    #[test]
+    fn tokenize_tuple_excess_closing_bracket_expected_error() {
+        let abi = ABIParser::new();
+        let params = Property {
+            name: "input".to_string(),
+            type_field: "(u64, [u64; 3])".to_string(),
+            components: Some(vec![
+                Property {
+                    name: "__tuple_element".to_string(),
+                    type_field: "u64".to_string(),
+                    components: None,
+                },
+                Property {
+                    name: "__tuple_element".to_string(),
+                    type_field: "[u64; 3]".to_string(),
+                    components: None,
+                },
+            ]),
+        };
+
+        if let ParamType::Tuple(tuple_params) = parse_tuple_param(&params).unwrap() {
             let error_message = abi
                 .tokenize_tuple("(0, [0,0,0]))", &tuple_params)
                 .unwrap_err()
@@ -1956,7 +2016,30 @@ mod tests {
                 "Invalid data: tuple value string has excess closing brackets",
                 error_message
             );
+        }
+    }
 
+    #[test]
+    fn tokenize_tuple_excess_quotes_expected_error() {
+        let abi = ABIParser::new();
+        let params = Property {
+            name: "input".to_string(),
+            type_field: "(u64, [u64; 3])".to_string(),
+            components: Some(vec![
+                Property {
+                    name: "__tuple_element".to_string(),
+                    type_field: "u64".to_string(),
+                    components: None,
+                },
+                Property {
+                    name: "__tuple_element".to_string(),
+                    type_field: "[u64; 3]".to_string(),
+                    components: None,
+                },
+            ]),
+        };
+
+        if let ParamType::Tuple(tuple_params) = parse_tuple_param(&params).unwrap() {
             let error_message = abi
                 .tokenize_tuple("(0, \"[0,0,0])", &tuple_params)
                 .unwrap_err()
@@ -1966,7 +2049,30 @@ mod tests {
                 "Invalid data: tuple value string has excess quotes",
                 error_message
             );
+        }
+    }
 
+    #[test]
+    fn tokenize_tuple_excess_value_elements_expected_error() {
+        let abi = ABIParser::new();
+        let params = Property {
+            name: "input".to_string(),
+            type_field: "(u64, [u64; 3])".to_string(),
+            components: Some(vec![
+                Property {
+                    name: "__tuple_element".to_string(),
+                    type_field: "u64".to_string(),
+                    components: None,
+                },
+                Property {
+                    name: "__tuple_element".to_string(),
+                    type_field: "[u64; 3]".to_string(),
+                    components: None,
+                },
+            ]),
+        };
+
+        if let ParamType::Tuple(tuple_params) = parse_tuple_param(&params).unwrap() {
             let error_message = abi
                 .tokenize_tuple("(0, [0,0,0], 0, 0)", &tuple_params)
                 .unwrap_err()
@@ -1990,9 +2096,8 @@ mod tests {
     }
 
     #[test]
-    fn tokenize_errors_array() {
+    fn tokenize_array_invalid_start_end_bracket_expected_error() {
         let param = ParamType::U16;
-
         let abi = ABIParser::new();
 
         let error_message = abi
@@ -2004,6 +2109,12 @@ mod tests {
             "Invalid data: array value string must start and end with square brackets",
             error_message
         );
+    }
+
+    #[test]
+    fn tokenize_array_excess_opening_bracket_expected_error() {
+        let param = ParamType::U16;
+        let abi = ABIParser::new();
 
         let error_message = abi
             .tokenize_array("[[[1,2],[3],4]", &param)
@@ -2014,16 +2125,12 @@ mod tests {
             "Invalid data: array value string has excess opening brackets",
             error_message
         );
+    }
 
-        let error_message = abi
-            .tokenize_array("[[1,\"2],[3],4]]", &param)
-            .unwrap_err()
-            .to_string();
-
-        assert_eq!(
-            "Invalid data: array value string has excess quotes",
-            error_message
-        );
+    #[test]
+    fn tokenize_array_excess_closing_bracket_expected_error() {
+        let param = ParamType::U16;
+        let abi = ABIParser::new();
 
         let error_message = abi
             .tokenize_array("[[1,2],[3],4]]", &param)
@@ -2037,7 +2144,24 @@ mod tests {
     }
 
     #[test]
-    fn tokenize_errors_struct() {
+    fn tokenize_array_excess_quotes_expected_error() {
+        let param = ParamType::U16;
+        let abi = ABIParser::new();
+
+        let error_message = abi
+            .tokenize_array("[[1,\"2],[3],4]]", &param)
+            .unwrap_err()
+            .to_string();
+
+        assert_eq!(
+            "Invalid data: array value string has excess quotes",
+            error_message
+        );
+    }
+
+    #[test]
+    fn tokenize_struct_invalid_start_end_bracket_expected_error() {
+        let abi = ABIParser::new();
         let params = Property {
             name: "input".to_string(),
             type_field: "struct MyStruct".to_string(),
@@ -2055,8 +2179,6 @@ mod tests {
             ]),
         };
 
-        let abi = ABIParser::new();
-
         if let ParamType::Struct(struct_params) = parse_custom_type_param(&params).unwrap() {
             let error_message = abi
                 .tokenize_struct("0, [0,0,0])", &struct_params)
@@ -2067,7 +2189,30 @@ mod tests {
                 "Invalid data: struct value string must start and end with round brackets",
                 error_message
             );
+        }
+    }
 
+    #[test]
+    fn tokenize_struct_excess_opening_bracket_expected_error() {
+        let abi = ABIParser::new();
+        let params = Property {
+            name: "input".to_string(),
+            type_field: "struct MyStruct".to_string(),
+            components: Some(vec![
+                Property {
+                    name: "num".to_string(),
+                    type_field: "u64".to_string(),
+                    components: None,
+                },
+                Property {
+                    name: "arr".to_string(),
+                    type_field: "[u64; 3]".to_string(),
+                    components: None,
+                },
+            ]),
+        };
+
+        if let ParamType::Struct(struct_params) = parse_custom_type_param(&params).unwrap() {
             let error_message = abi
                 .tokenize_struct("((0, [0,0,0])", &struct_params)
                 .unwrap_err()
@@ -2077,7 +2222,30 @@ mod tests {
                 "Invalid data: struct value string has excess opening brackets",
                 error_message
             );
+        }
+    }
 
+    #[test]
+    fn tokenize_struct_excess_closing_bracket_expected_error() {
+        let abi = ABIParser::new();
+        let params = Property {
+            name: "input".to_string(),
+            type_field: "struct MyStruct".to_string(),
+            components: Some(vec![
+                Property {
+                    name: "num".to_string(),
+                    type_field: "u64".to_string(),
+                    components: None,
+                },
+                Property {
+                    name: "arr".to_string(),
+                    type_field: "[u64; 3]".to_string(),
+                    components: None,
+                },
+            ]),
+        };
+
+        if let ParamType::Struct(struct_params) = parse_custom_type_param(&params).unwrap() {
             let error_message = abi
                 .tokenize_struct("(0, [0,0,0]))", &struct_params)
                 .unwrap_err()
@@ -2087,7 +2255,30 @@ mod tests {
                 "Invalid data: struct value string has excess closing brackets",
                 error_message
             );
+        }
+    }
 
+    #[test]
+    fn tokenize_struct_excess_quotes_expected_error() {
+        let abi = ABIParser::new();
+        let params = Property {
+            name: "input".to_string(),
+            type_field: "struct MyStruct".to_string(),
+            components: Some(vec![
+                Property {
+                    name: "num".to_string(),
+                    type_field: "u64".to_string(),
+                    components: None,
+                },
+                Property {
+                    name: "arr".to_string(),
+                    type_field: "[u64; 3]".to_string(),
+                    components: None,
+                },
+            ]),
+        };
+
+        if let ParamType::Struct(struct_params) = parse_custom_type_param(&params).unwrap() {
             let error_message = abi
                 .tokenize_struct("(0, \"[0,0,0])", &struct_params)
                 .unwrap_err()
@@ -2097,7 +2288,30 @@ mod tests {
                 "Invalid data: struct value string has excess quotes",
                 error_message
             );
+        }
+    }
 
+    #[test]
+    fn tokenize_struct_excess_value_elements_expected_error() {
+        let abi = ABIParser::new();
+        let params = Property {
+            name: "input".to_string(),
+            type_field: "struct MyStruct".to_string(),
+            components: Some(vec![
+                Property {
+                    name: "num".to_string(),
+                    type_field: "u64".to_string(),
+                    components: None,
+                },
+                Property {
+                    name: "arr".to_string(),
+                    type_field: "[u64; 3]".to_string(),
+                    components: None,
+                },
+            ]),
+        };
+
+        if let ParamType::Struct(struct_params) = parse_custom_type_param(&params).unwrap() {
             let error_message = abi
                 .tokenize_struct("(0, [0,0,0], 0, 0)", &struct_params)
                 .unwrap_err()

--- a/packages/fuels-core/src/json_abi.rs
+++ b/packages/fuels-core/src/json_abi.rs
@@ -291,7 +291,7 @@ impl ABIParser {
                             let token = self.tokenize(
                                 params_iter.next().ok_or_else(|| {
                                     Error::InvalidData(
-                                        "struct value is missing a matching parameter type".into(),
+                                        "struct value contains more elements than the parameter types provided".into(),
                                     )
                                 })?,
                                 sub.to_string(),
@@ -316,7 +316,7 @@ impl ABIParser {
                     let token = self.tokenize(
                         params_iter.next().ok_or_else(|| {
                             Error::InvalidData(
-                                "struct value is missing a matching parameter type".into(),
+                                "struct value contains more elements than the parameter types provided".into(),
                             )
                         })?,
                         sub.to_string(),
@@ -482,7 +482,7 @@ impl ABIParser {
                             let token = self.tokenize(
                                 params_iter.next().ok_or_else(|| {
                                     Error::InvalidData(
-                                        "tuple value is missing a matching parameter type".into(),
+                                        "tuple value contains more elements than the parameter types provided".into(),
                                     )
                                 })?,
                                 sub.to_string(),
@@ -507,7 +507,7 @@ impl ABIParser {
                     let token = self.tokenize(
                         params_iter.next().ok_or_else(|| {
                             Error::InvalidData(
-                                "tuple value is missing a matching parameter type".into(),
+                                "tuple value contains more elements than the parameter types provided".into(),
                             )
                         })?,
                         sub.to_string(),
@@ -1973,7 +1973,7 @@ mod tests {
                 .to_string();
 
             assert_eq!(
-                "Invalid data: tuple value is missing a matching parameter type",
+                "Invalid data: tuple value contains more elements than the parameter types provided",
                 error_message
             );
 
@@ -1983,7 +1983,7 @@ mod tests {
                 .to_string();
 
             assert_eq!(
-                "Invalid data: tuple value is missing a matching parameter type",
+                "Invalid data: tuple value contains more elements than the parameter types provided",
                 error_message
             );
         }
@@ -2104,7 +2104,7 @@ mod tests {
                 .to_string();
 
             assert_eq!(
-                "Invalid data: struct value is missing a matching parameter type",
+                "Invalid data: struct value contains more elements than the parameter types provided",
                 error_message
             );
 
@@ -2114,7 +2114,7 @@ mod tests {
                 .to_string();
 
             assert_eq!(
-                "Invalid data: struct value is missing a matching parameter type",
+                "Invalid data: struct value contains more elements than the parameter types provided",
                 error_message
             );
         }

--- a/packages/fuels-core/src/json_abi.rs
+++ b/packages/fuels-core/src/json_abi.rs
@@ -211,11 +211,11 @@ impl ABIParser {
             ParamType::Bool => Ok(Token::Bool(trimmed_value.parse::<bool>()?)),
             ParamType::Byte => Ok(Token::Byte(trimmed_value.parse::<u8>()?)),
             ParamType::B256 => {
-                const B256_HEX_ENC_LENGHT: usize = 64;
-                if trimmed_value.len() != B256_HEX_ENC_LENGHT {
+                const B256_HEX_ENC_LENGTH: usize = 64;
+                if trimmed_value.len() != B256_HEX_ENC_LENGTH {
                     return Err(Error::InvalidData(format!(
                         "the hex encoding of the b256 must have {} characters",
-                        B256_HEX_ENC_LENGHT
+                        B256_HEX_ENC_LENGTH
                     )));
                 }
                 let v = Vec::from_hex(trimmed_value)?;

--- a/packages/fuels-core/src/json_abi.rs
+++ b/packages/fuels-core/src/json_abi.rs
@@ -211,10 +211,12 @@ impl ABIParser {
             ParamType::Bool => Ok(Token::Bool(trimmed_value.parse::<bool>()?)),
             ParamType::Byte => Ok(Token::Byte(trimmed_value.parse::<u8>()?)),
             ParamType::B256 => {
-                if trimmed_value.len() != 64 {
-                    return Err(Error::InvalidData(
-                        "the hex encoding of the b256 must have 64 characters".into(),
-                    ));
+                const B256_HEX_ENC_LENGHT: usize = 64;
+                if trimmed_value.len() != B256_HEX_ENC_LENGHT {
+                    return Err(Error::InvalidData(format!(
+                        "the hex encoding of the b256 must have {} characters",
+                        B256_HEX_ENC_LENGHT
+                    )));
                 }
                 let v = Vec::from_hex(trimmed_value)?;
                 let s: [u8; 32] = v.as_slice().try_into().unwrap();

--- a/packages/fuels-core/src/json_abi.rs
+++ b/packages/fuels-core/src/json_abi.rs
@@ -291,7 +291,7 @@ impl ABIParser {
                             let token = self.tokenize(
                                 params_iter.next().ok_or_else(|| {
                                     Error::InvalidData(
-                                        "last struct value is missing a matching param".into(),
+                                        "struct value is missing a matching parameter type".into(),
                                     )
                                 })?,
                                 sub.to_string(),
@@ -315,7 +315,9 @@ impl ABIParser {
 
                     let token = self.tokenize(
                         params_iter.next().ok_or_else(|| {
-                            Error::InvalidData("struct value is missing a matching param".into())
+                            Error::InvalidData(
+                                "struct value is missing a matching parameter type".into(),
+                            )
                         })?,
                         sub.to_string(),
                     )?;
@@ -480,7 +482,7 @@ impl ABIParser {
                             let token = self.tokenize(
                                 params_iter.next().ok_or_else(|| {
                                     Error::InvalidData(
-                                        "last tuple value is missing a matching param".into(),
+                                        "tuple value is missing a matching parameter type".into(),
                                     )
                                 })?,
                                 sub.to_string(),
@@ -504,7 +506,9 @@ impl ABIParser {
 
                     let token = self.tokenize(
                         params_iter.next().ok_or_else(|| {
-                            Error::InvalidData("tuple value is missing a matching param".into())
+                            Error::InvalidData(
+                                "tuple value is missing a matching parameter type".into(),
+                            )
                         })?,
                         sub.to_string(),
                     )?;

--- a/packages/fuels-core/src/json_abi.rs
+++ b/packages/fuels-core/src/json_abi.rs
@@ -1973,7 +1973,7 @@ mod tests {
                 .to_string();
 
             assert_eq!(
-                "Invalid data: tuple value is missing a matching param",
+                "Invalid data: tuple value is missing a matching parameter type",
                 error_message
             );
 
@@ -1983,7 +1983,7 @@ mod tests {
                 .to_string();
 
             assert_eq!(
-                "Invalid data: last tuple value is missing a matching param",
+                "Invalid data: tuple value is missing a matching parameter type",
                 error_message
             );
         }
@@ -2104,7 +2104,7 @@ mod tests {
                 .to_string();
 
             assert_eq!(
-                "Invalid data: struct value is missing a matching param",
+                "Invalid data: struct value is missing a matching parameter type",
                 error_message
             );
 
@@ -2114,7 +2114,7 @@ mod tests {
                 .to_string();
 
             assert_eq!(
-                "Invalid data: last struct value is missing a matching param",
+                "Invalid data: struct value is missing a matching parameter type",
                 error_message
             );
         }


### PR DESCRIPTION
This PR should close https://github.com/FuelLabs/fuels-rs/issues/359

I have added tests to cover expected tokenization errors for the built-in types, tuples, arrays and structs.

I have also added a new error for the `b256` type, when the hex encoding doesn't have the required length.