### PR TITLE
build: bump `fuel-core` and `fuel-gql-client` to `0.9`

### DIFF
--- a/packages/fuels-abigen-macro/Cargo.toml
+++ b/packages/fuels-abigen-macro/Cargo.toml
@@ -20,8 +20,8 @@ syn = "1.0.12"
 
 [dev-dependencies]
 ctor = " 0.1"
-fuel-core = { version = "0.8", default-features = false }
-fuel-gql-client = { version = "0.8", default-features = false }
+fuel-core = { version = "0.9", default-features = false }
+fuel-gql-client = { version = "0.9", default-features = false }
 fuels = { path = "../fuels", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 sha2 = "0.9.5"

--- a/packages/fuels-contract/Cargo.toml
+++ b/packages/fuels-contract/Cargo.toml
@@ -11,7 +11,7 @@ description = "Fuel Rust SDK contracts."
 [dependencies]
 anyhow = "1"
 bytes = { version = "1.0.1", features = ["serde"] }
-fuel-gql-client = { version = "0.8", default-features = false }
+fuel-gql-client = { version = "0.9", default-features = false }
 fuels-core = { version = "0.15.3", path = "../fuels-core" }
 fuels-signers = { version = "0.15.3", path = "../fuels-signers" }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }

--- a/packages/fuels-signers/Cargo.toml
+++ b/packages/fuels-signers/Cargo.toml
@@ -15,9 +15,9 @@ coins-bip32 = "0.6.0"
 coins-bip39 = "0.6.0"
 elliptic-curve = { version = "0.11.6", default-features = false }
 eth-keystore = { version = "0.3.0" }
-fuel-core = { version = "0.8", default-features = false, optional = true }
+fuel-core = { version = "0.9", default-features = false, optional = true }
 fuel-crypto = { version = "0.5", features = ["random"] }
-fuel-gql-client = { version = "0.8", default-features = false }
+fuel-gql-client = { version = "0.9", default-features = false }
 fuels-core = { version = "0.15.3", path = "../fuels-core" }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 rand = { version = "0.8.4", default-features = false }

--- a/packages/fuels-test-helpers/Cargo.toml
+++ b/packages/fuels-test-helpers/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/FuelLabs/fuels-rs"
 description = "Fuel Rust SDK test helpers."
 
 [dependencies]
-fuel-core = { version = "0.8", default-features = false, optional = true }
-fuel-core-interfaces = { version = "0.8", default-features = false }
-fuel-gql-client = { version = "0.8", default-features = false }
+fuel-core = { version = "0.9", default-features = false, optional = true }
+fuel-core-interfaces = { version = "0.9", default-features = false }
+fuel-gql-client = { version = "0.9", default-features = false }
 fuel-types = { version = "0.5", default-features = false, features = ["random"] }
 fuels-contract = { version = "0.15.3", path = "../fuels-contract" }
 fuels-core = { version = "0.15.3", path = "../fuels-core" }

--- a/packages/fuels/Cargo.toml
+++ b/packages/fuels/Cargo.toml
@@ -10,8 +10,8 @@ rust-version = "1.61.0"
 description = "Fuel Rust SDK."
 
 [dependencies]
-fuel-core = { version = "0.8", default-features = false, optional = true }
-fuel-gql-client = { version = "0.8", default-features = false }
+fuel-core = { version = "0.9", default-features = false, optional = true }
+fuel-gql-client = { version = "0.9", default-features = false }
 fuels-abigen-macro = { version = "0.15.3", path = "../fuels-abigen-macro" }
 fuels-contract = { version = "0.15.3", path = "../fuels-contract" }
 fuels-core = { version = "0.15.3", path = "../fuels-core" }


### PR DESCRIPTION
Closes #402.
