### PR TITLE
docs: migrate all examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,5 @@ members = [
     "scripts/build-test-projects",
     "examples/contracts",
     "examples/wallets",
+    "examples/rust_bindings",
 ]

--- a/docs/src/getting-started/basics.md
+++ b/docs/src/getting-started/basics.md
@@ -35,6 +35,13 @@ If you are only interested in a single instance of your contract then use `deplo
 {{#include ../../../examples/contracts/src/lib.rs:deploy_contract}}
 ```
 
+You can then use the contract methods very simply:
+
+
+```rust,ignore
+{{#include ../../../examples/contracts/src/lib.rs:use_deployed_contract}}
+```
+
 Alternatively, if you want multiple instances of the same contract then use `deploy_with_salt`
 
 ```rust,ignore

--- a/docs/src/getting-started/basics.md
+++ b/docs/src/getting-started/basics.md
@@ -46,26 +46,13 @@ Alternatively, if you want multiple instances of the same contract then use `dep
 If you need multiple test wallets, they can be setup as follows:
 
 ```rust,ignore
-// This helper will launch a local node and provide 10 test wallets linked to it.
-// The initial balance defaults to 1 coin per wallet with an amount of 1_000_000_000
-let wallets = launch_provider_and_get_wallets(WalletsConfig::default()).await;
+{{#include ../../../examples/wallets/src/lib.rs:multiple_wallets_helper}}
 ```
 
 The returned test wallets can be customized via `WalletsConfig`
 
 ```rust,ignore
-let num_wallets = 5;
-let coins_per_wallet = 3;
-let amount_per_coin = 100;
-
-let config = WalletsConfig::new(
-    Some(num_wallets),
-    Some(coins_per_wallet),
-    Some(amount_per_coin)
-);
-
-// Launches a local node and provides test wallets as specified by the config
-let wallets = launch_provider_and_get_wallets(WalletsConfig::default()).await;
+{{#include ../../../examples/wallets/src/lib.rs:setup_5_wallets}}
 ```
 
 ## Setting up a test wallet with multiple assets
@@ -73,19 +60,7 @@ let wallets = launch_provider_and_get_wallets(WalletsConfig::default()).await;
 You can create a test wallet which contains multiple different assets (including the base asset to pay for gas).
 
 ```rust,ignore
-let mut wallet = LocalWallet::new_random(None);
-let num_assets = 5; // 5 different assets
-let coins_per_asset = 10; // Per asset id, 10 coins in the wallet
-let amount_per_coin = 15; // For each coin (UTXO) of the asset, amount of 15
-
-let (coins, asset_ids) = setup_multiple_assets_coins(
-    wallet.address(),
-    num_assets,
-    coins_per_asset,
-    amount_per_coin,
-);
-let (provider, _socket_addr) = setup_test_provider(coins.clone(), Config::local_node()).await;
-wallet.set_provider(provider);
+{{#include ../../../examples/wallets/src/lib.rs:multiple_assets_wallet}}
 ```
 
 - `coins: Vec<(UtxoId, Coin)>` has `num_assets * coins_per_assets` coins (UTXOs)
@@ -98,7 +73,7 @@ Once you've deployed your contract, as seen in the previous section, you'll like
 Start by creating an instance of your contract once you have a wallet set up:
 
 ```rust,ignore
-let contract_instance = MyContract::new(contract_id.to_string(), wallet);
+{{#include ../../../examples/contracts/src/lib.rs:instantiate_contract}}
 ```
 
 Then we move to configuring contract calls.
