### PR TITLE
feat: add support for nested enums

### DIFF
--- a/packages/fuels-abigen-macro/tests/harness.rs
+++ b/packages/fuels-abigen-macro/tests/harness.rs
@@ -1629,3 +1629,32 @@ async fn test_transaction_script_workflow() {
     let response = call_handler.get_response(receipts).unwrap();
     assert_eq!(response.value, 42);
 }
+
+#[tokio::test]
+async fn nested_enums() {
+    abigen!(
+        MyContract,
+        "packages/fuels-abigen-macro/tests/test_projects/nested_enums/out/debug/nested_enums-abi.json"
+    );
+
+    let wallet = launch_provider_and_get_single_wallet().await;
+
+    let id = Contract::deploy(
+        "tests/test_projects/nested_enums/out/debug/nested_enums.bin",
+        &wallet,
+        TxParameters::default(),
+    )
+    .await
+    .unwrap();
+
+    let instance = MyContract::new(id.to_string(), wallet.clone());
+    let expected = Option::Some(Identity::Address(Address::zeroed()));
+
+    let result = instance.some_address().call().await.unwrap();
+
+    assert_eq!(result.value, expected);
+
+    let result = instance.none().call().await.unwrap();
+
+    assert_eq!(result.value, Option::None());
+}

--- a/packages/fuels-abigen-macro/tests/test_projects/nested_enums/.gitignore
+++ b/packages/fuels-abigen-macro/tests/test_projects/nested_enums/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/packages/fuels-abigen-macro/tests/test_projects/nested_enums/Forc.toml
+++ b/packages/fuels-abigen-macro/tests/test_projects/nested_enums/Forc.toml
@@ -1,0 +1,7 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "nested_enums"
+
+[dependencies]

--- a/packages/fuels-abigen-macro/tests/test_projects/nested_enums/src/main.sw
+++ b/packages/fuels-abigen-macro/tests/test_projects/nested_enums/src/main.sw
@@ -1,0 +1,22 @@
+contract;
+
+use std::{
+    address::Address,
+    constants::NATIVE_ASSET_ID,
+    identity::Identity,
+    option::Option,
+};
+
+abi MyContract {
+    fn some_address() -> Option<Identity>;
+    fn none() -> Option<Identity>;
+}
+
+impl MyContract for Contract {
+    fn some_address() -> Option<Identity> {
+        Option::Some(Identity::Address(~Address::from(NATIVE_ASSET_ID)))
+    }
+    fn none() -> Option<Identity> {
+        Option::None
+    }
+}


### PR DESCRIPTION
Should close https://github.com/FuelLabs/fuels-rs/issues/375

The function `pub fn expand_custom_enum(name: &str, prop: &Property) -> Result<TokenStream, Error>` can now handle nested enums. 
I have updated the corresponding unit test and I have added a new `test_project` in `fuels-abigen-macro` and tested the new behavior.