### PR TITLE
fix: improve fn signature generation for tuples

### DIFF
--- a/packages/fuels-abigen-macro/tests/harness.rs
+++ b/packages/fuels-abigen-macro/tests/harness.rs
@@ -1259,6 +1259,17 @@ async fn test_tuples() {
         .unwrap();
 
     assert_eq!(response.value, my_enum_tuple);
+
+    let id = *ContractId::zeroed();
+    let my_b256_u8_tuple: ([u8; 32], u8) = (id, 10);
+
+    let response = instance
+        .tuple_with_b256(my_b256_u8_tuple)
+        .call()
+        .await
+        .unwrap();
+
+    assert_eq!(response.value, my_b256_u8_tuple);
 }
 
 #[tokio::test]

--- a/packages/fuels-abigen-macro/tests/test_projects/tuples/src/main.sw
+++ b/packages/fuels-abigen-macro/tests/test_projects/tuples/src/main.sw
@@ -14,6 +14,7 @@ abi MyContract {
     fn returns_tuple(input: (u64, u64)) -> (u64, u64);
     fn returns_struct_in_tuple(input: (u64, Person)) -> (u64, Person);
     fn returns_enum_in_tuple(input: (u64, State)) -> (u64, State);
+    fn tuple_with_b256(p: (b256, u8)) -> (b256, u8);
 }
 
 impl MyContract for Contract {
@@ -27,5 +28,9 @@ impl MyContract for Contract {
 
     fn returns_enum_in_tuple(input: (u64, State)) -> (u64, State) {
         input
+    }
+
+    fn tuple_with_b256(p: (b256, u8)) -> (b256, u8) {
+        p
     }
 }


### PR DESCRIPTION
This fixes the following case:

```Rust
fn tuple_with_b256(p: (b256, u8)) -> (b256, u8);
```

```Rust
let id = *ContractId::zeroed();
let my_b256_u8_tuple: ([u8; 32], u8) = (id, 10);

let response = instance
    .tuple_with_b256(my_b256_u8_tuple)
    .call()
    .await
    .unwrap();

assert_eq!(response.value, my_b256_u8_tuple);
```

Previously, the generated function looked like this:

```
 pub fn tuple_with_b256(&self, value: (b256, u8)) -> ContractCall<()>
 ```
 
 But `b256` isn't a Rust type, this needs to be properly expanded to `[32; u8]`. 

This PR improves how the components inside a tuple are being expanded, fixing this issue.