### PR TITLE
add abigen to fuels Cargo.Toml

### DIFF
--- a/docs/src/getting-started/setup.md
+++ b/docs/src/getting-started/setup.md
@@ -14,7 +14,6 @@ Now you're up and ready to develop with the Fuel Rust SDK!
 Add these dependencies on your `Cargo.toml`:
 
 ```toml
-fuels-abigen-macro = "0.15"
 fuels = "0.15"
 ```
 
@@ -24,5 +23,4 @@ And then, in your Rust file that's going to make use of the SDK:
 
 ```rust,ignore
 use fuels::prelude::*;
-use fuels_abigen_macro::abigen;
 ```

--- a/docs/src/getting-started/type-safe-bindings.md
+++ b/docs/src/getting-started/type-safe-bindings.md
@@ -117,7 +117,7 @@ assert_eq!(52, result.unwrap());
 To generate these bindings, all you have to do is:
 
 ```rust,ignore
-use fuels_abigen_macro::abigen;
+use fuels::prelude::*;
 
 abigen!(
     MyContractName,
@@ -133,7 +133,7 @@ And this `abigen!` macro will _expand_ the code with the type-safe Rust bindings
 The same as the example above but passing the ABI definition directly:
 
 ```rust,ignore
-use fuels_abigen_macro::abigen;
+use fuels::prelude::*;
 
 abigen!(
     MyContractName,

--- a/examples/contracts/Cargo.toml
+++ b/examples/contracts/Cargo.toml
@@ -13,6 +13,6 @@ description = "Fuel Rust SDK contract examples."
 
 [dependencies]
 fuels = { version = "0.15.2", path = "../../packages/fuels" }
-fuels-abigen-macro = { version = "0.15.2", path = "../../packages/fuels-abigen-macro" }
+#fuels-abigen-macro = { version = "0.15.2", path = "../../packages/fuels-abigen-macro" }
 rand = "0.8"
 tokio = { version = "1.10", features = ["full"] }

--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -174,7 +174,6 @@ async fn deploy_with_multiple_wallets() {
 #[tokio::test]
 async fn call_params() -> Result<(), Error> {
     use fuels::prelude::*;
-    use fuels_abigen_macro::abigen;
 
     abigen!(
         MyContract,
@@ -216,7 +215,6 @@ async fn call_params() -> Result<(), Error> {
 #[tokio::test]
 async fn call_params_gas() -> Result<(), Error> {
     use fuels::prelude::*;
-    use fuels_abigen_macro::abigen;
 
     abigen!(
         MyContract,

--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -14,7 +14,6 @@ async fn instantiate_client() {
 // ANCHOR: deploy_contract
 async fn deploy_contract() {
     use fuels::prelude::*;
-    use fuels_abigen_macro::abigen;
 
     // This will generate your contract's methods onto `MyContract`.
     // This means an instance of `MyContract` will have access to all
@@ -78,7 +77,6 @@ async fn deploy_contract() {
 // ANCHOR: deploy_with_salt
 async fn deploy_with_salt() {
     use fuels::prelude::*;
-    use fuels_abigen_macro::abigen;
     use rand::prelude::{Rng, SeedableRng, StdRng};
 
     abigen!(
@@ -120,7 +118,6 @@ async fn deploy_with_salt() {
 // ANCHOR: deploy_with_multiple_wallets
 async fn deploy_with_multiple_wallets() {
     use fuels::prelude::*;
-    use fuels_abigen_macro::abigen;
 
     abigen!(
             MyContract,

--- a/packages/fuels-abigen-macro/src/lib.rs
+++ b/packages/fuels-abigen-macro/src/lib.rs
@@ -7,7 +7,6 @@ use syn::parse::{Parse, ParseStream, Result as ParseResult};
 use syn::{parse_macro_input, Ident, LitStr, Token};
 
 /// Abigen proc macro definition and helper functions/types.
-
 #[proc_macro]
 pub fn abigen(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as Spanned<ContractArgs>);

--- a/packages/fuels-abigen-macro/tests/harness.rs
+++ b/packages/fuels-abigen-macro/tests/harness.rs
@@ -1,11 +1,10 @@
 use fuel_core::service::Config;
 use fuel_gql_client::fuel_tx::{AssetId, ContractId, Receipt};
 use fuels::prelude::{
-    launch_provider_and_get_single_wallet, setup_multiple_assets_coins, setup_single_asset_coins,
-    setup_test_provider, CallParameters, Contract, Error, LocalWallet, Provider, Signer,
-    TxParameters, DEFAULT_COIN_AMOUNT, DEFAULT_NUM_COINS,
+    abigen, launch_provider_and_get_single_wallet, setup_multiple_assets_coins,
+    setup_single_asset_coins, setup_test_provider, CallParameters, Contract, Error, LocalWallet,
+    Provider, Signer, TxParameters, DEFAULT_COIN_AMOUNT, DEFAULT_NUM_COINS,
 };
-use fuels_abigen_macro::abigen;
 use fuels_core::tx::Address;
 use fuels_core::Parameterize;
 use fuels_core::{constants::BASE_ASSET_ID, Token};

--- a/packages/fuels/src/lib.rs
+++ b/packages/fuels/src/lib.rs
@@ -21,7 +21,7 @@ pub mod client {
 }
 
 pub mod fuels_abigen {
-   pub use fuels_abigen_macro::*;
+    pub use fuels_abigen_macro::*;
 }
 
 pub mod contract {
@@ -66,11 +66,10 @@ pub mod prelude {
     pub use super::core::tx::{Address, AssetId, ContractId};
     pub use super::core::{Detokenize, InvalidOutputType};
     pub use super::core::{Token, Tokenizable};
+    pub use super::fuels_abigen::abigen;
     pub use super::node::service::Config;
     pub use super::signers::provider::*;
     pub use super::signers::{LocalWallet, Signer};
     pub use super::test_helpers::*;
     pub use super::tx::Salt;
-    pub use super::fuels_abigen::abigen;
-
 }

--- a/packages/fuels/src/lib.rs
+++ b/packages/fuels/src/lib.rs
@@ -16,7 +16,6 @@
 //! Examples on how you can use the types imported by the prelude can be found in
 //! the [main test suite](https://github.com/FuelLabs/fuels-rs/blob/master/fuels-abigen-macro/tests/harness.rs)
 
-
 pub mod client {
     pub use fuel_gql_client::client::*;
 }

--- a/packages/fuels/src/lib.rs
+++ b/packages/fuels/src/lib.rs
@@ -4,10 +4,10 @@
 //!
 //! A prelude is provided which imports all the important data types and traits for you. Use this when you want to quickly bootstrap a new project.
 //!
+//!
 //! ```no_run
 //! # #[allow(unused)]
 //! use fuels::prelude::*;
-//! use fuels_abigen_macro::abigen;
 //! ```
 //!
 //! Note that `fuels_abigen_macro` isn't included in the `fuels` crate because
@@ -18,6 +18,10 @@
 
 pub mod client {
     pub use fuel_gql_client::client::*;
+}
+
+pub mod fuels_abigen {
+   pub use fuels_abigen_macro::*;
 }
 
 pub mod contract {
@@ -67,4 +71,6 @@ pub mod prelude {
     pub use super::signers::{LocalWallet, Signer};
     pub use super::test_helpers::*;
     pub use super::tx::Salt;
+    pub use super::fuels_abigen::abigen;
+
 }

--- a/packages/fuels/src/lib.rs
+++ b/packages/fuels/src/lib.rs
@@ -59,8 +59,8 @@ pub mod prelude {
     pub use super::core::parameters::*;
     pub use super::core::tx::{Address, AssetId, ContractId};
     pub use super::core::{InstantiationError, Token, Tokenizable};
-    pub use super::signers::provider::*;
     pub use super::fuels_abigen::abigen;
+    pub use super::signers::provider::*;
     pub use super::signers::{LocalWallet, Signer};
     pub use super::test_helpers::Config;
     pub use super::test_helpers::*;


### PR DESCRIPTION
I inserted `abigen!()` macro into the `fuel` library so users don't have to import the `fuels-core-abigen` library into Cargo.toml of their tests to use `abigen!()` macro.
From :

```rust
[project]
name = "zule"
version = "0.1.0"
authors = ["salka1988"]
edition = "2021"
license = "Apache-2.0"

[dependencies]
fuels = "0.14"
fuels-abigen-macro = "0.14"
tokio = { version = "1.12", features = ["rt", "macros"] }

[[test]]
harness = true
name = "integration_tests"
path = "tests/harness.rs"
```
To:
```rust
[project]
name = "zule"
version = "0.1.0"
authors = ["salka1988"]
edition = "2021"
license = "Apache-2.0"

[dependencies]
fuels = "0.14"
tokio = { version = "1.12", features = ["rt", "macros"] }

[[test]]
harness = true
name = "integration_tests"
path = "tests/harness.rs"
```
```