### PR TITLE
fix: custom types containing reserved keyword

### DIFF
--- a/packages/fuels-abigen-macro/tests/harness.rs
+++ b/packages/fuels-abigen-macro/tests/harness.rs
@@ -1838,6 +1838,28 @@ async fn nested_structs() {
         fuelvm_judgement,
         "The FuelVM deems that we've not encoded the argument correctly. Investigate!"
     );
+
+    let memory_address = MemoryAddress {
+        contract_id: ContractId::zeroed(),
+        function_selector: 10,
+        function_data: 0,
+    };
+
+    let call_data = CallData {
+        memory_address,
+        num_coins_to_forward: 10,
+        asset_id_of_coins_to_forward: ContractId::zeroed(),
+        amount_of_gas_to_forward: 5,
+    };
+
+    let actual = instance
+        .nested_struct_with_reserved_keyword_substring(call_data.clone())
+        .call()
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(actual, call_data);
 }
 
 #[tokio::test]

--- a/packages/fuels-abigen-macro/tests/test_projects/nested_structs/src/main.sw
+++ b/packages/fuels-abigen-macro/tests/test_projects/nested_structs/src/main.sw
@@ -1,5 +1,7 @@
 contract;
 
+use std::contract_id::ContractId;
+
 pub struct SomeStruct {
     par1: u32,
 }
@@ -8,9 +10,23 @@ pub struct AllStruct {
     some_struct: SomeStruct,
 }
 
+pub struct CallData {
+    memory_address: MemoryAddress,
+    num_coins_to_forward: u64,
+    asset_id_of_coins_to_forward: ContractId,
+    amount_of_gas_to_forward: u64,
+}
+
+struct MemoryAddress {
+    contract_id: ContractId,
+    function_selector: u64,
+    function_data: u64,
+}
+
 abi MyContract {
     fn get_struct() -> AllStruct;
     fn check_struct_integrity(arg: AllStruct) -> bool;
+    fn nested_struct_with_reserved_keyword_substring(call_data: CallData) -> CallData;
 }
 
 impl MyContract for Contract {
@@ -23,5 +39,9 @@ impl MyContract for Contract {
     }
     fn check_struct_integrity(arg: AllStruct) -> bool {
         arg.some_struct.par1 == 12345u32
+    }
+
+    fn nested_struct_with_reserved_keyword_substring(call_data: CallData) -> CallData {
+        call_data
     }
 }

--- a/packages/fuels-core/src/constants.rs
+++ b/packages/fuels-core/src/constants.rs
@@ -19,3 +19,6 @@ pub const DEFAULT_SPENDABLE_COIN_AMOUNT: u64 = 1_000_000;
 // Bytes representation of the asset ID of the "base" asset used for gas fees.
 pub const BASE_ASSET_ID: AssetId = AssetId::new([0u8; 32]);
 // ANCHOR_END: default_call_parameters
+
+pub const CONTRACT_ID_SWAY_NATIVE_TYPE: &str = "ContractId";
+pub const ADDRESS_SWAY_NATIVE_TYPE: &str = "Address";


### PR DESCRIPTION
Fixes https://github.com/FuelLabs/fuels-rs/issues/414.

Custom types in the JSON ABI containing the strings `Address` or `ContractID` were being ignored and not generated. That's because we don't re-generate Sway-native types, but the check for it was buggy: we checked if it contained, not if it's an exact match.

For instance, `struct Address` in your JSON ABI would be correctly ignored. `struct MemoryAddress` would be _incorrectly_ ignored because it contains `Address` in it. 

This PR changes the check logic and fixes this issue.