@@ -115,19 +90,20 @@ Transaction parameters are:
 These parameters can be configured by creating an instance of [`TxParameters`](https://github.com/FuelLabs/fuels-rs/blob/adf81bd451d7637ce0976363bd7784408430031a/packages/fuels-contract/src/parameters.rs#L7) and passing it to a chain method called `tx_params`:
 
 ```rust,ignore
-// In order: gas_price, gas_limit, byte_price, and maturity
-let my_tx_params = TxParameters::new(None, Some(1_000_000), None, None);
+{{#include ../../../examples/contracts/src/lib.rs:tx_parameters}}
+```
+You can also use `TxParameters::default()` to use the default values:
 
-let result = contract_instance
-        .initialize_counter(42)  // Our contract method.
-        .tx_params(my_tx_params) // Chain the tx params setting method.
-        .call()                  // Perform the contract call.
-        .await                   // This is an async call, `.await` for it.
-        .unwrap();               // It returns a `Result<CallResponse<D>, Error>,
-                                 // unwrap or handle it in any other preferable way.
+```rust,ignore
+{{#include ../../../packages/fuels-core/src/constants.rs:default_tx_parameters}}
 ```
 
-You can also use `TxParameters::default()` to use the [default values](https://github.com/FuelLabs/fuels-rs/blob/adf81bd451d7637ce0976363bd7784408430031a/packages/fuels-core/src/constants.rs#L4-L7).
+this way:
+
+```rust,ignore
+{{#include ../../../examples/contracts/src/lib.rs:tx_parameters_default}}
+```
+
 
 ### `CallParameters`
 
@@ -138,43 +114,29 @@ Call parameters are:
 
 This is commonly used to forward coins to a contract. These parameters can be configured by creating an instance of [`CallParameters`](https://github.com/FuelLabs/fuels-rs/blob/adf81bd451d7637ce0976363bd7784408430031a/packages/fuels-contract/src/parameters.rs#L15) and passing it to a chain method called `call_params`.
 
-For instance, suppose the following contract that makes use of Sway's `msg_amount()` to return the amount sent in that message to the contract:
+For instance, suppose the following contract that makes use of Sway's `msg_amount()` to return the amount sent in that transaction.
 
 ```rust,ignore
-abi FuelTest {
-    fn get_msg_amount() -> u64;
-}
-
-impl FuelTest for Contract {
-    fn get_msg_amount() -> u64 {
-        msg_amount()
-    }
-}
+{{#include ../../../packages/fuels-abigen-macro/tests/test_projects/contract_test/src/main.sw:msg_amount}}
 ```
 
-Then, in Rust, after setting up and deploying the above contract, you can configure the amount being sent to the `get_msg_amount()` method like this:
+Then, in Rust, after setting up and deploying the above contract, you can configure the amount being sent in the transaction like this:
 
 ```rust,ignore
-let tx_params = TxParameters::new(None, Some(1_000_000), None, None);
-
-// Forward 1_000_000 coin amount of base asset_id
-// this is a big number for checking that amount can be a u64
-let call_params = CallParameters::new(Some(1_000_000), None);
-
-let response = contract_instance
-    .get_msg_amount()          // Our contract method.
-    .tx_params(tx_params)      // Chain the tx params setting method.
-    .call_params(call_params)  // Chain the call params setting method.
-    .call()                    // Perform the contract call.
-    .await
-    .unwrap();
+{{#include ../../../examples/contracts/src/lib.rs:call_parameters}}
 ```
 
 You can also use `CallParameters::default()` to use the default values:
 
 ```rust,ignore
-pub const DEFAULT_COIN_AMOUNT: u64 = 1_000_000;
-pub const NATIVE_ASSET_ID: AssetId = AssetId::new([0u8; 32]);
+{{#include ../../../packages/fuels-core/src/constants.rs:default_call_parameters}}
+```
+
+this way:
+
+
+```rust,ignore
+{{#include ../../../examples/contracts/src/lib.rs:call_parameters_default}}
 ```
 
 ### `CallResponse`: Reading returned values
@@ -188,11 +150,7 @@ You've probably noticed that you're often chaining `.call().await.unwrap(). That
 Once you unwrap the `CallResponse`, you have access to this struct:
 
 ```rust,ignore
-pub struct CallResponse<D> {
-    pub value: D,
-    pub receipts: Vec<Receipt>,
-    pub logs: Option<Vec<String>>,
-}
+{{#include ../../../packages/fuels-contract/src/contract.rs:call_response}}
 ```
 
 Where `value` will hold the value returned by its respective contract method, represented by the exact type returned by the FuelVM. E.g., if your contract returns a FuelVM's `u64`, `value`'s `D` will be a `u64`. If it's a FuelVM's tuple `(u8,bool)`, then `D` will be a `(u8,bool)`. If it's a custom type, for instance, a Sway struct `MyStruct` containing 2 components, a `u64` and a `b256`, `D` will be a struct generated at compile-time, called `MyStruct` with `u64` and a `[u8; 32]` (the equivalent of `b256` in Rust-land).
@@ -216,7 +174,7 @@ In this case, there's no need to generate an actual blockchain transaction; you 
 You can do this with the SDK by, instead of `.call()`ing the method, using `.simulate()` instead:
 
 ```rust,ignore
-let my_balance = contract_instance.return_my_balance().simulate().await.unwrap();
+{{#include ../../../examples/contracts/src/lib.rs:simulate}}
 ```
 
 Note that if you use `.simulate()` on a method that _does_ change the state of the blockchain, it won't work properly; it will just `dry-run` it.
@@ -228,33 +186,13 @@ At the moment, it's up to you to know whether a contract method changes state or
 In some cases, you might want to send funds to the output of a transaction. Sway has a specific method for that: `transfer_to_output(coins, asset_id, recipient)`. So, if you have a contract that does something like this:
 
 ```rust,ignore
-contract;
-
-use std::{address::Address, context::balance_of, context::msg_amount, contract_id::ContractId, token::*};
-
-abi FuelTest {
-    fn transfer_coins_to_output(coins: u64, asset_id: ContractId, recipient: Address);
-}
-
-impl FuelTest for Contract {
-    fn transfer_coins_to_output(coins: u64, asset_id: ContractId, recipient: Address) {
-        transfer_to_output(coins, asset_id, recipient);
-    }
-}
+{{#include ../../../packages/fuels-abigen-macro/tests/test_projects/token_ops/src/main.sw:variable_outputs}}
 ```
 
 With the SDK, you can call `transfer_coins_to_output`, by chaining `append_variable_outputs(amount)` to your contract call. Like this:
 
 ```rust,ignore
-let address = wallet.address();
-
-// withdraw some tokens to wallet
-contract_instance
-    .transfer_coins_to_output(1_000_000, id, address)
-    .append_variable_outputs(1)
-    .call()
-    .await
-    .unwrap();
+{{#include ../../../examples/contracts/src/lib.rs:variable_outputs}}
 ```
 
 `append_variable_outputs` effectively appends a given amount of `Output::Variable`s to the transaction's list of outputs. This output type indicates that the output's amount and owner may vary based on transaction execution.
@@ -266,12 +204,7 @@ Note that the Sway `lib-std` function `mint_to_address` calls `transfer_to_outpu
 Sometimes, you might need to call your contract, which calls other contracts. To do so, you must feed the external contract IDs that your contract depends on to the method you're calling. You do it by chaining `.set_contracts(&[external_contract_id, ...])` to the method you want to call. For instance:
 
 ```rust,ignore
-let response = contract_instance
-.my_method(...)
-.set_contracts( & [another_contract_id]) // Add this to set the external contract
-.call()
-.await
-.unwrap();
+{{#include ../../../packages/fuels-abigen-macro/tests/harness.rs:external_contract}}
 ```
 
 For a more concrete example, see the `test_contract_calling_contract` function in
@@ -282,16 +215,7 @@ For a more concrete example, see the `test_contract_calling_contract` function i
 If you already have a deployed contract and want to call its methods using the SDK,  but without deploying it again, all you need is the contract ID of your deployed contract. You can skip the whole deployment setup and call `::new(contract_id, wallet)` directly. For example:
 
 ```rust,ignore
-abigen!(
-    MyContract,
-    "path/to/abi.json"
-);
-
-let wallet = launch_provider_and_get_single_wallet().await;
-
-let contract_id = "0x0123..." // Your contract ID as a string.
-
-let connected_contract_instance = MyContract::new(contract_id, wallet);
+{{#include ../../../examples/contracts/src/lib.rs:deployed_contracts}}
 ```
 
 ## Getting the contract call outputs
@@ -299,28 +223,13 @@ let connected_contract_instance = MyContract::new(contract_id, wallet);
 - Getting the contract call outputs is done this way:
 
 ```rust,ignore
-let response = contract_instance.my_method(args).call().await;
-match response {
-   // The transaction is valid and executes to completion
-    Ok(call_response) => {
-        let logs: Vec<String> = call_response.logs;
-        let receipts: Vec<Receipt> = call_response.receipts;
-        // Do things with logs and receipts
-    }
-    
-    // - The transaction is invalid or node is offline
-    // - The transaction is valid but reverts
-    ContractCallError(reason, receipts) => {
-        println!("ContractCall failed with reason: {}", reason);
-        println!("Transaction receipts are: {:?}", receipts);
-    }
-}
+{{#include ../../../examples/contracts/src/lib.rs:contract_receipts}}
 ```
 
 > **Note:** It is generally considered good practice when you expect the call to succeed, to unwrap the response with `?`, this way:
 >
 > ```rust, ignore
-> let response = contract_instance.my_method(args).call().await?;
+> {{#include ../../../examples/contracts/src/lib.rs:good_practice}}
 > ```
 
 ## More examples

--- a/docs/src/getting-started/type-safe-bindings.md
+++ b/docs/src/getting-started/type-safe-bindings.md
@@ -4,125 +4,28 @@ The SDK lets you transform ABI methods of a contract call, specified as JSON obj
 
 For instance, a contract with two methods: `initialize_counter(arg: u64) -> u64` and `increment_counter(arg: u64) -> u64`, with the following JSON ABI:
 
-```json
-[
-  {
-    "type": "function",
-    "inputs": [
-      {
-        "name": "arg",
-        "type": "u64"
-      }
-    ],
-    "name": "initialize_counter",
-    "outputs": [
-      {
-        "name": "arg",
-        "type": "u64"
-      }
-    ]
-  },
-  {
-    "type": "function",
-    "inputs": [
-      {
-        "name": "arg",
-        "type": "u64"
-      }
-    ],
-    "name": "increment_counter",
-    "outputs": [
-      {
-        "name": "arg",
-        "type": "u64"
-      }
-    ]
-  }
-]
+```json,ignore
+{{#include ../../../examples/rust_bindings/src/abi.json}}
 ```
 
 Can become this (shortened for brevity's sake):
 
 ```rust,ignore
-// Note that is all GENERATED code. No need to write any of that. Ever.
-pub struct MyContract {
-    contract_id: FuelContractId,
-    provider: Provider,
-    wallet: LocalWallet,
-}
-
-impl MyContract {
-    pub fn new(contract_id: String, provider: Provider, wallet: LocalWallet) -> Self {
-        let contract_id = FuelContractId::from_str(&contract_id).unwrap();
-        Self {
-            contract_id,
-            provider,
-            wallet,
-        }
-    }
-    #[doc = "Calls the contract\'s `initialize_counter` (0x00000000ab64e5f2) function"]
-    pub fn initialize_counter(&self, value: u64) -> ContractCall<u64> {
-        Contract::method_hash(
-            &self.provider,
-            self.contract_id,
-            &self.wallet,
-            [0, 0, 0, 0, 171, 100, 229, 242],
-            &[ParamType::U64],
-            &[value.into_token()],
-        )
-            .expect("method not found (this should never happen)")
-    }
-    #[doc = "Calls the contract\'s `increment_counter` (0x00000000faf90dd3) function"]
-    pub fn increment_counter(&self, value: u64) -> ContractCall<u64> {
-        Contract::method_hash(
-            &self.provider,
-            self.contract_id,
-            &self.wallet,
-            [0, 0, 0, 0, 250, 249, 13, 211],
-            &[ParamType::U64],
-            &[value.into_token()],
-        )
-            .expect("method not found (this should never happen)")
-    }
-}
+{{#include ../../../examples/rust_bindings/src/rust_bindings_formatted.rs}}
 ```
 
-And, then, you're able to use to call the actual methods on the deployed contract:
+> Note: that is all **generated** code. No need to write any of that. Ever.
+
+And, then, you're able to use it to call the actual methods on the deployed contract:
 
 ```rust,ignore
-//...
-let contract_instance = MyContract::new(contract_id.to_string(), provider, wallet);
-
-let result = contract_instance
-.initialize_counter(42) // Build the ABI call
-// Perform the network call, this will use the default values for
-// gas price (0), gas limit (1_000_000), and byte price (0).
-.call()
-.await
-.unwrap();
-
-assert_eq!(42, result.unwrap());
-
-let result = contract_instance
-.increment_counter(10)
-.call()
-// You can configure the parameters for a specific contract call:
-.tx_params(TxParameters::new(Some(100), Some(1_000_000), Some(0)))
-.await
-.unwrap();
-
-assert_eq!(52, result.unwrap());
+{{#include ../../../examples/contracts/src/lib.rs:use_deployed_contract}}
 ```
 
 To generate these bindings, all you have to do is:
 
 ```rust,ignore
-use fuels_abigen_macro::abigen;
-
-abigen!(
-    MyContractName,
-    "path/to/json/abi.json"
-);
+{{#include ../../../examples/rust_bindings/src/lib.rs:use_abigen}}
 ```
 
 And this `abigen!` macro will _expand_ the code with the type-safe Rust bindings. It takes 2 arguments:
@@ -133,45 +36,5 @@ And this `abigen!` macro will _expand_ the code with the type-safe Rust bindings
 The same as the example above but passing the ABI definition directly:
 
 ```rust,ignore
-use fuels_abigen_macro::abigen;
-
-abigen!(
-    MyContractName,
-    r#"
-    [
-        {
-            "type": "function",
-            "inputs": [
-                {
-                    "name": "arg",
-                    "type": "u64"
-                }
-            ],
-            "name": "initialize_counter",
-            "outputs": [
-                {
-                    "name": "arg",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "type": "function",
-            "inputs": [
-                {
-                    "name": "arg",
-                    "type": "u64"
-                }
-            ],
-            "name": "increment_counter",
-            "outputs": [
-                {
-                    "name": "arg",
-                    "type": "u64"
-                }
-            ]
-        }
-    ]
-    "#
-);
+{{#include ../../../examples/rust_bindings/src/lib.rs:abigen_with_string}}
 ```

--- a/docs/src/getting-started/type-safe-bindings.md
+++ b/docs/src/getting-started/type-safe-bindings.md
@@ -14,7 +14,9 @@ Can become this (shortened for brevity's sake):
 {{#include ../../../examples/rust_bindings/src/rust_bindings_formatted.rs}}
 ```
 
-> Note: that is all **generated** code. No need to write any of that. Ever.
+> **Note:** that is all **generated** code. No need to write any of that. Ever.
+
+> **Note:** the generated code might look different from one version to another, this is just an example to give an idea of what it looks like.
 
 And, then, you're able to use it to call the actual methods on the deployed contract:
 

--- a/docs/src/getting-started/wallets.md
+++ b/docs/src/getting-started/wallets.md
@@ -64,14 +64,13 @@ If you had already created a wallet using a mnemonic phrase or a private key, yo
 First, one should keep in mind that, with UTXOs, each _coin_ is unique. Each UTXO corresponds to a unique _coin_, and said _coin_ has a corresponding _amount_ (the same way a dollar bill has either 10$ or 5$ face value). So, when you want to query the balance for a given asset ID, you want to query the sum of the amount in each unspent coin. This is done very easily with a wallet:
 
 ```rust,ignore
-let asset_id : AssetId = BASE_ASSET_ID
-let balance : u64 = wallet.get_asset_balance(&asset_id).await;
+{{#include ../../../examples/wallets/src/lib.rs:get_asset_balance}}
 ```
 
 If you want to query all the balances (i.e. get the balance for each asset IDs in that wallet), then it is as simple as:
 
 ```rust,ignore
-let balances = wallet.get_balances().await.unwrap();
+{{#include ../../../examples/wallets/src/lib.rs:get_balances}}
 ```
 
 The return type is a `HashMap`, where the key is the _asset ID_ and the value is the corresponding balance.

--- a/docs/src/workspaces/fuels-abigen-macro.md
+++ b/docs/src/workspaces/fuels-abigen-macro.md
@@ -9,49 +9,7 @@ The specifications for the JSON ABI format and its encoding/decoding can be foun
 A simple example of generating type-safe bindings from a JSON ABI specified in-line:
 
 ```rust,ignore
-fn compile_bindings_from_inline_contract() {
-    // Generates the bindings from the an ABI definition inline.
-    // The generated bindings can be accessed through `SimpleContract`.
-    abigen!(
-        SimpleContract,
-        r#"
-        [
-            {
-                "type": "contract",
-                "inputs": [
-                    {
-                        "name": "arg",
-                        "type": "u32"
-                    },
-                    {
-                        "name": "second_arg",
-                        "type": "u16"
-                    }
-                ],
-                "name": "takes_ints_returns_bool",
-                "outputs": [
-                    {
-                        "name": "",
-                        "type": "bool"
-                    }
-                ]
-            }
-        ]
-        "#
-    );
-
-    let dummy_client = FuelClient::new("").unwrap();
-    let contract_instance = SimpleContract::new(contract_id.to_string(),dummy_client);
-
-    let contract_call = contract_instance.takes_ints_returns_bool(42 as u32, 10 as u16);
-
-    let encoded = format!(
-        "{}{}",
-        contract_call.encoded_selector, contract_call.encoded_params
-    );
-
-    assert_eq!("0000000003b568d4000000000000002a000000000000000a", encoded);
-}
+{{#include ../../../packages/fuels-abigen-macro/tests/harness.rs:bindings_from_inline_contracts}}
 ```
 
 This example and many more can be found under `tests/harness.rs`. To run the whole test suite run `cargo test` inside `fuels-abi-gen-macro/`.

--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -14,11 +14,11 @@ async fn instantiate_client() {
 // ANCHOR_END: instantiate_client
 
 #[tokio::test]
-// ANCHOR: deploy_contract
 async fn deploy_contract() {
     use fuels::prelude::*;
     use fuels_abigen_macro::abigen;
 
+    // ANCHOR: deploy_contract
     // This will generate your contract's methods onto `MyContract`.
     // This means an instance of `MyContract` will have access to all
     // your contract's methods that are running on-chain!
@@ -53,14 +53,14 @@ async fn deploy_contract() {
         .await
         .unwrap();
     println!("Contract deployed @ {:x}", contract_id);
+    // ANCHOR_END: deploy_contract
 
-    // Here is an instance of your contract which you can use to make calls to
-    // your functions
+    // ANCHOR: use_deployed_contract
+    // This is an instance of your contract which you can use to make calls to your functions
     let contract_instance = MyContract::new(contract_id.to_string(), wallet);
 
     let result = contract_instance
         .initialize_counter(42) // Build the ABI call
-        .tx_params(TxParameters::new(None, Some(1_000_000), None, None))
         .call() // Perform the network call
         .await
         .unwrap();
@@ -74,8 +74,8 @@ async fn deploy_contract() {
         .unwrap();
 
     assert_eq!(52, result.value);
+    // ANCHOR_END: use_deployed_contract
 }
-// ANCHOR_END: deploy_contract
 
 #[tokio::test]
 // ANCHOR: deploy_with_salt

--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -1,3 +1,6 @@
+#[allow(unused_imports)]
+use fuels::prelude::Error;
+
 #[tokio::test]
 // ANCHOR: instantiate_client
 async fn instantiate_client() {
@@ -170,3 +173,181 @@ async fn deploy_with_multiple_wallets() {
     assert_eq!(42, result.value);
 }
 // ANCHOR_END: deploy_with_multiple_wallets
+
+#[tokio::test]
+#[allow(unused_variables)]
+async fn contract_tx_and_call_params() -> Result<(), Error> {
+    use fuels::prelude::*;
+    use fuels_abigen_macro::abigen;
+    abigen!(
+            MyContract,
+            "packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test-abi.json"
+        );
+
+    let wallet = launch_provider_and_get_single_wallet().await;
+    let contract_id = Contract::deploy(
+        "../../packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test.bin",
+        &wallet,
+        TxParameters::default()
+    ).await?;
+    println!("Contract deployed @ {:x}", contract_id);
+    // ANCHOR: instantiate_contract
+    let contract_instance = MyContract::new(contract_id.to_string(), wallet.clone());
+    // ANCHOR_END: instantiate_contract
+    // ANCHOR: tx_parameters
+    // In order: gas_price, gas_limit, byte_price, and maturity
+    let my_tx_params = TxParameters::new(None, Some(1_000_000), None, None);
+
+    let response = contract_instance
+        .initialize_counter(42) // Our contract method.
+        .tx_params(my_tx_params) // Chain the tx params setting method.
+        .call() // Perform the contract call.
+        .await?; // This is an async call, `.await` for it.
+
+    // ANCHOR_END: tx_parameters
+
+    // ANCHOR: tx_parameters_default
+    let response = contract_instance
+        .initialize_counter(42)
+        .tx_params(TxParameters::default())
+        .call()
+        .await?;
+
+    // ANCHOR_END: tx_parameters_default
+    // ANCHOR: tx_parameters
+    // In order: gas_price, gas_limit, byte_price, and maturity
+    let my_tx_params = TxParameters::new(None, Some(1_000_000), None, None);
+
+    let response = contract_instance
+        .initialize_counter(42) // Our contract method.
+        .tx_params(my_tx_params) // Chain the tx params setting method.
+        .call() // Perform the contract call.
+        .await?; // This is an async call, `.await` for it.
+
+    // ANCHOR_END: tx_parameters
+
+    // ANCHOR: call_parameters
+
+    let tx_params = TxParameters::default();
+
+    // Forward 1_000_000 coin amount of base asset_id
+    // this is a big number for checking that amount can be a u64
+    let call_params = CallParameters::new(Some(1_000_000), None);
+
+    let response = contract_instance
+        .get_msg_amount() // Our contract method.
+        .tx_params(tx_params) // Chain the tx params setting method.
+        .call_params(call_params) // Chain the call params setting method.
+        .call() // Perform the contract call.
+        .await?;
+    // ANCHOR_END: call_parameters
+    // ANCHOR: call_parameters_default
+    let response = contract_instance
+        .initialize_counter(42)
+        .call_params(CallParameters::default())
+        .call()
+        .await?;
+
+    // ANCHOR_END: call_parameters_default
+    Ok(())
+}
+
+#[tokio::test]
+#[allow(unused_variables)]
+async fn token_ops_tests() -> Result<(), Error> {
+    use fuels::prelude::*;
+    use fuels_abigen_macro::abigen;
+    abigen!(
+        MyContract,
+        "packages/fuels-abigen-macro/tests/test_projects/token_ops/out/debug/token_ops-abi\
+            .json"
+    );
+
+    let wallet = launch_provider_and_get_single_wallet().await;
+    let contract_id = Contract::deploy(
+        "../../packages/fuels-abigen-macro/tests/test_projects/token_ops/out/debug/token_ops\
+        .bin",
+        &wallet,
+        TxParameters::default(),
+    )
+    .await?;
+    println!("Contract deployed @ {:x}", contract_id);
+    let contract_instance = MyContract::new(contract_id.to_string(), wallet.clone());
+    // ANCHOR: simulate
+    // you would mint 100 coins if the transaction wasn't simulated
+    let counter = contract_instance.mint_coins(100).simulate().await?;
+    // ANCHOR_END: simulate
+    let response = contract_instance.mint_coins(1_000_000).call().await?;
+    // ANCHOR: variable_outputs
+    let address = wallet.address();
+
+    // withdraw some tokens to wallet
+    let response = contract_instance
+        .transfer_coins_to_output(1_000_000, contract_id, address)
+        .append_variable_outputs(1)
+        .call()
+        .await?;
+    // ANCHOR_END: variable_outputs
+    Ok(())
+}
+
+#[tokio::test]
+#[allow(unused_variables)]
+async fn get_contract_outputs() -> Result<(), Error> {
+    use fuels::prelude::Error::ContractCallError;
+    use fuels::prelude::*;
+    use fuels::tx::Receipt;
+    use fuels_abigen_macro::abigen;
+    abigen!(
+        TestContract,
+        "packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test-abi.json"
+    );
+    let wallet = launch_provider_and_get_single_wallet().await;
+    let contract_id = Contract::deploy(
+        "../../packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test\
+        .bin",
+        &wallet,
+        TxParameters::default(),
+    )
+        .await?;
+    let contract_instance = TestContract::new(contract_id.to_string(), wallet);
+
+    // ANCHOR: good_practice
+    let response = contract_instance.increment_counter(162).call().await?;
+    // ANCHOR_END: good_practice
+    // ANCHOR: contract_receipts
+    let response = contract_instance.increment_counter(162).call().await;
+    match response {
+        // The transaction is valid and executes to completion
+        Ok(call_response) => {
+            let logs: Vec<String> = call_response.logs;
+            let receipts: Vec<Receipt> = call_response.receipts;
+            // Do things with logs and receipts
+        }
+
+        // The transaction is invalid or node is offline
+        // OR
+        // The transaction is valid but reverts
+        Err(ContractCallError(reason, receipts)) => {
+            println!("ContractCall failed with reason: {}", reason);
+            println!("Transaction receipts are: {:?}", receipts);
+        }
+        Err(_) => {}
+    }
+    // ANCHOR_END: contract_receipts
+    // ANCHOR: deployed_contracts
+    // Replace with your contract ABI.json path
+    abigen!(
+        MyContract,
+        "packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test-abi.json"
+    );
+    let wallet = launch_provider_and_get_single_wallet().await;
+    // Your contract ID as a String.
+    let contract_id =
+        "0x068fe90ddc43b18a8f76756ecad8bf30eb0ceea33d2e6990c0185d01b0dbb675".to_string();
+
+    let connected_contract_instance = MyContract::new(contract_id, wallet);
+    // You can now use the `connected_contract_instance` just as you did above!
+    // ANCHOR_END: deployed_contracts
+    Ok(())
+}

--- a/examples/rust_bindings/Cargo.toml
+++ b/examples/rust_bindings/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "fuels-example-rust-bindings"
+version = "0.0.0"
+edition = "2021"
+publish = false
+authors = ["Fuel Labs <contact@fuel.sh>"]
+homepage = "https://fuel.network/"
+license = "Apache-2.0"
+repository = "https://github.com/FuelLabs/fuels-rs"
+description = "Fuel Rust SDK examples for Rust-native bindings"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+fuels = { version = "0.15.2", path = "../../packages/fuels" }
+fuels-abigen-macro = { version = "0.15.2", path = "../../packages/fuels-abigen-macro" }
+rand = "0.8"
+tokio = { version = "1.10", features = ["full"] }
+proc-macro2 = "1.0"

--- a/examples/rust_bindings/src/abi.json
+++ b/examples/rust_bindings/src/abi.json
@@ -1,0 +1,34 @@
+[
+  {
+    "type": "function",
+    "inputs": [
+      {
+        "name": "arg",
+        "type": "u64"
+      }
+    ],
+    "name": "initialize_counter",
+    "outputs": [
+      {
+        "name": "arg",
+        "type": "u64"
+      }
+    ]
+  },
+  {
+    "type": "function",
+    "inputs": [
+      {
+        "name": "arg",
+        "type": "u64"
+      }
+    ],
+    "name": "increment_counter",
+    "outputs": [
+      {
+        "name": "arg",
+        "type": "u64"
+      }
+    ]
+  }
+]

--- a/examples/rust_bindings/src/lib.rs
+++ b/examples/rust_bindings/src/lib.rs
@@ -1,0 +1,58 @@
+#[allow(unused_imports)]
+use fuels::prelude::Error;
+
+#[tokio::test]
+#[allow(unused_variables)]
+async fn transform_json_to_bindings() -> Result<(), Error> {
+    use fuels::test_helpers::launch_provider_and_get_single_wallet;
+    let wallet = launch_provider_and_get_single_wallet().await;
+    // ANCHOR: use_abigen
+    use fuels_abigen_macro::abigen;
+    // Replace with your own JSON abi path (relative to the root of your crate)
+    abigen!(MyContractName, "examples/rust_bindings/src/abi.json");
+    // ANCHOR_END: use_abigen
+
+    // ANCHOR: abigen_with_string
+    // Don't forget to import the `abigen` macro as above
+    abigen!(
+        MyContract,
+        r#"
+    [
+        {
+            "type": "function",
+            "inputs": [
+                {
+                    "name": "arg",
+                    "type": "u64"
+                }
+            ],
+            "name": "initialize_counter",
+            "outputs": [
+                {
+                    "name": "arg",
+                    "type": "u64"
+                }
+            ]
+        },
+        {
+            "type": "function",
+            "inputs": [
+                {
+                    "name": "arg",
+                    "type": "u64"
+                }
+            ],
+            "name": "increment_counter",
+            "outputs": [
+                {
+                    "name": "arg",
+                    "type": "u64"
+                }
+            ]
+        }
+    ]
+    "#
+    );
+    // ANCHOR_END: abigen_with_string
+    Ok(())
+}

--- a/examples/rust_bindings/src/rust_bindings_formatted.rs
+++ b/examples/rust_bindings/src/rust_bindings_formatted.rs
@@ -1,0 +1,37 @@
+pub struct MyContract {
+    contract_id: ContractId,
+    wallet: LocalWallet,
+}
+impl MyContract {
+    pub fn new(contract_id: String, wallet: LocalWallet) -> Self {
+        let contract_id = ContractId::from_str(&contract_id).expect("Invalid contract id");
+        Self {
+            contract_id,
+            wallet,
+        }
+    }
+    #[doc = "Calls the contract's `initialize_counter` (0x00000000ab64e5f2) function"]
+    pub fn initialize_counter(&self, arg: u64) -> ContractCallHandler<u64> {
+        Contract::method_hash(
+            &self.wallet.get_provider().expect("Provider not set up"),
+            self.contract_id,
+            &self.wallet,
+            [0, 0, 0, 0, 171, 100, 229, 242],
+            &[ParamType::U64],
+            &[arg.into_token()],
+        )
+        .expect("method not found (this should never happen)")
+    }
+    #[doc = "Calls the contract's `increment_counter` (0x00000000faf90dd3) function"]
+    pub fn increment_counter(&self, arg: u64) -> ContractCallHandler<u64> {
+        Contract::method_hash(
+            &self.wallet.get_provider().expect("Provider not set up"),
+            self.contract_id,
+            &self.wallet,
+            [0, 0, 0, 0, 250, 249, 13, 211],
+            &[ParamType::U64],
+            &[arg.into_token()],
+        )
+        .expect("method not found (this should never happen)")
+    }
+}

--- a/examples/wallets/src/lib.rs
+++ b/examples/wallets/src/lib.rs
@@ -128,3 +128,48 @@ async fn wallet_transfer() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(wallet_2_final_coins.len(), 2);
     Ok(())
 }
+
+#[tokio::test]
+#[allow(unused_variables)]
+async fn setup_multiple_wallets() {
+    // ANCHOR: multiple_wallets_helper
+    use fuels::prelude::*;
+    // This helper will launch a local node and provide 10 test wallets linked to it.
+    // The initial balance defaults to 1 coin per wallet with an amount of 1_000_000_000
+    let wallets = launch_provider_and_get_wallets(WalletsConfig::default()).await;
+    // ANCHOR_END: multiple_wallets_helper
+    // ANCHOR: setup_5_wallets
+    let num_wallets = 5;
+    let coins_per_wallet = 3;
+    let amount_per_coin = 100;
+
+    let config = WalletsConfig::new(
+        Some(num_wallets),
+        Some(coins_per_wallet),
+        Some(amount_per_coin),
+    );
+    // Launches a local node and provides test wallets as specified by the config
+    let wallets = launch_provider_and_get_wallets(config).await;
+    // ANCHOR_END: setup_5_wallets
+}
+
+#[tokio::test]
+#[allow(unused_variables)]
+async fn setup_wallet_multiple_assets() {
+    // ANCHOR: multiple_assets_wallet
+    use fuels::prelude::*;
+    let mut wallet = LocalWallet::new_random(None);
+    let num_assets = 5; // 5 different assets
+    let coins_per_asset = 10; // Per asset id, 10 coins in the wallet
+    let amount_per_coin = 15; // For each coin (UTXO) of the asset, amount of 15
+
+    let (coins, asset_ids) = setup_multiple_assets_coins(
+        wallet.address(),
+        num_assets,
+        coins_per_asset,
+        amount_per_coin,
+    );
+    let (provider, _socket_addr) = setup_test_provider(coins.clone(), Config::local_node()).await;
+    wallet.set_provider(provider);
+    // ANCHOR_END: multiple_assets_wallet
+}

--- a/examples/wallets/src/lib.rs
+++ b/examples/wallets/src/lib.rs
@@ -1,3 +1,6 @@
+#[allow(unused_imports)]
+use fuels::prelude::ProviderError;
+
 #[tokio::test]
 // ANCHOR: create_random_wallet
 async fn create_random_wallet() {
@@ -172,4 +175,22 @@ async fn setup_wallet_multiple_assets() {
     let (provider, _socket_addr) = setup_test_provider(coins.clone(), Config::local_node()).await;
     wallet.set_provider(provider);
     // ANCHOR_END: multiple_assets_wallet
+}
+
+#[tokio::test]
+#[allow(unused_variables)]
+async fn get_balances() -> Result<(), ProviderError> {
+    use fuels::prelude::{launch_provider_and_get_single_wallet, BASE_ASSET_ID};
+    use fuels::tx::AssetId;
+    use std::collections::HashMap;
+
+    let wallet = launch_provider_and_get_single_wallet().await;
+    // ANCHOR: get_asset_balance
+    let asset_id: AssetId = BASE_ASSET_ID;
+    let balance: u64 = wallet.get_asset_balance(&asset_id).await?;
+    // ANCHOR_END: get_asset_balance
+    // ANCHOR: get_balances
+    let balances: HashMap<String, u64> = wallet.get_balances().await?;
+    // ANCHOR_END: get_balances
+    Ok(())
 }

--- a/examples/wallets/src/lib.rs
+++ b/examples/wallets/src/lib.rs
@@ -172,7 +172,7 @@ async fn setup_wallet_multiple_assets() {
         coins_per_asset,
         amount_per_coin,
     );
-    let (provider, _socket_addr) = setup_test_provider(coins.clone(), Config::local_node()).await;
+    let (provider, _socket_addr) = setup_test_provider(coins.clone(), None).await;
     wallet.set_provider(provider);
     // ANCHOR_END: multiple_assets_wallet
 }

--- a/packages/fuels-abigen-macro/tests/harness.rs
+++ b/packages/fuels-abigen-macro/tests/harness.rs
@@ -55,7 +55,8 @@ async fn compile_bindings_from_contract_file() {
 }
 
 #[tokio::test]
-async fn compile_bindings_from_inline_contract() {
+async fn compile_bindings_from_inline_contract() -> Result<(), Error> {
+    // ANCHOR: bindings_from_inline_contracts
     // Generates the bindings from the an ABI definition inline.
     // The generated bindings can be accessed through `SimpleContract`.
     abigen!(
@@ -95,6 +96,8 @@ async fn compile_bindings_from_inline_contract() {
     );
 
     assert_eq!("000000009593586c000000000000002a", encoded);
+    // ANCHOR_END: bindings_from_inline_contracts
+    Ok(())
 }
 
 #[tokio::test]

--- a/packages/fuels-abigen-macro/tests/harness.rs
+++ b/packages/fuels-abigen-macro/tests/harness.rs
@@ -970,7 +970,7 @@ async fn test_provider_launch_and_connect() {
 }
 
 #[tokio::test]
-async fn test_contract_calling_contract() {
+async fn test_contract_calling_contract() -> Result<(), Error> {
     // Tests a contract call that calls another contract (FooCaller calls FooContract underneath)
     abigen!(
         FooContract,
@@ -1018,14 +1018,16 @@ async fn test_contract_calling_contract() {
 
     // Calls the contract that calls the `FooContract` contract, also just
     // flips the bool value passed to it.
+    // ANCHOR: external_contract
     let res = foo_caller_contract_instance
         .call_foo_contract(*foo_contract_id, true)
         .set_contracts(&[foo_contract_id]) // Sets the external contract
         .call()
-        .await
-        .unwrap();
+        .await?;
+    // ANCHOR_END: external_contract
 
     assert!(!res.value);
+    Ok(())
 }
 
 #[tokio::test]

--- a/packages/fuels-abigen-macro/tests/test_projects/contract_test/src/main.sw
+++ b/packages/fuels-abigen-macro/tests/test_projects/contract_test/src/main.sw
@@ -3,6 +3,7 @@ contract;
 use std::*;
 use core::*;
 use std::storage::*;
+use std::context::msg_amount;
 
 struct MyType {
     x: u64,
@@ -29,11 +30,18 @@ abi TestContract {
     fn array_of_structs(p: [Person; 2]) -> [Person; 2];
     fn array_of_enums(p: [State; 2]) -> [State; 2];
     fn get_array(p: [u64; 2]) -> [u64; 2];
+    fn get_msg_amount() -> u64;
 }
 
 const COUNTER_KEY = 0x0000000000000000000000000000000000000000000000000000000000000000;
 
 impl TestContract for Contract {
+    // ANCHOR: msg_amount
+    fn get_msg_amount() -> u64 {
+        msg_amount()
+    }
+    // ANCHOR_END: msg_amount
+
     fn initialize_counter(value: u64) -> u64 {
         store(COUNTER_KEY, value);
         value

--- a/packages/fuels-abigen-macro/tests/test_projects/token_ops/src/main.sw
+++ b/packages/fuels-abigen-macro/tests/test_projects/token_ops/src/main.sw
@@ -24,9 +24,11 @@ impl TestFuelCoin for Contract {
         force_transfer_to_contract(coins, asset_id, target);
     }
 
+    // ANCHOR: variable_outputs
     fn transfer_coins_to_output(coins: u64, asset_id: ContractId, recipient: Address) {
         transfer_to_output(coins, asset_id, recipient);
     }
+    // ANCHOR_END: variable_outputs
 
     fn get_balance(target: ContractId, asset_id: ContractId) -> u64 {
         balance_of(target, asset_id)

--- a/packages/fuels-contract/src/contract.rs
+++ b/packages/fuels-contract/src/contract.rs
@@ -35,11 +35,13 @@ pub struct Contract {
 /// holds the decoded typed value returned by the contract's method. The other field
 /// holds all the receipts returned by the call.
 #[derive(Debug)]
+// ANCHOR: call_response
 pub struct CallResponse<D> {
     pub value: D,
     pub receipts: Vec<Receipt>,
     pub logs: Vec<String>,
 }
+// ANCHOR_END: call_response
 
 impl<D> CallResponse<D> {
     pub fn new(value: D, receipts: Vec<Receipt>) -> Self {

--- a/packages/fuels-core/src/constants.rs
+++ b/packages/fuels-core/src/constants.rs
@@ -1,17 +1,21 @@
 use fuel_tx::Word;
 use fuel_types::AssetId;
 
+// ANCHOR: default_tx_parameters
 pub const DEFAULT_GAS_LIMIT: u64 = 1_000_000;
 pub const DEFAULT_GAS_PRICE: u64 = 0;
 pub const DEFAULT_BYTE_PRICE: u64 = 0;
 pub const DEFAULT_MATURITY: u64 = 0;
+// ANCHOR_END: default_tx_parameters
 
 pub const WORD_SIZE: usize = core::mem::size_of::<Word>();
 pub const ENUM_DISCRIMINANT_WORD_WIDTH: usize = 1;
 
+// ANCHOR: default_call_parameters
 // This constant is used as the lower limit when querying spendable UTXOs
 pub const DEFAULT_SPENDABLE_COIN_AMOUNT: u64 = 1_000_000;
 
 // This constant is the bytes representation of the asset ID of
 // the "base" asset used for gas fees.
 pub const BASE_ASSET_ID: AssetId = AssetId::new([0u8; 32]);
+// ANCHOR_END: default_call_parameters

--- a/packages/fuels-signers/src/provider.rs
+++ b/packages/fuels-signers/src/provider.rs
@@ -102,7 +102,7 @@ impl Provider {
 
     /// Get some spendable coins of asset `asset_id` for address `from` that add up at least to
     /// amount `amount`. The returned coins (UTXOs) are actual coins that can be spent. The number
-    /// of coins (UXTOs) is minimized via an approximate solution.
+    /// of coins (UXTOs) is optimized to prevent dust accumulation.
     pub async fn get_spendable_coins(
         &self,
         from: &Address,

--- a/packages/fuels-signers/src/wallet.rs
+++ b/packages/fuels-signers/src/wallet.rs
@@ -335,7 +335,7 @@ impl Wallet {
 
     /// Get some spendable coins of asset `asset_id` owned by the wallet that add up at least to
     /// amount `amount`. The returned coins (UTXOs) are actual coins that can be spent. The number
-    /// of coins (UXTOs) is minimized via an approximate solution.
+    /// of coins (UXTOs) is optimized to prevent dust accumulation.
     pub async fn get_spendable_coins(
         &self,
         asset_id: &AssetId,

--- a/packages/fuels-test-helpers/src/script.rs
+++ b/packages/fuels-test-helpers/src/script.rs
@@ -57,7 +57,7 @@ fn get_script(script_binary: Vec<u8>) -> Script {
 
 #[cfg(test)]
 mod tests {
-    use crate::run_compiled_script;
+    use crate::script::run_compiled_script;
     use fuels_core::errors::Error;
 
     #[tokio::test]

--- a/packages/fuels-test-helpers/src/script.rs
+++ b/packages/fuels-test-helpers/src/script.rs
@@ -45,6 +45,6 @@ mod tests {
 
         assert_eq!(correct_hex.unwrap(), return_val[0].data().unwrap());
         // ANCHOR_END: run_compiled_script
-        return Ok(());
+        Ok(())
     }
 }

--- a/packages/fuels-test-helpers/src/script.rs
+++ b/packages/fuels-test-helpers/src/script.rs
@@ -32,17 +32,19 @@ pub async fn run_compiled_script(binary_filepath: &str) -> Result<Vec<Receipt>, 
 #[cfg(test)]
 mod tests {
     use crate::run_compiled_script;
+    use fuels_core::errors::Error;
 
     #[tokio::test]
-    // ANCHOR: run_compiled_script
-    async fn test_run_compiled_script() {
+    async fn test_run_compiled_script() -> Result<(), Error> {
+        // ANCHOR: run_compiled_script
         let path_to_bin = "../fuels-abigen-macro/tests/test_projects/logging/out/debug/logging.bin";
-        let return_val = run_compiled_script(path_to_bin).await;
+        let return_val = run_compiled_script(path_to_bin).await?;
 
         let correct_hex =
             hex::decode("ef86afa9696cf0dc6385e2c407a6e159a1103cefb7e2ae0636fb33d3cb2a9e4a");
 
-        assert_eq!(correct_hex.unwrap(), return_val.unwrap()[0].data().unwrap());
+        assert_eq!(correct_hex.unwrap(), return_val[0].data().unwrap());
+        // ANCHOR_END: run_compiled_script
+        return Ok(());
     }
-    // ANCHOR_END: run_compiled_script
 }


### PR DESCRIPTION
This PR closes #342.
- All examples in `The Book` now use the `examples` directory. Some
  reorganization of that structure might/should happen down the road, but for
  now the idea is to just move forward with using only tested code in `The
  Book`.
  
Apologies in advance, this PR will probably be *hell* to review because there are snippets distributed everywhere lol :sweat_smile: 
