### PR TITLE
fix: broken crate publishing CI due to abigen feature flag

### DIFF
--- a/packages/fuels-abigen-macro/Cargo.toml
+++ b/packages/fuels-abigen-macro/Cargo.toml
@@ -22,12 +22,9 @@ syn = "1.0.12"
 ctor = " 0.1"
 fuel-core = { version = "0.9", default-features = false }
 fuel-gql-client = { version = "0.9", default-features = false }
-fuels = { path = "../fuels", default-features = false }
+fuels = { path = "../fuels", default-features = false, features = ["fuel-core-lib"] }
 hex = { version = "0.4.3", default-features = false }
 sha2 = "0.9.5"
 tokio = "1.15.0"
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
-
-[features]
-fuel-core-lib = ["fuels/fuel-core-lib"]


### PR DESCRIPTION
Currently, we're seeing the following error when trying to publish the `0.16` crate: 
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/3484025/174850721-f4afeba7-dcfc-458a-87d1-dd0bb6d37b17.png">

That's because we're adding a `fuels` feature flag to `fuels-abigen-macro` but not having `fuels` as a `dependencies`, only as `dev-dependencies`. Adding `fuels` to `dependencies` breaks it all because it introduces a circular dependency issue. 