### PR TITLE
fix: do not modify custom type names

### DIFF
--- a/packages/fuels-abigen-macro/tests/harness.rs
+++ b/packages/fuels-abigen-macro/tests/harness.rs
@@ -457,11 +457,11 @@ async fn compile_bindings_enum_input() {
                         "type":"enum MyEnum",
                         "components": [
                             {
-                                "name": "x",
+                                "name": "X",
                                 "type": "u32"
                             },
                             {
-                                "name": "y",
+                                "name": "Y",
                                 "type": "bool"
                             }
                         ]

--- a/packages/fuels-abigen-macro/tests/test_projects/enum_as_input/src/main.sw
+++ b/packages/fuels-abigen-macro/tests/test_projects/enum_as_input/src/main.sw
@@ -1,15 +1,15 @@
 contract;
 
 enum StandardEnum {
-    one: b256,
-    two: u32,
-    three: bool,
+    One: b256,
+    Two: u32,
+    Three: bool,
 }
 
 enum UnitEnum {
-    one: (),
-    two: (),
-    three: (),
+    One: (),
+    Two: (),
+    Three: (),
 }
 
 abi EnumTesting {
@@ -22,11 +22,11 @@ abi EnumTesting {
 
 impl EnumTesting for Contract {
     fn get_standard_enum() -> StandardEnum {
-        StandardEnum::two(12345)
+        StandardEnum::Two(12345)
     }
     fn check_standard_enum_integrity(arg: StandardEnum) -> bool {
         match arg {
-            StandardEnum::two(value) => {
+            StandardEnum::Two(value) => {
                 value == 12345u32
             },
             _ => {
@@ -36,11 +36,11 @@ impl EnumTesting for Contract {
     }
 
     fn get_unit_enum() -> UnitEnum {
-        UnitEnum::two()
+        UnitEnum::Two()
     }
     fn check_unit_enum_integrity(arg: UnitEnum) -> bool {
         match arg {
-            UnitEnum::two(_) => {
+            UnitEnum::Two(_) => {
                 true
             },
             _ => {

--- a/packages/fuels-core/src/code_gen/custom_types_gen.rs
+++ b/packages/fuels-core/src/code_gen/custom_types_gen.rs
@@ -13,8 +13,7 @@ use quote::quote;
 /// Transforms a custom type defined in [`Property`] into a [`TokenStream`]
 /// that represents that same type as a Rust-native struct.
 pub fn expand_custom_struct(prop: &Property) -> Result<TokenStream, Error> {
-    let struct_name = &extract_custom_type_name_from_abi_property(prop, Some(CustomType::Struct))?
-        .to_class_case();
+    let struct_name = &extract_custom_type_name_from_abi_property(prop, Some(CustomType::Struct))?;
     let struct_ident = ident(struct_name);
     let components = prop
         .components
@@ -43,13 +42,10 @@ pub fn expand_custom_struct(prop: &Property) -> Result<TokenStream, Error> {
         match param_type {
             // Case where a struct takes another struct
             ParamType::Struct(_params) => {
-                let inner_struct_ident = ident(
-                    &extract_custom_type_name_from_abi_property(
-                        component,
-                        Some(CustomType::Struct),
-                    )?
-                    .to_class_case(),
-                );
+                let inner_struct_ident = ident(&extract_custom_type_name_from_abi_property(
+                    component,
+                    Some(CustomType::Struct),
+                )?);
 
                 fields.push(quote! {pub #field_name: #inner_struct_ident});
                 args.push(
@@ -62,10 +58,10 @@ pub fn expand_custom_struct(prop: &Property) -> Result<TokenStream, Error> {
             }
             // The struct contains a nested enum
             ParamType::Enum(_params) => {
-                let enum_name = ident(
-                    &extract_custom_type_name_from_abi_property(component, Some(CustomType::Enum))?
-                        .to_class_case(),
-                );
+                let enum_name = ident(&extract_custom_type_name_from_abi_property(
+                    component,
+                    Some(CustomType::Enum),
+                )?);
                 fields.push(quote! {pub #field_name: #enum_name});
                 args.push(quote! {#field_name: #enum_name::new_from_tokens(&tokens[#idx..])});
                 struct_fields_tokens.push(quote! { tokens.push(self.#field_name.into_token()) });
@@ -175,7 +171,7 @@ pub fn expand_custom_struct(prop: &Property) -> Result<TokenStream, Error> {
 
 /// Transforms a custom enum defined in [`Property`] into a [`TokenStream`]
 /// that represents that same type as a Rust-native enum.
-pub fn expand_custom_enum(name: &str, prop: &Property) -> Result<TokenStream, Error> {
+pub fn expand_custom_enum(enum_name: &str, prop: &Property) -> Result<TokenStream, Error> {
     let components = prop
         .components
         .as_ref()
@@ -189,12 +185,11 @@ pub fn expand_custom_enum(name: &str, prop: &Property) -> Result<TokenStream, Er
     // Used when creating a struct from tokens with `MyEnum::new_from_tokens()`.
     let mut args = Vec::new();
 
-    let enum_name = name.to_class_case();
-    let enum_ident = ident(&enum_name);
+    let enum_ident = ident(enum_name);
     let mut param_types = Vec::new();
 
     for (discriminant, component) in components.iter().enumerate() {
-        let variant_name = ident(&component.name.to_class_case());
+        let variant_name = ident(&component.name);
         let dis = discriminant as u8;
 
         let param_type = parse_param(component)?;
@@ -208,8 +203,7 @@ pub fn expand_custom_enum(name: &str, prop: &Property) -> Result<TokenStream, Er
                 let inner_struct_name = &extract_custom_type_name_from_abi_property(
                     component,
                     Some(CustomType::Struct),
-                )?
-                .to_class_case();
+                )?;
                 let inner_struct_ident = ident(inner_struct_name);
                 // Enum variant declaration
                 enum_variants.push(quote! { #variant_name(#inner_struct_ident)});
@@ -453,18 +447,18 @@ mod tests {
             type_field: String::from("unused"),
             components: Some(vec![
                 Property {
-                    name: String::from("long_island"),
+                    name: String::from("LongIsland"),
                     type_field: String::from("u64"),
                     components: None,
                 },
                 Property {
-                    name: String::from("moscow_mule"),
+                    name: String::from("MoscowMule"),
                     type_field: String::from("bool"),
                     components: None,
                 },
             ]),
         };
-        let result = expand_custom_enum("matcha_tea", &p);
+        let result = expand_custom_enum("MatchaTea", &p);
         let expected = TokenStream::from_str(
             r#"
             # [derive (Clone , Debug , Eq , PartialEq)] pub enum MatchaTea { LongIsland (u64) , MoscowMule (bool) } impl Parameterize for MatchaTea { fn param_types () -> Vec < ParamType > { let mut types = Vec :: new () ; types . push (ParamType :: U64) ; types . push (ParamType :: Bool) ; types } fn new_from_tokens (tokens : & [Token]) -> Self { if tokens . is_empty () { panic ! ("Empty tokens array received in `{}::new_from_tokens`" , "MatchaTea") ; } match tokens [0] . clone () { Token :: Enum (content) => { if let enum_selector = * content { return match enum_selector { (0u8 , token , _) => MatchaTea :: LongIsland (< u64 > :: from_tokens (vec ! [token]) . expect (& format ! ("Failed to run `new_from_tokens` for custom {} enum type" , "MatchaTea"))) , (1u8 , token , _) => MatchaTea :: MoscowMule (< bool > :: from_tokens (vec ! [token]) . expect (& format ! ("Failed to run `new_from_tokens` for custom {} enum type" , "MatchaTea"))) , (_ , _ , _) => panic ! ("Failed to match with discriminant selector {:?}" , enum_selector) } ; } else { panic ! ("The EnumSelector `{:?}` didn't have a match" , content) ; } } , _ => panic ! ("This should contain an `Enum` token, found `{:?}`" , tokens) , } } } impl Tokenizable for MatchaTea { fn into_token (self) -> Token { let (dis , tok) = match self { MatchaTea :: LongIsland (value) => (0u8 , Token :: U64 (value)) , MatchaTea :: MoscowMule (value) => (1u8 , Token :: Bool (value)) , } ; let variants = EnumVariants :: new (Self :: param_types ()) . unwrap () ; let selector = (dis , tok , variants) ; Token :: Enum (Box :: new (selector)) } fn from_token (token : Token) -> Result < Self , InvalidOutputType > { if let Token :: Enum (_) = token { Ok (MatchaTea :: new_from_tokens (& [token])) } else { Err (InvalidOutputType ("Enum token doesn't contain inner tokens." . to_string ())) } } }
@@ -478,16 +472,16 @@ mod tests {
     #[test]
     fn test_expand_struct_inside_enum() {
         let inner_struct = Property {
-            name: String::from("infrastructure"),
+            name: String::from("Infrastructure"),
             type_field: String::from("struct Building"),
             components: Some(vec![
                 Property {
-                    name: String::from("rooms"),
+                    name: String::from("Rooms"),
                     type_field: String::from("u8"),
                     components: None,
                 },
                 Property {
-                    name: String::from("floors"),
+                    name: String::from("Floors"),
                     type_field: String::from("u16"),
                     components: None,
                 },
@@ -496,7 +490,7 @@ mod tests {
         let enum_components = vec![
             inner_struct,
             Property {
-                name: "service".to_string(),
+                name: "Service".to_string(),
                 type_field: "u32".to_string(),
                 components: None,
             },
@@ -526,7 +520,7 @@ mod tests {
             type_field: String::from("unused"),
             components: Some(vec![Property {
                 name: String::from("long_island"),
-                type_field: String::from("enum cocktail"),
+                type_field: String::from("enum Cocktail"),
                 components: Some(vec![Property {
                     name: String::from("cosmopolitan"),
                     type_field: String::from("bool"),
@@ -541,7 +535,7 @@ mod tests {
     fn test_expand_custom_struct() {
         let p = Property {
             name: String::from("unused"),
-            type_field: String::from("struct cocktail"),
+            type_field: String::from("struct Cocktail"),
             components: Some(vec![
                 Property {
                     name: String::from("long_island"),
@@ -574,11 +568,11 @@ mod tests {
     fn test_expand_custom_struct_with_struct() {
         let p = Property {
             name: String::from("unused"),
-            type_field: String::from("struct cocktail"),
+            type_field: String::from("struct Cocktail"),
             components: Some(vec![
                 Property {
                     name: String::from("long_island"),
-                    type_field: String::from("struct shaker"),
+                    type_field: String::from("struct Shaker"),
                     components: Some(vec![
                         Property {
                             name: String::from("cosmopolitan"),

--- a/packages/fuels-core/src/code_gen/functions_gen.rs
+++ b/packages/fuels-core/src/code_gen/functions_gen.rs
@@ -313,23 +313,17 @@ fn expand_input_param(
             })
         }
         ParamType::Enum(_) => {
-            let ident = ident(
-                &extract_custom_type_name_from_abi_property(
-                    custom_type_property.expect("Custom type property not found for enum"),
-                    Some(CustomType::Enum),
-                )?
-                .to_class_case(),
-            );
+            let ident = ident(&extract_custom_type_name_from_abi_property(
+                custom_type_property.expect("Custom type property not found for enum"),
+                Some(CustomType::Enum),
+            )?);
             Ok(quote! { #ident })
         }
         ParamType::Struct(_) => {
-            let ident = ident(
-                &extract_custom_type_name_from_abi_property(
-                    custom_type_property.expect("Custom type property not found for struct"),
-                    Some(CustomType::Struct),
-                )?
-                .to_class_case(),
-            );
+            let ident = ident(&extract_custom_type_name_from_abi_property(
+                custom_type_property.expect("Custom type property not found for struct"),
+                Some(CustomType::Struct),
+            )?);
             Ok(quote! { #ident })
         }
         // Primitive type
@@ -741,32 +735,6 @@ pub fn hello_world(
         assert_eq!(result.unwrap().to_string(), ":: std :: vec :: Vec < u64 >");
     }
     #[test]
-    fn test_expand_input_param_custom_type() {
-        let def = Function::default();
-        let struct_type = ParamType::Struct(vec![ParamType::Bool, ParamType::U64]);
-        let struct_prop = Property {
-            name: String::from("unused"),
-            type_field: String::from("struct babies"),
-            components: None,
-        };
-        let struct_name = Some(&struct_prop);
-        let result = expand_input_param(&def, "unused", &struct_type, &struct_name);
-        // Notice the removed plural!
-        assert_eq!(result.unwrap().to_string(), "Baby");
-
-        let enum_type =
-            ParamType::Enum(EnumVariants::new(vec![ParamType::U8, ParamType::U32]).unwrap());
-        let enum_prop = Property {
-            name: String::from("unused"),
-            type_field: String::from("enum babies"),
-            components: None,
-        };
-        let enum_name = Some(&enum_prop);
-        let result = expand_input_param(&def, "unused", &enum_type, &enum_name);
-        // Notice the removed plural!
-        assert_eq!(result.unwrap().to_string(), "Baby");
-    }
-    #[test]
     fn test_expand_input_param_struct_wrong_name() {
         let def = Function::default();
         let struct_type = ParamType::Struct(vec![ParamType::Bool, ParamType::U64]);
@@ -785,7 +753,7 @@ pub fn hello_world(
         let struct_type = ParamType::Struct(vec![ParamType::Bool, ParamType::U64]);
         let struct_prop = Property {
             name: String::from("unused"),
-            type_field: String::from("enum butitsastruct"),
+            type_field: String::from("enum Butitsastruct"),
             components: None,
         };
         let struct_name = Some(&struct_prop);

--- a/packages/fuels-core/src/code_gen/functions_gen.rs
+++ b/packages/fuels-core/src/code_gen/functions_gen.rs
@@ -334,6 +334,8 @@ fn expand_input_param(
 // Regarding string->TokenStream->string, refer to `custom_types_gen` tests for more details.
 #[cfg(test)]
 mod tests {
+    use crate::EnumVariants;
+
     use super::*;
     use std::str::FromStr;
 
@@ -732,6 +734,30 @@ pub fn hello_world(
         let array_type = ParamType::Array(Box::new(ParamType::U64), 10);
         let result = expand_input_param(&Function::default(), "unused", &array_type, &None);
         assert_eq!(result.unwrap().to_string(), ":: std :: vec :: Vec < u64 >");
+    }
+    #[test]
+    fn test_expand_input_param_custom_type() {
+        let def = Function::default();
+        let struct_type = ParamType::Struct(vec![ParamType::Bool, ParamType::U64]);
+        let struct_prop = Property {
+            name: String::from("unused"),
+            type_field: String::from("struct Babies"),
+            components: None,
+        };
+        let struct_name = Some(&struct_prop);
+        let result = expand_input_param(&def, "unused", &struct_type, &struct_name);
+        assert_eq!(result.unwrap().to_string(), "Babies");
+
+        let enum_type =
+            ParamType::Enum(EnumVariants::new(vec![ParamType::U8, ParamType::U32]).unwrap());
+        let enum_prop = Property {
+            name: String::from("unused"),
+            type_field: String::from("enum Babies"),
+            components: None,
+        };
+        let enum_name = Some(&enum_prop);
+        let result = expand_input_param(&def, "unused", &enum_type, &enum_name);
+        assert_eq!(result.unwrap().to_string(), "Babies");
     }
     #[test]
     fn test_expand_input_param_struct_wrong_name() {

--- a/packages/fuels-core/src/code_gen/functions_gen.rs
+++ b/packages/fuels-core/src/code_gen/functions_gen.rs
@@ -335,7 +335,6 @@ fn expand_input_param(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::EnumVariants;
     use std::str::FromStr;
 
     #[test]


### PR DESCRIPTION
# Problem

Suppose the following two structs in Sway:

```Rust
pub struct Campaign {
    author: Identity,
    asset: ContractId,
    beneficiary: Identity,
    claimed: bool,
    deadline: u64,
    state: u64, 
    target_amount: u64,
    total_pledge: u64,
}

pub struct Campaigns {
    active: [u64; 1],
    completed: [u64; 1],
}
```

Given the current state of the SDK, this would lead to this error:

<img width="625" alt="image" src="https://user-images.githubusercontent.com/3484025/173702129-bcc266fd-7c6f-4169-ba91-a2a5bc078d1f.png">


That's because `Campaigns` was being turned into `Campaign` due to `Inflector`'s `.to_class_case()`, and then conflicting with the original `Campaign`. 

Fiddling with the casing chosen by the Sway user is bad and not wanted, whatever the Sway user decides (and the _compiler_ allows) should be what is generated by the SDK, otherwise, there will be a discrepancy between what the user chose and what the SDK is generating, which isn't good.


# Solution

This PR simply removes the mutation of casing altogether. No more `.to_class_case()`. A very few tests were updated to use proper casing and not to expect casing mutation at all. The other tests don't break with the removal of `.to_cass_case()` and cases where the user defines structs such as `Campaign` and `Campaigns` are expected to work.