### PR TITLE
Encoding of an enum with all unit variants (#390)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
   RUSTFLAGS: "-D warnings"
   RUST_VERSION: 1.61.0
-  FORC_VERSION: 0.15.2
+  FORC_VERSION: 0.16.0
 
 jobs:
   cancel-previous-runs:

--- a/packages/fuels-abigen-macro/tests/test_projects/call_empty_return/src/main.sw
+++ b/packages/fuels-abigen-macro/tests/test_projects/call_empty_return/src/main.sw
@@ -4,12 +4,14 @@ use std::storage::store;
 use std::storage::get;
 
 abi TestContract {
+  #[storage(write)]
   fn store_value(val: u64);
 }
 
 const COUNTER_KEY = 0x0000000000000000000000000000000000000000000000000000000000000000;
 
 impl TestContract for Contract {
+  #[storage(write)]
   fn store_value(val: u64) {
     store(COUNTER_KEY, val);
   }

--- a/packages/fuels-abigen-macro/tests/test_projects/complex_types_contract/src/main.sw
+++ b/packages/fuels-abigen-macro/tests/test_projects/complex_types_contract/src/main.sw
@@ -9,18 +9,23 @@ struct CounterConfig {
 }
 
 abi TestContract {
+  #[storage(write)]
   fn initialize_counter(config: CounterConfig) -> u64;
+  #[storage(read, write)]
   fn increment_counter(amount: u64) -> u64;
 }
 
 const COUNTER_KEY = 0x0000000000000000000000000000000000000000000000000000000000000000;
 
 impl TestContract for Contract {
+  #[storage(write)]
   fn initialize_counter(config: CounterConfig) -> u64 {
     let value = config.initial_value;
     store(COUNTER_KEY, value);
     value
   }
+
+  #[storage(read, write)]
   fn increment_counter(amount: u64) -> u64 {
     let value = get::<u64>(COUNTER_KEY) + amount;
     store(COUNTER_KEY, value);

--- a/packages/fuels-abigen-macro/tests/test_projects/contract_test/src/main.sw
+++ b/packages/fuels-abigen-macro/tests/test_projects/contract_test/src/main.sw
@@ -21,8 +21,11 @@ enum State {
 }
 
 abi TestContract {
+    #[storage(write)]
     fn initialize_counter(value: u64) -> u64;
+    #[storage(read, write)]
     fn increment_counter(value: u64) -> u64;
+    #[storage(read)]
     fn get_counter() -> u64;
     fn get(x: u64, y: u64) -> u64;
     fn get_alt(x: MyType) -> MyType;
@@ -42,17 +45,20 @@ impl TestContract for Contract {
     }
     // ANCHOR_END: msg_amount
 
+    #[storage(write)]
     fn initialize_counter(value: u64) -> u64 {
         store(COUNTER_KEY, value);
         value
     }
 
+    #[storage(read, write)]
     fn increment_counter(value: u64) -> u64 {
         let new_value = get::<u64>(COUNTER_KEY) + value;
         store(COUNTER_KEY, new_value);
         new_value
     }
 
+    #[storage(read)]
     fn get_counter() -> u64 {
         get::<u64>(COUNTER_KEY)
     }

--- a/packages/fuels-abigen-macro/tests/test_projects/enum_encoding/src/main.sw
+++ b/packages/fuels-abigen-macro/tests/test_projects/enum_encoding/src/main.sw
@@ -5,29 +5,42 @@ enum EnumThatHasABigAndSmallVariant {
     Small: u32,
 }
 
-struct Bundle {
+struct BigBundle {
     arg_1: EnumThatHasABigAndSmallVariant,
     arg_2: u64,
     arg_3: u64,
     arg_4: u64,
 }
 
+enum UnitEnum {
+    var1: (),
+    var2: (),
+}
+
+struct UnitBundle {
+    arg_1: UnitEnum,
+    arg_2: u64,
+}
+
 abi EnumTesting {
-    fn get_bundle() -> Bundle;
-    fn check_bundle_integrity(arg: Bundle) -> bool;
+    fn get_big_bundle() -> BigBundle;
+    fn check_big_bundle_integrity(arg: BigBundle) -> bool;
+
+    fn get_unit_bundle() -> UnitBundle;
+    fn check_unit_bundle_integrity(arg: UnitBundle) -> bool;
 }
 
 impl EnumTesting for Contract {
-    fn get_bundle() -> Bundle {
+    fn get_big_bundle() -> BigBundle {
         let arg_1 = EnumThatHasABigAndSmallVariant::Small(12345);
         let arg_2 = 6666;
         let arg_3 = 7777;
         let arg_4 = 8888;
-        Bundle {
+        BigBundle {
             arg_1, arg_2, arg_3, arg_4
         }
     }
-    fn check_bundle_integrity(arg: Bundle) -> bool {
+    fn check_big_bundle_integrity(arg: BigBundle) -> bool {
         let arg_1_is_correct = match arg.arg_1 {
             EnumThatHasABigAndSmallVariant::Small(value) => {
                 value == 12345u32
@@ -36,5 +49,19 @@ impl EnumTesting for Contract {
         };
 
         arg_1_is_correct && arg.arg_2 == 6666 && arg.arg_3 == 7777 && arg.arg_4 == 8888
+    }
+
+    fn get_unit_bundle() -> UnitBundle {
+        UnitBundle {
+            arg_1: UnitEnum::var2(),
+            arg_2: 18_446_744_073_709_551_615u64,
+        }
+    }
+    fn check_unit_bundle_integrity(arg: UnitBundle) -> bool {
+        let arg_1_is_correct = match arg.arg_1 {
+            UnitEnum::var2(_) => true, _ => false, 
+        };
+
+        arg_1_is_correct && arg.arg_2 == 18_446_744_073_709_551_615u64
     }
 }

--- a/packages/fuels-abigen-macro/tests/test_projects/foo_caller_contract/src/main.sw
+++ b/packages/fuels-abigen-macro/tests/test_projects/foo_caller_contract/src/main.sw
@@ -1,7 +1,7 @@
 contract;
 
 use foo::FooContract;
-use std::constants::NATIVE_ASSET_ID;
+use std::constants::BASE_ASSET_ID;
 use std::contract_id::ContractId;
 
 abi FooCaller {
@@ -12,7 +12,7 @@ impl FooCaller for Contract {
     fn call_foo_contract(target: b256, value: bool) -> bool {
         let foo_contract = abi(FooContract, target);
         let response = foo_contract.foo {
-            gas: 10000, coins: 0, asset_id: NATIVE_ASSET_ID
+            gas: 10000, coins: 0, asset_id: BASE_ASSET_ID
         }
         (value);
 

--- a/packages/fuels-abigen-macro/tests/test_projects/multiple_read_calls/src/main.sw
+++ b/packages/fuels-abigen-macro/tests/test_projects/multiple_read_calls/src/main.sw
@@ -4,17 +4,21 @@ use std::storage::store;
 use std::storage::get;
 
 abi MyContract {
+    #[storage(write)]
     fn store(input: u64);
+    #[storage(read)]
     fn read(input: u64) -> u64;
 }
 
 const COUNTER_KEY = 0x0000000000000000000000000000000000000000000000000000000000000000;
 
 impl MyContract for Contract {
+    #[storage(write)]
     fn store(input: u64) {
         store(COUNTER_KEY, input);
     }
 
+    #[storage(read)]
     fn read(input: u64) -> u64 {
         let v = get::<u64>(COUNTER_KEY);
         v

--- a/packages/fuels-abigen-macro/tests/test_projects/nested_enums/src/main.sw
+++ b/packages/fuels-abigen-macro/tests/test_projects/nested_enums/src/main.sw
@@ -1,12 +1,6 @@
 contract;
 
-use std::{
-    address::Address,
-    constants::NATIVE_ASSET_ID,
-    identity::Identity,
-    option::Option,
-};
-
+use std::{address::Address, constants::BASE_ASSET_ID, identity::Identity, option::Option};
 
 enum EnumLevel1 {
     Num: u32,
@@ -23,7 +17,6 @@ enum EnumLevel3 {
     Num: u8,
 }
 
-
 abi MyContract {
     fn get_nested_enum() -> EnumLevel3;
     fn check_nested_enum_integrity(e: EnumLevel3) -> bool;
@@ -33,7 +26,7 @@ abi MyContract {
 
 impl MyContract for Contract {
     fn get_nested_enum() -> EnumLevel3 {
-       EnumLevel3::El2(EnumLevel2::El1(EnumLevel1::Num(42)))
+        EnumLevel3::El2(EnumLevel2::El1(EnumLevel1::Num(42)))
     }
 
     fn check_nested_enum_integrity(e: EnumLevel3) -> bool {
@@ -41,14 +34,14 @@ impl MyContract for Contract {
             EnumLevel3::El2(EnumLevel2::El1(EnumLevel1::Num(value))) => {
                 value == 42u32
             },
-            _ => false,
+            _ => false, 
         };
 
         arg_is_correct
     }
 
     fn get_some_address() -> Option<Identity> {
-        Option::Some(Identity::Address(~Address::from(NATIVE_ASSET_ID)))
+        Option::Some(Identity::Address(~Address::from(BASE_ASSET_ID)))
     }
 
     fn get_none() -> Option<Identity> {

--- a/packages/fuels-contract/src/contract.rs
+++ b/packages/fuels-contract/src/contract.rs
@@ -97,9 +97,7 @@ impl Contract {
         output_param: Option<ParamType>,
         args: &[Token],
     ) -> Result<ContractCallHandler<D>, Error> {
-        let mut encoder = ABIEncoder::new();
-
-        let encoded_args = encoder.encode(args).unwrap();
+        let encoded_args = ABIEncoder::encode(args).unwrap();
         let encoded_selector = signature;
 
         let tx_parameters = TxParameters::default();

--- a/packages/fuels-core/src/abi_decoder.rs
+++ b/packages/fuels-core/src/abi_decoder.rs
@@ -188,7 +188,7 @@ impl ABIDecoder {
     }
 
     /// The encoding follows the ABI specs defined
-    /// [here](https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md)
+    /// [here](https://github.com/FuelLabs/fuel-specs/blob/1be31f70c757d8390f74b9e1b3beb096620553eb/specs/protocol/abi.md)
     ///
     /// # Arguments
     ///

--- a/packages/fuels-core/src/abi_decoder.rs
+++ b/packages/fuels-core/src/abi_decoder.rs
@@ -619,7 +619,7 @@ mod tests {
     fn out_of_bounds_discriminant_is_detected() {
         let data = [0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2];
         let variants = EnumVariants::new(vec![ParamType::U32]).unwrap();
-        let enum_type = ParamType::Enum(variants.clone());
+        let enum_type = ParamType::Enum(variants);
 
         let result = ABIDecoder::decode_single(&enum_type, &data);
 

--- a/packages/fuels-core/src/abi_encoder.rs
+++ b/packages/fuels-core/src/abi_encoder.rs
@@ -6,7 +6,6 @@ use crate::{
     ParamType, Token,
 };
 use sha2::{Digest, Sha256};
-use std::slice;
 
 pub struct ABIEncoder {
     buffer: Vec<u8>,
@@ -126,7 +125,7 @@ impl ABIEncoder {
         if !variants.only_units_inside() {
             let param_type = Self::type_of_chosen_variant(discriminant, variants)?;
             self.encode_enum_padding(variants, param_type);
-            self.encode_tokens(slice::from_ref(token_within_enum))?;
+            self.encode_token(token_within_enum)?;
         }
 
         Ok(())
@@ -173,6 +172,7 @@ impl ABIEncoder {
 mod tests {
     use super::*;
     use crate::{EnumVariants, ParamType};
+    use std::slice;
 
     #[test]
     fn encode_function_signature() {

--- a/packages/fuels-core/src/abi_encoder.rs
+++ b/packages/fuels-core/src/abi_encoder.rs
@@ -12,7 +12,7 @@ pub struct ABIEncoder {
 }
 
 impl ABIEncoder {
-    /// Encodes the function selector followin the ABI specs defined  ///
+    /// Encodes the function selector following the ABI specs defined  ///
     /// [here](https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md)
     pub fn encode_function_selector(fn_selector: &str) -> ByteArray {
         let signature = fn_selector.as_bytes();

--- a/packages/fuels-core/src/abi_encoder.rs
+++ b/packages/fuels-core/src/abi_encoder.rs
@@ -2,99 +2,136 @@ use crate::constants::{ENUM_DISCRIMINANT_WORD_WIDTH, WORD_SIZE};
 use crate::encoding_utils::{compute_encoding_width, compute_encoding_width_of_enum};
 use crate::errors::CodecError;
 use crate::{
-    pad_string, pad_u16, pad_u32, pad_u8, ByteArray, EnumSelector, EnumVariants, ParamType, Token,
+    pad_string, pad_u16, pad_u32, pad_u8, Bits256, ByteArray, EnumSelector, EnumVariants,
+    ParamType, Token,
 };
 use sha2::{Digest, Sha256};
 use std::slice;
 
-pub struct ABIEncoder {
-    pub function_selector: ByteArray,
-    pub encoded_args: Vec<u8>,
-}
+pub struct ABIEncoder;
 
 impl ABIEncoder {
-    pub fn new() -> Self {
-        Self {
-            function_selector: [0; 8],
-            encoded_args: Vec::new(),
-        }
-    }
-
-    pub fn new_with_fn_selector(signature: &[u8]) -> Self {
-        Self {
-            function_selector: Self::encode_function_selector(signature),
-            encoded_args: Vec::new(),
-        }
+    pub fn encode_function_selector(fn_selector: &str) -> ByteArray {
+        let signature = fn_selector.as_bytes();
+        let mut hasher = Sha256::new();
+        hasher.update(signature);
+        let result = hasher.finalize();
+        let mut output = ByteArray::default();
+        (&mut output[4..]).copy_from_slice(&result[..4]);
+        output
     }
 
     /// Encode takes an array of `Token`s, encodes these tokens, and returns the
     /// raw bytes (as a Vec<u8>) that represent the encoded tokens.
     /// The encoding follows the ABI specs defined
     /// [here](https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md)
-    pub fn encode(&mut self, args: &[Token]) -> Result<Vec<u8>, CodecError> {
+    pub fn encode(args: &[Token]) -> Result<Vec<u8>, CodecError> {
+        let mut encoded = vec![];
         for arg in args {
-            match arg {
-                Token::U8(arg_u8) => self.encoded_args.extend(pad_u8(arg_u8)),
-                Token::U16(arg_u16) => self.encoded_args.extend(pad_u16(arg_u16)),
-                Token::U32(arg_u32) => self.encoded_args.extend(pad_u32(arg_u32)),
-                Token::U64(arg_u64) => self.encoded_args.extend(arg_u64.to_be_bytes()),
-                Token::Byte(arg_byte) => self.encoded_args.extend(pad_u8(arg_byte)),
-                Token::Bool(arg_bool) => {
-                    self.encoded_args
-                        .extend(pad_u8(if *arg_bool { &1 } else { &0 }))
-                }
-                Token::B256(arg_bits256) => self.encoded_args.extend(arg_bits256),
-                Token::Array(arg_array) => {
-                    // Recursively encode the array of Tokens
-                    self.encode(arg_array)?;
-                }
-                Token::String(arg_string) => self.encoded_args.extend(pad_string(arg_string)),
-                Token::Struct(arg_struct) => {
-                    for property in arg_struct.iter() {
-                        self.encode(slice::from_ref(property))?;
-                    }
-                }
-                Token::Enum(arg_enum) => {
-                    self.encode_enum(arg_enum)?;
-                }
-                Token::Tuple(arg_tuple) => {
-                    self.encode(arg_tuple)?;
-                }
-                Token::Unit => {
-                    self.rightpad_with_zeroes(WORD_SIZE);
-                }
-            };
+            encoded.extend(Self::encode_token(arg)?);
         }
-        Ok(self.encoded_args.clone())
+        Ok(encoded)
+    }
+
+    fn encode_token(arg: &Token) -> Result<Vec<u8>, CodecError> {
+        Ok(match arg {
+            Token::U8(arg_u8) => Self::encode_u8(arg_u8),
+            Token::U16(arg_u16) => Self::encode_u16(arg_u16),
+            Token::U32(arg_u32) => Self::encode_u32(arg_u32),
+            Token::U64(arg_u64) => Self::encode_u64(arg_u64),
+            Token::Byte(arg_byte) => Self::encode_byte(arg_byte),
+            Token::Bool(arg_bool) => Self::encode_bool(arg_bool),
+            Token::B256(arg_bits256) => Self::encode_b256(arg_bits256),
+            Token::Array(arg_array) => Self::encode_array(arg_array)?,
+            Token::String(arg_string) => Self::encode_string(arg_string),
+            Token::Struct(arg_struct) => Self::encode_struct(arg_struct)?,
+            Token::Enum(arg_enum) => Self::encode_enum(arg_enum)?,
+            Token::Tuple(arg_tuple) => Self::encode_tuple(arg_tuple)?,
+            Token::Unit => Self::encode_unit(),
+        })
+    }
+
+    fn encode_unit() -> Vec<u8> {
+        vec![0; WORD_SIZE]
+    }
+
+    fn encode_tuple(arg_tuple: &[Token]) -> Result<Vec<u8>, CodecError> {
+        Self::encode(arg_tuple)
+    }
+
+    fn encode_struct(arg_struct: &[Token]) -> Result<Vec<u8>, CodecError> {
+        let mut data = vec![];
+        for property in arg_struct.iter() {
+            data.extend(Self::encode(slice::from_ref(property))?);
+        }
+        Ok(data)
+    }
+
+    fn encode_string(arg_string: &str) -> Vec<u8> {
+        pad_string(arg_string)
+    }
+
+    fn encode_array(arg_array: &[Token]) -> Result<Vec<u8>, CodecError> {
+        // Recursively encode the array of Tokens
+        Self::encode(arg_array)
+    }
+
+    fn encode_b256(arg_bits256: &Bits256) -> Vec<u8> {
+        arg_bits256.to_vec()
+    }
+
+    fn encode_bool(arg_bool: &bool) -> Vec<u8> {
+        pad_u8(if *arg_bool { &1 } else { &0 }).to_vec()
+    }
+
+    fn encode_byte(arg_byte: &u8) -> Vec<u8> {
+        pad_u8(arg_byte).to_vec()
+    }
+
+    fn encode_u64(arg_u64: &u64) -> Vec<u8> {
+        arg_u64.to_be_bytes().to_vec()
+    }
+
+    fn encode_u32(arg_u32: &u32) -> Vec<u8> {
+        pad_u32(arg_u32).to_vec()
+    }
+
+    fn encode_u16(arg_u16: &u16) -> Vec<u8> {
+        pad_u16(arg_u16).to_vec()
+    }
+
+    fn encode_u8(arg_u8: &u8) -> Vec<u8> {
+        pad_u8(arg_u8).to_vec()
     }
 
     /// The encoding follows the ABI specs defined
     /// [here](https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md)
-    fn encode_enum(&mut self, selector: &EnumSelector) -> Result<(), CodecError> {
+    fn encode_enum(selector: &EnumSelector) -> Result<Vec<u8>, CodecError> {
         let (discriminant, token_within_enum, variants) = selector;
 
-        self.encode_discriminant(discriminant);
+        let mut data = vec![];
+        data.extend(Self::encode_discriminant(discriminant));
 
         // The sway compiler has an optimization for enums which have only Units
         // as variants -- such an enum is encoded only by encoding its
         // discriminant.
         if !variants.only_units_inside() {
             let param_type = Self::type_of_chosen_variant(discriminant, variants)?;
-            self.add_enum_padding(variants, param_type);
-            self.encode(slice::from_ref(token_within_enum))?;
+            data.extend(Self::add_enum_padding(variants, param_type));
+            data.extend(Self::encode(slice::from_ref(token_within_enum))?);
         }
 
-        Ok(())
+        Ok(data)
     }
 
-    fn add_enum_padding(&mut self, variants: &EnumVariants, param_type: &ParamType) {
+    fn add_enum_padding(variants: &EnumVariants, param_type: &ParamType) -> Vec<u8> {
         let biggest_variant_width =
             compute_encoding_width_of_enum(variants) - ENUM_DISCRIMINANT_WORD_WIDTH;
         let variant_width = compute_encoding_width(param_type);
 
         let padding_amount = (biggest_variant_width - variant_width) * WORD_SIZE;
 
-        self.rightpad_with_zeroes(padding_amount);
+        Self::rightpad_with_zeroes(padding_amount)
     }
 
     fn type_of_chosen_variant<'a>(
@@ -116,32 +153,13 @@ impl ABIEncoder {
             })
     }
 
-    fn encode_discriminant(&mut self, discriminant: &u8) {
-        self.encoded_args.extend(pad_u8(discriminant));
+    fn encode_discriminant(discriminant: &u8) -> Vec<u8> {
+        pad_u8(discriminant).to_vec()
     }
 
     /// Will append `amount` number of zeroes to the internal buffer, right-padding it
-    fn rightpad_with_zeroes(&mut self, amount: usize) {
-        self.encoded_args
-            .resize(self.encoded_args.len() + amount, 0);
-    }
-
-    pub fn encode_function_selector(signature: &[u8]) -> ByteArray {
-        let mut hasher = Sha256::new();
-        hasher.update(signature);
-        let result = hasher.finalize();
-
-        let mut output = ByteArray::default();
-
-        (&mut output[4..]).copy_from_slice(&result[..4]);
-
-        output
-    }
-}
-
-impl Default for ABIEncoder {
-    fn default() -> Self {
-        Self::new()
+    fn rightpad_with_zeroes(amount: usize) -> Vec<u8> {
+        vec![0; amount]
     }
 }
 
@@ -154,7 +172,7 @@ mod tests {
     fn encode_function_signature() {
         let sway_fn = "entry_one(u64)";
 
-        let result = ABIEncoder::encode_function_selector(sway_fn.as_bytes());
+        let result = ABIEncoder::encode_function_selector(sway_fn);
 
         println!(
             "Encoded function selector for ({}): {:#0x?}",
@@ -187,14 +205,14 @@ mod tests {
 
         let expected_function_selector = [0x0, 0x0, 0x0, 0x0, 0xb7, 0x9e, 0xf7, 0x43];
 
-        let mut abi_encoder = ABIEncoder::new_with_fn_selector(sway_fn.as_bytes());
+        let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = abi_encoder.encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args).unwrap();
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
-        assert_eq!(abi_encoder.function_selector, expected_function_selector);
+        assert_eq!(encoded_function_selector, expected_function_selector);
     }
 
     #[test]
@@ -221,16 +239,15 @@ mod tests {
             0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xff, 0xff, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xff, 0xff,
         ];
 
-        let expected_function_selector = [0x0, 0x0, 0x0, 0x0, 0xa7, 0x07, 0xb0, 0x8e];
+        let expected_fn_selector = [0x0, 0x0, 0x0, 0x0, 0xa7, 0x07, 0xb0, 0x8e];
 
-        let mut abi_encoder = ABIEncoder::new_with_fn_selector(sway_fn.as_bytes());
-
-        let encoded = abi_encoder.encode(&args).unwrap();
+        let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
+        let encoded = ABIEncoder::encode(&args).unwrap();
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
-        assert_eq!(abi_encoder.function_selector, expected_function_selector);
+        assert_eq!(encoded_function_selector, expected_fn_selector);
     }
 
     #[test]
@@ -256,14 +273,14 @@ mod tests {
 
         let expected_function_selector = [0x0, 0x0, 0x0, 0x0, 0x0c, 0x36, 0xcb, 0x9c];
 
-        let mut abi_encoder = ABIEncoder::new_with_fn_selector(sway_fn.as_bytes());
+        let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = abi_encoder.encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args).unwrap();
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
-        assert_eq!(abi_encoder.function_selector, expected_function_selector);
+        assert_eq!(encoded_function_selector, expected_function_selector);
     }
 
     #[test]
@@ -289,14 +306,14 @@ mod tests {
 
         let expected_function_selector = [0x0, 0x0, 0x0, 0x0, 0x66, 0x8f, 0xff, 0x58];
 
-        let mut abi_encoder = ABIEncoder::new_with_fn_selector(sway_fn.as_bytes());
+        let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = abi_encoder.encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args).unwrap();
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
-        assert_eq!(abi_encoder.function_selector, expected_function_selector);
+        assert_eq!(encoded_function_selector, expected_function_selector);
     }
 
     #[test]
@@ -325,14 +342,14 @@ mod tests {
 
         let expected_function_selector = [0x0, 0x0, 0x0, 0x0, 0xf5, 0x40, 0x73, 0x2b];
 
-        let mut abi_encoder = ABIEncoder::new_with_fn_selector(sway_fn.as_bytes());
+        let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = abi_encoder.encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args).unwrap();
 
         println!("Encoded ABI for ({}) {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
-        assert_eq!(abi_encoder.function_selector, expected_function_selector);
+        assert_eq!(encoded_function_selector, expected_function_selector);
     }
 
     #[test]
@@ -358,14 +375,14 @@ mod tests {
 
         let expected_function_selector = [0x0, 0x0, 0x0, 0x0, 0x2e, 0xe3, 0xce, 0x1f];
 
-        let mut abi_encoder = ABIEncoder::new_with_fn_selector(sway_fn.as_bytes());
+        let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = abi_encoder.encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args).unwrap();
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
-        assert_eq!(abi_encoder.function_selector, expected_function_selector);
+        assert_eq!(encoded_function_selector, expected_function_selector);
     }
 
     #[test]
@@ -401,14 +418,14 @@ mod tests {
 
         let expected_function_selector = [0x0, 0x0, 0x0, 0x0, 0x01, 0x49, 0x42, 0x96];
 
-        let mut abi_encoder = ABIEncoder::new_with_fn_selector(sway_fn.as_bytes());
+        let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = abi_encoder.encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args).unwrap();
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
-        assert_eq!(abi_encoder.function_selector, expected_function_selector);
+        assert_eq!(encoded_function_selector, expected_function_selector);
     }
 
     #[test]
@@ -444,14 +461,14 @@ mod tests {
 
         let expected_function_selector = [0x0, 0x0, 0x0, 0x0, 0x2c, 0x5a, 0x10, 0x2e];
 
-        let mut abi_encoder = ABIEncoder::new_with_fn_selector(sway_fn.as_bytes());
+        let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = abi_encoder.encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args).unwrap();
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
-        assert_eq!(abi_encoder.function_selector, expected_function_selector);
+        assert_eq!(encoded_function_selector, expected_function_selector);
     }
 
     #[test]
@@ -479,14 +496,14 @@ mod tests {
 
         let expected_function_selector = [0x0, 0x0, 0x0, 0x0, 0xd5, 0x6e, 0x76, 0x51];
 
-        let mut abi_encoder = ABIEncoder::new_with_fn_selector(sway_fn.as_bytes());
+        let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = abi_encoder.encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args).unwrap();
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
-        assert_eq!(abi_encoder.function_selector, expected_function_selector);
+        assert_eq!(encoded_function_selector, expected_function_selector);
     }
 
     #[test]
@@ -525,16 +542,16 @@ mod tests {
 
         let expected_function_selector = [0x0, 0x0, 0x0, 0x0, 0xa8, 0x1e, 0x8d, 0xd7];
 
-        let mut abi_encoder = ABIEncoder::new_with_fn_selector(sway_fn.as_bytes());
+        let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = abi_encoder.encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args).unwrap();
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
-        assert_eq!(abi_encoder.function_selector, expected_function_selector);
+        assert_eq!(encoded_function_selector, expected_function_selector);
     }
 
     #[test]
@@ -576,12 +593,12 @@ mod tests {
 
         let expected_function_selector = [0x0, 0x0, 0x0, 0x0, 0x35, 0x5c, 0xa6, 0xfa];
 
-        let mut abi_encoder = ABIEncoder::new_with_fn_selector(sway_fn.as_bytes());
+        let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = abi_encoder.encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args).unwrap();
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
-        assert_eq!(abi_encoder.function_selector, expected_function_selector);
+        assert_eq!(encoded_function_selector, expected_function_selector);
     }
 
     // The encoding follows the ABI specs defined  [here](https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md)
@@ -593,10 +610,7 @@ mod tests {
         let enum_variants = EnumVariants::new(vec![ParamType::B256, ParamType::U64]).unwrap();
         let enum_selector = Box::new((1, Token::U64(42), enum_variants));
 
-        let fun = "takes_my_enum(MyEnum)".as_bytes();
-        let encoded = ABIEncoder::new_with_fn_selector(fun)
-            .encode(slice::from_ref(&Token::Enum(enum_selector)))
-            .unwrap();
+        let encoded = ABIEncoder::encode(slice::from_ref(&Token::Enum(enum_selector))).unwrap();
 
         let enum_discriminant_enc = vec![0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1];
         let u64_enc = vec![0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2a];
@@ -661,10 +675,7 @@ mod tests {
             Token::Enum(Box::new((0, struct_a_token, top_level_enum_variants)));
         let top_lvl_discriminant_enc = vec![0x0; 8];
 
-        let encoded =
-            ABIEncoder::new_with_fn_selector("takes_top_level_enum(TopLevelEnum)".as_bytes())
-                .encode(slice::from_ref(&top_level_enum_token))
-                .unwrap();
+        let encoded = ABIEncoder::encode(slice::from_ref(&top_level_enum_token)).unwrap();
 
         let correct_encoding: Vec<u8> = [
             top_lvl_discriminant_enc,
@@ -721,14 +732,14 @@ mod tests {
 
         let expected_function_selector = [0x0, 0x0, 0x0, 0x0, 0xea, 0x0a, 0xfd, 0x23];
 
-        let mut abi_encoder = ABIEncoder::new_with_fn_selector(sway_fn.as_bytes());
+        let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = abi_encoder.encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args).unwrap();
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
-        assert_eq!(abi_encoder.function_selector, expected_function_selector);
+        assert_eq!(encoded_function_selector, expected_function_selector);
     }
 
     #[test]
@@ -812,26 +823,17 @@ mod tests {
 
         let expected_function_selector = [0x0, 0x0, 0x0, 0x0, 0x10, 0x93, 0xb2, 0x12];
 
-        let mut abi_encoder = ABIEncoder::new_with_fn_selector(sway_fn.as_bytes());
+        let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = abi_encoder.encode(&args).unwrap();
-
-        println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
-
-        println!(
-            "abi_encoder.function_selector: {:#0x?}\n",
-            abi_encoder.function_selector
-        );
+        let encoded = ABIEncoder::encode(&args).unwrap();
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
-        assert_eq!(abi_encoder.function_selector, expected_function_selector);
+        assert_eq!(encoded_function_selector, expected_function_selector);
     }
 
     #[test]
     fn enums_with_only_unit_variants_are_encoded_in_one_word() {
         let expected = [0, 0, 0, 0, 0, 0, 0, 1];
-
-        let mut encoder = ABIEncoder::new();
 
         let enum_selector = Box::new((
             1,
@@ -839,7 +841,7 @@ mod tests {
             EnumVariants::new(vec![ParamType::Unit, ParamType::Unit]).unwrap(),
         ));
 
-        let actual = encoder.encode(&[Token::Enum(enum_selector)]).unwrap();
+        let actual = ABIEncoder::encode(&[Token::Enum(enum_selector)]).unwrap();
 
         assert_eq!(actual, expected);
     }
@@ -848,11 +850,8 @@ mod tests {
     fn units_in_composite_types_are_encoded_in_one_word() {
         let expected = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5];
 
-        let mut encoder = ABIEncoder::new();
-
-        let actual = encoder
-            .encode(&[Token::Struct(vec![Token::Unit, Token::U32(5)])])
-            .unwrap();
+        let actual =
+            ABIEncoder::encode(&[Token::Struct(vec![Token::Unit, Token::U32(5)])]).unwrap();
 
         assert_eq!(actual, expected);
     }
@@ -862,15 +861,13 @@ mod tests {
         let padding = vec![0; 32];
         let expected: Vec<u8> = [discriminant, padding].into_iter().flatten().collect();
 
-        let mut encoder = ABIEncoder::new();
-
         let enum_selector = Box::new((
             1,
             Token::Unit,
             EnumVariants::new(vec![ParamType::B256, ParamType::Unit]).unwrap(),
         ));
 
-        let actual = encoder.encode(&[Token::Enum(enum_selector)]).unwrap();
+        let actual = ABIEncoder::encode(&[Token::Enum(enum_selector)]).unwrap();
 
         assert_eq!(actual, expected);
     }

--- a/packages/fuels-core/src/abi_encoder.rs
+++ b/packages/fuels-core/src/abi_encoder.rs
@@ -75,20 +75,16 @@ impl ABIEncoder {
         self.encode_tokens(arg_tuple)
     }
 
-    fn encode_struct(&mut self, subcomponents: &Vec<Token>) -> Result<(), CodecError> {
-        for component in subcomponents {
-            self.encode_tokens(slice::from_ref(component))?;
-        }
-        Ok(())
+    fn encode_struct(&mut self, subcomponents: &[Token]) -> Result<(), CodecError> {
+        self.encode_tokens(subcomponents)
+    }
+
+    fn encode_array(&mut self, arg_array: &[Token]) -> Result<(), CodecError> {
+        self.encode_tokens(arg_array)
     }
 
     fn encode_string(&mut self, arg_string: &str) {
         self.buffer.extend(pad_string(arg_string));
-    }
-
-    fn encode_array(&mut self, arg_array: &[Token]) -> Result<(), CodecError> {
-        // Recursively encode the array of Tokens
-        self.encode_tokens(arg_array)
     }
 
     fn encode_b256(&mut self, arg_bits256: &Bits256) {

--- a/packages/fuels-core/src/abi_encoder.rs
+++ b/packages/fuels-core/src/abi_encoder.rs
@@ -13,7 +13,7 @@ pub struct ABIEncoder {
 
 impl ABIEncoder {
     /// Encodes the function selector following the ABI specs defined  ///
-    /// [here](https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md)
+    /// [here](https://github.com/FuelLabs/fuel-specs/blob/1be31f70c757d8390f74b9e1b3beb096620553eb/specs/protocol/abi.md)
     pub fn encode_function_selector(fn_selector: &str) -> ByteArray {
         let signature = fn_selector.as_bytes();
         let mut hasher = Sha256::new();
@@ -25,7 +25,7 @@ impl ABIEncoder {
     }
 
     /// Encodes `Token`s in `args` following the ABI specs defined
-    /// [here](https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md)
+    /// [here](https://github.com/FuelLabs/fuel-specs/blob/1be31f70c757d8390f74b9e1b3beb096620553eb/specs/protocol/abi.md)
     pub fn encode(args: &[Token]) -> Result<Vec<u8>, CodecError> {
         let mut encoder = ABIEncoder::new();
 

--- a/packages/fuels-core/src/abi_encoder.rs
+++ b/packages/fuels-core/src/abi_encoder.rs
@@ -8,9 +8,13 @@ use crate::{
 use sha2::{Digest, Sha256};
 use std::slice;
 
-pub struct ABIEncoder;
+pub struct ABIEncoder {
+    buffer: Vec<u8>,
+}
 
 impl ABIEncoder {
+    /// Encodes the function selector followin the ABI specs defined  ///
+    /// [here](https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md)
     pub fn encode_function_selector(fn_selector: &str) -> ByteArray {
         let signature = fn_selector.as_bytes();
         let mut hasher = Sha256::new();
@@ -21,117 +25,132 @@ impl ABIEncoder {
         output
     }
 
-    /// Encode takes an array of `Token`s, encodes these tokens, and returns the
-    /// raw bytes (as a Vec<u8>) that represent the encoded tokens.
-    /// The encoding follows the ABI specs defined
+    /// Encodes `Token`s in `args` following the ABI specs defined
     /// [here](https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md)
     pub fn encode(args: &[Token]) -> Result<Vec<u8>, CodecError> {
-        let mut encoded = vec![];
+        let mut encoder = ABIEncoder::new();
+
+        encoder.encode_tokens(args)?;
+
+        Ok(encoder.buffer)
+    }
+
+    fn new() -> Self {
+        ABIEncoder {
+            buffer: Default::default(),
+        }
+    }
+
+    fn encode_tokens(&mut self, args: &[Token]) -> Result<(), CodecError> {
         for arg in args {
-            encoded.extend(Self::encode_token(arg)?);
+            self.encode_token(arg)?;
         }
-        Ok(encoded)
+        Ok(())
     }
 
-    fn encode_token(arg: &Token) -> Result<Vec<u8>, CodecError> {
-        Ok(match arg {
-            Token::U8(arg_u8) => Self::encode_u8(arg_u8),
-            Token::U16(arg_u16) => Self::encode_u16(arg_u16),
-            Token::U32(arg_u32) => Self::encode_u32(arg_u32),
-            Token::U64(arg_u64) => Self::encode_u64(arg_u64),
-            Token::Byte(arg_byte) => Self::encode_byte(arg_byte),
-            Token::Bool(arg_bool) => Self::encode_bool(arg_bool),
-            Token::B256(arg_bits256) => Self::encode_b256(arg_bits256),
-            Token::Array(arg_array) => Self::encode_array(arg_array)?,
-            Token::String(arg_string) => Self::encode_string(arg_string),
-            Token::Struct(arg_struct) => Self::encode_struct(arg_struct)?,
-            Token::Enum(arg_enum) => Self::encode_enum(arg_enum)?,
-            Token::Tuple(arg_tuple) => Self::encode_tuple(arg_tuple)?,
-            Token::Unit => Self::encode_unit(),
-        })
+    fn encode_token(&mut self, arg: &Token) -> Result<(), CodecError> {
+        match arg {
+            Token::U8(arg_u8) => self.encode_u8(*arg_u8),
+            Token::U16(arg_u16) => self.encode_u16(*arg_u16),
+            Token::U32(arg_u32) => self.encode_u32(*arg_u32),
+            Token::U64(arg_u64) => self.encode_u64(*arg_u64),
+            Token::Byte(arg_byte) => self.encode_byte(*arg_byte),
+            Token::Bool(arg_bool) => self.encode_bool(*arg_bool),
+            Token::B256(arg_bits256) => self.encode_b256(arg_bits256),
+            Token::Array(arg_array) => self.encode_array(arg_array)?,
+            Token::String(arg_string) => self.encode_string(arg_string),
+            Token::Struct(arg_struct) => self.encode_struct(arg_struct)?,
+            Token::Enum(arg_enum) => self.encode_enum(arg_enum)?,
+            Token::Tuple(arg_tuple) => self.encode_tuple(arg_tuple)?,
+            Token::Unit => self.encode_unit(),
+        };
+        Ok(())
     }
 
-    fn encode_unit() -> Vec<u8> {
-        vec![0; WORD_SIZE]
+    fn encode_unit(&mut self) {
+        self.rightpad_with_zeroes(WORD_SIZE);
     }
 
-    fn encode_tuple(arg_tuple: &[Token]) -> Result<Vec<u8>, CodecError> {
-        Self::encode(arg_tuple)
+    fn encode_tuple(&mut self, arg_tuple: &[Token]) -> Result<(), CodecError> {
+        self.encode_tokens(arg_tuple)
     }
 
-    fn encode_struct(arg_struct: &[Token]) -> Result<Vec<u8>, CodecError> {
-        let mut data = vec![];
-        for property in arg_struct.iter() {
-            data.extend(Self::encode(slice::from_ref(property))?);
+    fn encode_struct(&mut self, subcomponents: &Vec<Token>) -> Result<(), CodecError> {
+        for component in subcomponents {
+            self.encode_tokens(slice::from_ref(component))?;
         }
-        Ok(data)
+        Ok(())
     }
 
-    fn encode_string(arg_string: &str) -> Vec<u8> {
-        pad_string(arg_string)
+    fn encode_string(&mut self, arg_string: &str) {
+        self.buffer.extend(pad_string(arg_string));
     }
 
-    fn encode_array(arg_array: &[Token]) -> Result<Vec<u8>, CodecError> {
+    fn encode_array(&mut self, arg_array: &[Token]) -> Result<(), CodecError> {
         // Recursively encode the array of Tokens
-        Self::encode(arg_array)
+        self.encode_tokens(arg_array)
     }
 
-    fn encode_b256(arg_bits256: &Bits256) -> Vec<u8> {
-        arg_bits256.to_vec()
+    fn encode_b256(&mut self, arg_bits256: &Bits256) {
+        self.buffer.extend(arg_bits256);
     }
 
-    fn encode_bool(arg_bool: &bool) -> Vec<u8> {
-        pad_u8(if *arg_bool { &1 } else { &0 }).to_vec()
+    fn encode_bool(&mut self, arg_bool: bool) {
+        self.buffer.extend(pad_u8(if arg_bool { 1 } else { 0 }));
     }
 
-    fn encode_byte(arg_byte: &u8) -> Vec<u8> {
-        pad_u8(arg_byte).to_vec()
+    fn encode_byte(&mut self, arg_byte: u8) {
+        self.buffer.extend(pad_u8(arg_byte));
     }
 
-    fn encode_u64(arg_u64: &u64) -> Vec<u8> {
-        arg_u64.to_be_bytes().to_vec()
+    fn encode_u64(&mut self, arg_u64: u64) {
+        self.buffer.extend(arg_u64.to_be_bytes());
     }
 
-    fn encode_u32(arg_u32: &u32) -> Vec<u8> {
-        pad_u32(arg_u32).to_vec()
+    fn encode_u32(&mut self, arg_u32: u32) {
+        self.buffer.extend(pad_u32(arg_u32));
     }
 
-    fn encode_u16(arg_u16: &u16) -> Vec<u8> {
-        pad_u16(arg_u16).to_vec()
+    fn encode_u16(&mut self, arg_u16: u16) {
+        self.buffer.extend(pad_u16(arg_u16));
     }
 
-    fn encode_u8(arg_u8: &u8) -> Vec<u8> {
-        pad_u8(arg_u8).to_vec()
+    fn encode_u8(&mut self, arg_u8: u8) {
+        self.buffer.extend(pad_u8(arg_u8));
     }
 
-    /// The encoding follows the ABI specs defined
-    /// [here](https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md)
-    fn encode_enum(selector: &EnumSelector) -> Result<Vec<u8>, CodecError> {
+    fn encode_enum(&mut self, selector: &EnumSelector) -> Result<(), CodecError> {
         let (discriminant, token_within_enum, variants) = selector;
 
-        let mut data = vec![];
-        data.extend(Self::encode_discriminant(discriminant));
+        self.encode_discriminant(*discriminant);
 
         // The sway compiler has an optimization for enums which have only Units
         // as variants -- such an enum is encoded only by encoding its
         // discriminant.
         if !variants.only_units_inside() {
             let param_type = Self::type_of_chosen_variant(discriminant, variants)?;
-            data.extend(Self::add_enum_padding(variants, param_type));
-            data.extend(Self::encode(slice::from_ref(token_within_enum))?);
+            self.encode_enum_padding(variants, param_type);
+            self.encode_tokens(slice::from_ref(token_within_enum))?;
         }
 
-        Ok(data)
+        Ok(())
     }
 
-    fn add_enum_padding(variants: &EnumVariants, param_type: &ParamType) -> Vec<u8> {
+    fn encode_discriminant(&mut self, discriminant: u8) {
+        self.encode_u8(discriminant);
+    }
+
+    fn encode_enum_padding(&mut self, variants: &EnumVariants, param_type: &ParamType) {
         let biggest_variant_width =
             compute_encoding_width_of_enum(variants) - ENUM_DISCRIMINANT_WORD_WIDTH;
         let variant_width = compute_encoding_width(param_type);
-
         let padding_amount = (biggest_variant_width - variant_width) * WORD_SIZE;
 
-        Self::rightpad_with_zeroes(padding_amount)
+        self.rightpad_with_zeroes(padding_amount);
+    }
+
+    fn rightpad_with_zeroes(&mut self, amount: usize) {
+        self.buffer.resize(self.buffer.len() + amount, 0);
     }
 
     fn type_of_chosen_variant<'a>(
@@ -151,15 +170,6 @@ impl ABIEncoder {
                 );
                 CodecError::InvalidData(msg)
             })
-    }
-
-    fn encode_discriminant(discriminant: &u8) -> Vec<u8> {
-        pad_u8(discriminant).to_vec()
-    }
-
-    /// Will append `amount` number of zeroes to the internal buffer, right-padding it
-    fn rightpad_with_zeroes(amount: usize) -> Vec<u8> {
-        vec![0; amount]
     }
 }
 

--- a/packages/fuels-core/src/code_gen/functions_gen.rs
+++ b/packages/fuels-core/src/code_gen/functions_gen.rs
@@ -29,9 +29,9 @@ pub fn expand_function(
     custom_structs: &HashMap<String, Property>,
 ) -> Result<TokenStream, Error> {
     let name = safe_ident(&function.name);
-    let fn_signature = abi_parser.build_fn_selector(&function.name, &function.inputs);
+    let fn_signature = abi_parser.build_fn_selector(&function.name, &function.inputs)?;
 
-    let encoded = ABIEncoder::encode_function_selector(fn_signature?.as_bytes());
+    let encoded = ABIEncoder::encode_function_selector(&fn_signature);
 
     let tokenized_signature = expand_selector(encoded);
     let tokenized_output = expand_fn_outputs(&function.outputs)?;

--- a/packages/fuels-core/src/encoding_utils.rs
+++ b/packages/fuels-core/src/encoding_utils.rs
@@ -3,6 +3,9 @@ use crate::{EnumVariants, ParamType, WORD_SIZE};
 
 // Calculates how many WORDs are needed to encode an enum.
 pub fn compute_encoding_width_of_enum(variants: &EnumVariants) -> usize {
+    if variants.only_units_inside() {
+        return ENUM_DISCRIMINANT_WORD_WIDTH;
+    }
     variants
         .param_types()
         .iter()

--- a/packages/fuels-core/src/json_abi.rs
+++ b/packages/fuels-core/src/json_abi.rs
@@ -1544,7 +1544,7 @@ mod tests {
 
         println!("Function: {}", hex::encode(abi.fn_selector.unwrap()));
         let expected_encode =
-            "00000000ebb8d011000000000000002a00000000000000014a6f686e0000000000000000000000010000000000000000";
+            "00000000ebb8d011000000000000002a00000000000000014a6f686e000000000000000000000001";
         assert_eq!(encoded, expected_encode);
     }
 

--- a/packages/fuels-core/src/json_abi.rs
+++ b/packages/fuels-core/src/json_abi.rs
@@ -70,12 +70,10 @@ impl ABIParser {
 
         let entry = entry.expect("No functions found");
 
-        let mut encoder = ABIEncoder::new_with_fn_selector(
-            self.build_fn_selector(fn_name, &entry.inputs)?.as_bytes(),
-        );
+        let fn_selector = self.build_fn_selector(fn_name, &entry.inputs)?;
 
         // Update the fn_selector field with the encoded selector.
-        self.fn_selector = Some(encoder.function_selector.to_vec());
+        self.fn_selector = Some(ABIEncoder::encode_function_selector(&fn_selector).to_vec());
 
         let params: Vec<_> = entry
             .inputs
@@ -86,7 +84,7 @@ impl ABIParser {
 
         let tokens = self.parse_tokens(&params)?;
 
-        Ok(hex::encode(encoder.encode(&tokens)?))
+        Ok(hex::encode(ABIEncoder::encode(&tokens)?))
     }
 
     /// Similar to `encode`, but includes the function selector in the
@@ -141,9 +139,9 @@ impl ABIParser {
             .to_owned()
             .expect("Function selector not encoded");
 
-        let encoded_fn_selector = hex::encode(fn_selector);
+        let encoded_function_selector = hex::encode(fn_selector);
 
-        Ok(format!("{}{}", encoded_fn_selector, encoded_params))
+        Ok(format!("{}{}", encoded_function_selector, encoded_params))
     }
 
     /// Helper function to return the encoded function selector.
@@ -165,8 +163,6 @@ impl ABIParser {
 
         let mut param_type_pairs: Vec<(ParamType, &str)> = vec![];
 
-        let mut encoder = ABIEncoder::new();
-
         for pair in pairs {
             let prop = Property {
                 name: "".to_string(),
@@ -181,7 +177,7 @@ impl ABIParser {
 
         let tokens = self.parse_tokens(&param_type_pairs)?;
 
-        let encoded = encoder.encode(&tokens)?;
+        let encoded = ABIEncoder::encode(&tokens)?;
 
         Ok(hex::encode(encoded))
     }

--- a/packages/fuels-core/src/lib.rs
+++ b/packages/fuels-core/src/lib.rs
@@ -534,21 +534,21 @@ impl Parameterize for fuel_tx::AssetId {
 }
 
 /// Converts a u8 to a right aligned array of 8 bytes.
-pub fn pad_u8(value: &u8) -> ByteArray {
+pub fn pad_u8(value: u8) -> ByteArray {
     let mut padded = ByteArray::default();
-    padded[7] = *value;
+    padded[7] = value;
     padded
 }
 
 /// Converts a u16 to a right aligned array of 8 bytes.
-pub fn pad_u16(value: &u16) -> ByteArray {
+pub fn pad_u16(value: u16) -> ByteArray {
     let mut padded = ByteArray::default();
     padded[6..].copy_from_slice(&value.to_be_bytes());
     padded
 }
 
 /// Converts a u32 to a right aligned array of 8 bytes.
-pub fn pad_u32(value: &u32) -> ByteArray {
+pub fn pad_u32(value: u32) -> ByteArray {
     let mut padded = [0u8; 8];
     padded[4..].copy_from_slice(&value.to_be_bytes());
     padded

--- a/packages/fuels-core/src/lib.rs
+++ b/packages/fuels-core/src/lib.rs
@@ -61,6 +61,12 @@ impl EnumVariants {
     pub fn param_types(&self) -> &Vec<ParamType> {
         &self.variants
     }
+
+    pub fn only_units_inside(&self) -> bool {
+        self.variants
+            .iter()
+            .all(|variant| *variant == ParamType::Unit)
+    }
 }
 
 #[derive(Debug, Clone, EnumString, PartialEq, Eq)]


### PR DESCRIPTION
closes: #390 
### The issue
The sway compiler, since the release of Forc 16.0.0, includes an optimization with regards to enums that only have unit types for variants.

Such enums are to be encoded in only one word that contains their discriminant.

This PR also contains the necessary fixes to our Sway files thanks to @digorithm 

### The solution 
The cleanest way of looking at this is to say that enums with only unit variants will not have their unit variant encoded at all. This is preferable to wording like 'units are 0B in enums, 1 B elsewhere'. Although the 'elsewhere' part can be debated since the SDK doesn't support using Units anywhere else. This phrasing was translated into code.

Although the changes are covered by unit tests, there is an e2e test that will safeguard us against regressions in the sway compiler -- the test will only pass if the aforementioned type of enums is encoded in one word.

I've also taken the liberty of refactoring ABIEncoder, since it was unnecessarily storing the encoded function selector while it was only necessary for it to compute it.

The flow of 'construct an encoder, give it data, get the encoding back' was wrapped in an associated function which can now be called `ABIEncoder::encode(...)` since this is the only way the encoder is used.