### PR TITLE
refactor: change the launch functions and wallet setup

### DIFF
--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -29,7 +29,7 @@ async fn deploy_contract() {
         );
 
     // This helper will launch a local node and provide a test wallet linked to it
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     // Optional: Configure deployment parameters or use `TxParameters::default()`
     let gas_price = 0;
@@ -88,7 +88,7 @@ async fn deploy_with_salt() {
             "packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test-abi.json"
         );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let contract_id_1 = Contract::deploy(
             "../../packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test.bin",
@@ -128,7 +128,7 @@ async fn deploy_with_multiple_wallets() {
             "packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test-abi.json"
         );
 
-    let wallets = launch_provider_and_get_wallets(WalletsConfig::default()).await;
+    let wallets = launch_custom_provider_and_get_wallets(WalletsConfig::default(), None).await;
 
     let contract_id_1 = Contract::deploy(
             "../../packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test.bin",
@@ -181,7 +181,7 @@ async fn contract_tx_and_call_params() -> Result<(), Error> {
             "packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test-abi.json"
         );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
     let contract_id = Contract::deploy(
         "../../packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test.bin",
         &wallet,
@@ -259,7 +259,7 @@ async fn token_ops_tests() -> Result<(), Error> {
             .json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
     let contract_id = Contract::deploy(
         "../../packages/fuels-abigen-macro/tests/test_projects/token_ops/out/debug/token_ops\
         .bin",
@@ -297,7 +297,7 @@ async fn get_contract_outputs() -> Result<(), Error> {
         TestContract,
         "packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test-abi.json"
     );
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
     let contract_id = Contract::deploy(
         "../../packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test\
         .bin",
@@ -336,7 +336,7 @@ async fn get_contract_outputs() -> Result<(), Error> {
         MyContract,
         "packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test-abi.json"
     );
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
     // Your contract ID as a String.
     let contract_id =
         "0x068fe90ddc43b18a8f76756ecad8bf30eb0ceea33d2e6990c0185d01b0dbb675".to_string();
@@ -356,7 +356,7 @@ async fn call_params_gas() -> Result<(), Error> {
         "packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let contract_id = Contract::deploy(
         "../../packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test.bin",

--- a/examples/rust_bindings/src/lib.rs
+++ b/examples/rust_bindings/src/lib.rs
@@ -4,8 +4,8 @@ use fuels::prelude::Error;
 #[tokio::test]
 #[allow(unused_variables)]
 async fn transform_json_to_bindings() -> Result<(), Error> {
-    use fuels::test_helpers::launch_provider_and_get_single_wallet;
-    let wallet = launch_provider_and_get_single_wallet().await;
+    use fuels::test_helpers::launch_provider_and_get_wallet;
+    let wallet = launch_provider_and_get_wallet().await;
     // ANCHOR: use_abigen
     use fuels::prelude::*;
     // Replace with your own JSON abi path (relative to the root of your crate)

--- a/examples/wallets/src/lib.rs
+++ b/examples/wallets/src/lib.rs
@@ -111,11 +111,14 @@ async fn wallet_transfer() -> Result<(), Box<dyn std::error::Error>> {
     use fuels::prelude::*;
 
     // Setup 2 test wallets with 1 coin each
-    let wallets = launch_provider_and_get_wallets(WalletsConfig {
-        num_wallets: 2,
-        coins_per_wallet: 1,
-        coin_amount: 1,
-    })
+    let wallets = launch_custom_provider_and_get_wallets(
+        WalletsConfig {
+            num_wallets: 2,
+            coins_per_wallet: 1,
+            coin_amount: 1,
+        },
+        None,
+    )
     .await;
 
     // Transfer 1 from wallet 1 to wallet 2
@@ -139,7 +142,7 @@ async fn setup_multiple_wallets() {
     use fuels::prelude::*;
     // This helper will launch a local node and provide 10 test wallets linked to it.
     // The initial balance defaults to 1 coin per wallet with an amount of 1_000_000_000
-    let wallets = launch_provider_and_get_wallets(WalletsConfig::default()).await;
+    let wallets = launch_custom_provider_and_get_wallets(WalletsConfig::default(), None).await;
     // ANCHOR_END: multiple_wallets_helper
     // ANCHOR: setup_5_wallets
     let num_wallets = 5;
@@ -152,7 +155,7 @@ async fn setup_multiple_wallets() {
         Some(amount_per_coin),
     );
     // Launches a local node and provides test wallets as specified by the config
-    let wallets = launch_provider_and_get_wallets(config).await;
+    let wallets = launch_custom_provider_and_get_wallets(config, None).await;
     // ANCHOR_END: setup_5_wallets
 }
 
@@ -180,11 +183,11 @@ async fn setup_wallet_multiple_assets() {
 #[tokio::test]
 #[allow(unused_variables)]
 async fn get_balances() -> Result<(), ProviderError> {
-    use fuels::prelude::{launch_provider_and_get_single_wallet, BASE_ASSET_ID};
+    use fuels::prelude::{launch_provider_and_get_wallet, BASE_ASSET_ID};
     use fuels::tx::AssetId;
     use std::collections::HashMap;
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
     // ANCHOR: get_asset_balance
     let asset_id: AssetId = BASE_ASSET_ID;
     let balance: u64 = wallet.get_asset_balance(&asset_id).await?;

--- a/packages/fuels-abigen-macro/tests/harness.rs
+++ b/packages/fuels-abigen-macro/tests/harness.rs
@@ -3,9 +3,9 @@ use sha2::{Digest, Sha256};
 use std::str::FromStr;
 
 use fuels::prelude::{
-    abigen, launch_provider_and_get_single_wallet, setup_multiple_assets_coins,
-    setup_single_asset_coins, setup_test_provider, CallParameters, Contract, Error, LocalWallet,
-    Provider, Signer, TxParameters, DEFAULT_COIN_AMOUNT, DEFAULT_NUM_COINS,
+    abigen, launch_provider_and_get_wallet, setup_multiple_assets_coins, setup_single_asset_coins,
+    setup_test_provider, CallParameters, Contract, Error, LocalWallet, Provider, Signer,
+    TxParameters, DEFAULT_COIN_AMOUNT, DEFAULT_NUM_COINS,
 };
 use fuels_core::tx::Address;
 use fuels_core::Tokenizable;
@@ -38,7 +38,7 @@ async fn compile_bindings_from_contract_file() {
         "packages/fuels-abigen-macro/tests/takes_ints_returns_bool.json",
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     // `SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
@@ -83,7 +83,7 @@ async fn compile_bindings_from_inline_contract() -> Result<(), Error> {
         "#,
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
     //`SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
@@ -125,7 +125,7 @@ async fn compile_bindings_array_input() {
         "#,
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     // `SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
@@ -170,7 +170,7 @@ async fn compile_bindings_bool_array_input() {
         "#,
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     // `SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
@@ -215,7 +215,7 @@ async fn compile_bindings_byte_input() {
         "#,
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     // `SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
@@ -256,7 +256,7 @@ async fn compile_bindings_string_input() {
         "#,
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     // `SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
@@ -300,7 +300,7 @@ async fn compile_bindings_b256_input() {
         "#,
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     // `SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
@@ -363,7 +363,7 @@ async fn compile_bindings_struct_input() {
         bar: "fuel".to_string(),
     };
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     // `SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
@@ -428,7 +428,7 @@ async fn compile_bindings_nested_struct_input() {
         foo: inner_struct,
     };
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     // `SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
@@ -479,7 +479,7 @@ async fn compile_bindings_enum_input() {
 
     let variant = MyEnum::X(42);
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     // `SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
@@ -540,7 +540,7 @@ async fn create_struct_from_decoded_tokens() {
     assert_eq!(10, struct_from_tokens.foo);
     assert!(struct_from_tokens.bar);
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     // `SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
@@ -613,7 +613,7 @@ async fn create_nested_struct_from_decoded_tokens() {
     assert_eq!(10, nested_struct_from_tokens.x);
     assert!(nested_struct_from_tokens.y.a);
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     // `SimpleContract` is the name of the contract
     let contract_instance = SimpleContract::new(null_contract_id(), wallet);
@@ -638,7 +638,7 @@ async fn type_safe_output_values() {
         "packages/fuels-abigen-macro/tests/test_projects/contract_output_test/out/debug/contract_output_test-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let contract_id = Contract::deploy(
         "tests/test_projects/contract_output_test/out/debug/contract_output_test.bin",
@@ -685,7 +685,7 @@ async fn call_with_structs() {
         "packages/fuels-abigen-macro/tests/test_projects/complex_types_contract/out/debug/contract_test-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let contract_id = Contract::deploy(
         "tests/test_projects/complex_types_contract/out/debug/contract_test.bin",
@@ -728,7 +728,7 @@ async fn call_with_empty_return() {
         "packages/fuels-abigen-macro/tests/test_projects/call_empty_return/out/debug/contract_test-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let contract_id = Contract::deploy(
         "tests/test_projects/call_empty_return/out/debug/contract_test.bin",
@@ -755,7 +755,7 @@ async fn abigen_different_structs_same_arg_name() {
         "packages/fuels-abigen-macro/tests/test_projects/two_structs/out/debug/two_structs-abi.json",
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let contract_id = Contract::deploy(
         "tests/test_projects/two_structs/out/debug/two_structs.bin",
@@ -791,7 +791,7 @@ async fn test_reverting_transaction() {
         "packages/fuels-abigen-macro/tests/test_projects/revert_transaction_error/out/debug/capture_revert_transaction_error-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let contract_id = Contract::deploy("tests/test_projects/revert_transaction_error/out/debug/capture_revert_transaction_error.bin", &wallet, TxParameters::default())
         .await
@@ -809,7 +809,7 @@ async fn multiple_read_calls() {
         "packages/fuels-abigen-macro/tests/test_projects/multiple_read_calls/out/debug/demo-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let contract_id = Contract::deploy(
         "tests/test_projects/multiple_read_calls/out/debug/demo.bin",
@@ -844,7 +844,7 @@ async fn test_methods_typeless_argument() {
         "packages/fuels-abigen-macro/tests/test_projects/empty_arguments/out/debug/method_four_arguments-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let contract_id = Contract::deploy(
         "tests/test_projects/empty_arguments/out/debug/method_four_arguments.bin",
@@ -872,7 +872,7 @@ async fn test_large_return_data() {
         "packages/fuels-abigen-macro/tests/test_projects/large_return_data/out/debug/contract_test-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let contract_id = Contract::deploy(
         "tests/test_projects/large_return_data/out/debug/contract_test.bin",
@@ -987,7 +987,7 @@ async fn test_contract_calling_contract() -> Result<(), Error> {
         "packages/fuels-abigen-macro/tests/test_projects/foo_caller_contract/out/debug/foo_caller_contract-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     // Load and deploy the first compiled contract
     let foo_contract_id = Contract::deploy(
@@ -1044,7 +1044,7 @@ async fn test_gas_errors() {
         "packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let contract_id = Contract::deploy(
         "tests/test_projects/contract_test/out/debug/contract_test.bin",
@@ -1093,7 +1093,7 @@ async fn test_call_param_gas_errors() {
         "packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let contract_id = Contract::deploy(
         "tests/test_projects/contract_test/out/debug/contract_test.bin",
@@ -1137,7 +1137,7 @@ async fn test_amount_and_asset_forwarding() {
         "packages/fuels-abigen-macro/tests/test_projects/token_ops/out/debug/token_ops-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let id = Contract::deploy(
         "tests/test_projects/token_ops/out/debug/token_ops.bin",
@@ -1226,7 +1226,7 @@ async fn test_multiple_args() {
         "packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let id = Contract::deploy(
         "tests/test_projects/contract_test/out/debug/contract_test.bin",
@@ -1258,7 +1258,7 @@ async fn test_tuples() {
         "packages/fuels-abigen-macro/tests/test_projects/tuples/out/debug/tuples-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let id = Contract::deploy(
         "tests/test_projects/tuples/out/debug/tuples.bin",
@@ -1319,7 +1319,7 @@ async fn test_array() {
         "packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let contract_id = Contract::deploy(
         "tests/test_projects/contract_test/out/debug/contract_test.bin",
@@ -1352,7 +1352,7 @@ async fn test_arrays_with_custom_types() {
         "packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let contract_id = Contract::deploy(
         "tests/test_projects/contract_test/out/debug/contract_test.bin",
@@ -1402,7 +1402,7 @@ async fn test_auth_msg_sender_from_sdk() {
         "packages/fuels-abigen-macro/tests/test_projects/auth_testing_contract/out/debug/auth_testing_contract-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let id = Contract::deploy(
         "tests/test_projects/auth_testing_contract/out/debug/auth_testing_contract.bin",
@@ -1432,7 +1432,7 @@ async fn workflow_enum_inside_struct() {
         /enum_inside_struct-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let id = Contract::deploy(
         "tests/test_projects/enum_inside_struct/out/debug/enum_inside_struct.bin",
@@ -1467,7 +1467,7 @@ async fn workflow_struct_inside_enum() {
         "packages/fuels-abigen-macro/tests/test_projects/struct_inside_enum/out/debug/struct_inside_enum-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let id = Contract::deploy(
         "tests/test_projects/struct_inside_enum/out/debug/struct_inside_enum.bin",
@@ -1497,7 +1497,7 @@ async fn test_logd_receipts() {
         "packages/fuels-abigen-macro/tests/test_projects/contract_logdata/out/debug/contract_logdata-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let id = Contract::deploy(
         "tests/test_projects/contract_logdata/out/debug/contract_logdata.bin",
@@ -1599,7 +1599,7 @@ async fn sway_native_types_support() {
         "packages/fuels-abigen-macro/tests/test_projects/sway_native_types/out/debug/sway_native_types-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let id = Contract::deploy(
         "tests/test_projects/sway_native_types/out/debug/sway_native_types.bin",
@@ -1639,7 +1639,7 @@ async fn test_transaction_script_workflow() {
         "packages/fuels-abigen-macro/tests/test_projects/contract_test/out/debug/contract_test-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
     let client = &wallet.get_provider().unwrap().client;
 
     let contract_id = Contract::deploy(
@@ -1671,7 +1671,7 @@ async fn enum_coding_w_variable_width_variants() {
         /enum_encoding-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let id = Contract::deploy(
         "tests/test_projects/enum_encoding/out/debug/enum_encoding.bin",
@@ -1715,7 +1715,7 @@ async fn enum_coding_w_unit_enums() {
         /enum_encoding-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let id = Contract::deploy(
         "tests/test_projects/enum_encoding/out/debug/enum_encoding.bin",
@@ -1757,7 +1757,7 @@ async fn enum_as_input() {
         /enum_as_input-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let id = Contract::deploy(
         "tests/test_projects/enum_as_input/out/debug/enum_as_input.bin",
@@ -1808,7 +1808,7 @@ async fn nested_structs() {
         /nested_structs-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let id = Contract::deploy(
         "tests/test_projects/nested_structs/out/debug/nested_structs.bin",
@@ -1869,7 +1869,7 @@ async fn nested_enums_are_correctly_encoded_decoded() {
         "packages/fuels-abigen-macro/tests/test_projects/nested_enums/out/debug/nested_enums-abi.json"
     );
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
 
     let id = Contract::deploy(
         "tests/test_projects/nested_enums/out/debug/nested_enums.bin",

--- a/packages/fuels-contract/src/contract.rs
+++ b/packages/fuels-contract/src/contract.rs
@@ -424,12 +424,12 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use fuels_test_helpers::launch_provider_and_get_single_wallet;
+    use fuels_test_helpers::launch_provider_and_get_wallet;
 
     #[tokio::test]
     #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: InvalidData(\"json\")")]
     async fn deploy_panics_on_non_binary_file() {
-        let wallet = launch_provider_and_get_single_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await;
 
         // Should panic as we are passing in a JSON instead of BIN
         Contract::deploy(
@@ -444,7 +444,7 @@ mod test {
     #[tokio::test]
     #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: InvalidData(\"json\")")]
     async fn deploy_with_salt_panics_on_non_binary_file() {
-        let wallet = launch_provider_and_get_single_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await;
 
         // Should panic as we are passing in a JSON instead of BIN
         Contract::deploy_with_salt(

--- a/packages/fuels-test-helpers/src/lib.rs
+++ b/packages/fuels-test-helpers/src/lib.rs
@@ -125,7 +125,7 @@ pub fn setup_single_asset_coins(
 // Setup a test client with the given coins. We return the SocketAddr so the launched node
 // client can be connected to more easily (even though it is often ignored).
 #[cfg(feature = "fuel-core-lib")]
-pub async fn setup_test_client(
+async fn setup_test_client(
     coins: Vec<(UtxoId, Coin)>,
     node_config: Option<Config>,
 ) -> (FuelClient, SocketAddr) {

--- a/packages/fuels-test-helpers/src/lib.rs
+++ b/packages/fuels-test-helpers/src/lib.rs
@@ -125,7 +125,7 @@ pub fn setup_single_asset_coins(
 // Setup a test client with the given coins. We return the SocketAddr so the launched node
 // client can be connected to more easily (even though it is often ignored).
 #[cfg(feature = "fuel-core-lib")]
-async fn setup_test_client(
+pub async fn setup_test_client(
     coins: Vec<(UtxoId, Coin)>,
     node_config: Option<Config>,
 ) -> (FuelClient, SocketAddr) {

--- a/packages/fuels-test-helpers/src/script.rs
+++ b/packages/fuels-test-helpers/src/script.rs
@@ -5,7 +5,7 @@ use fuel_core::service::{Config, FuelService};
 use fuel_gql_client::client::FuelClient;
 
 #[cfg(not(feature = "fuel-core-lib"))]
-use crate::launch_provider_and_get_single_wallet;
+use crate::launch_provider_and_get_wallet;
 
 use fuel_gql_client::fuel_tx::{Receipt, Transaction};
 use fuels_contract::script::Script;
@@ -29,7 +29,7 @@ pub async fn run_compiled_script(binary_filepath: &str) -> Result<Vec<Receipt>, 
 pub async fn run_compiled_script(binary_filepath: &str) -> Result<Vec<Receipt>, Error> {
     let script_binary = std::fs::read(binary_filepath)?;
 
-    let wallet = launch_provider_and_get_single_wallet().await;
+    let wallet = launch_provider_and_get_wallet().await;
     let client = wallet.get_provider().unwrap().clone().client;
 
     let script = get_script(script_binary);

--- a/packages/fuels-test-helpers/src/signers.rs
+++ b/packages/fuels-test-helpers/src/signers.rs
@@ -2,9 +2,6 @@ use std::net::SocketAddr;
 
 #[cfg(feature = "fuel-core-lib")]
 use fuel_core::{model::Coin, service::Config};
-
-use crate::{DEFAULT_COIN_AMOUNT, DEFAULT_NUM_COINS};
-
 use fuel_gql_client::fuel_tx::UtxoId;
 
 #[cfg(not(feature = "fuel-core-lib"))]
@@ -18,49 +15,34 @@ use fuels_signers::{provider::Provider, LocalWallet, Signer};
 use crate::{setup_single_asset_coins, setup_test_client, wallets_config::WalletsConfig};
 
 #[cfg(feature = "fuel-core-lib")]
-pub async fn launch_provider_and_get_single_wallet() -> LocalWallet {
-    let mut wallets = launch_provider_and_get_wallets(WalletsConfig::new_single(None, None)).await;
+pub async fn launch_provider_and_get_wallet() -> LocalWallet {
+    let mut wallets =
+        launch_custom_provider_and_get_wallets(WalletsConfig::new_single(None, None), None).await;
 
     wallets.pop().unwrap()
 }
 
 #[cfg(feature = "fuel-core-lib")]
-pub async fn launch_custom_provider_and_get_single_wallet(
-    node_config: Option<Config>,
-) -> LocalWallet {
-    let mut wallet = LocalWallet::new_random(None);
-
-    let coins: Vec<(UtxoId, Coin)> = setup_single_asset_coins(
-        wallet.address(),
-        Default::default(),
-        DEFAULT_NUM_COINS,
-        DEFAULT_COIN_AMOUNT,
-    );
-
-    let (provider, _) = setup_test_provider(coins, node_config).await;
-
-    wallet.set_provider(provider);
-    wallet
-}
-
-#[cfg(feature = "fuel-core-lib")]
-pub async fn launch_provider_and_get_wallets(config: WalletsConfig) -> Vec<LocalWallet> {
-    let mut wallets: Vec<LocalWallet> = (1..=config.num_wallets)
+pub async fn launch_custom_provider_and_get_wallets(
+    wallet_config: WalletsConfig,
+    provider_config: Option<Config>,
+) -> Vec<LocalWallet> {
+    let mut wallets: Vec<LocalWallet> = (1..=wallet_config.num_wallets)
         .map(|_i| LocalWallet::new_random(None))
         .collect();
 
-    let mut all_coins: Vec<(UtxoId, Coin)> = Vec::with_capacity(config.num_wallets as usize);
+    let mut all_coins: Vec<(UtxoId, Coin)> = Vec::with_capacity(wallet_config.num_wallets as usize);
     for wallet in &wallets {
         let coins: Vec<(UtxoId, Coin)> = setup_single_asset_coins(
             wallet.address(),
             Default::default(),
-            config.coins_per_wallet,
-            config.coin_amount,
+            wallet_config.coins_per_wallet,
+            wallet_config.coin_amount,
         );
         all_coins.extend(coins);
     }
 
-    let (provider, _) = setup_test_provider(all_coins, None).await;
+    let (provider, _) = setup_test_provider(all_coins, provider_config).await;
 
     wallets
         .iter_mut()
@@ -81,49 +63,34 @@ pub async fn setup_test_provider(
 }
 
 #[cfg(not(feature = "fuel-core-lib"))]
-pub async fn launch_provider_and_get_single_wallet() -> LocalWallet {
-    let mut wallets = launch_provider_and_get_wallets(WalletsConfig::new_single(None, None)).await;
+pub async fn launch_provider_and_get_wallet() -> LocalWallet {
+    let mut wallets =
+        launch_custom_provider_and_get_wallets(WalletsConfig::new_single(None, None), None).await;
 
     wallets.pop().unwrap()
 }
 
 #[cfg(not(feature = "fuel-core-lib"))]
-pub async fn launch_custom_provider_and_get_single_wallet(
-    node_config: Option<Config>,
-) -> LocalWallet {
-    let mut wallet = LocalWallet::new_random(None);
-
-    let coins: Vec<(UtxoId, Coin)> = setup_single_asset_coins(
-        wallet.address(),
-        Default::default(),
-        DEFAULT_NUM_COINS,
-        DEFAULT_COIN_AMOUNT,
-    );
-
-    let (provider, _) = setup_test_provider(coins, node_config).await;
-
-    wallet.set_provider(provider);
-    wallet
-}
-
-#[cfg(not(feature = "fuel-core-lib"))]
-pub async fn launch_provider_and_get_wallets(config: WalletsConfig) -> Vec<LocalWallet> {
-    let mut wallets: Vec<LocalWallet> = (1..=config.num_wallets)
+pub async fn launch_custom_provider_and_get_wallets(
+    wallet_config: WalletsConfig,
+    provider_config: Option<Config>,
+) -> Vec<LocalWallet> {
+    let mut wallets: Vec<LocalWallet> = (1..=wallet_config.num_wallets)
         .map(|_i| LocalWallet::new_random(None))
         .collect();
 
-    let mut all_coins: Vec<(UtxoId, Coin)> = Vec::with_capacity(config.num_wallets as usize);
+    let mut all_coins: Vec<(UtxoId, Coin)> = Vec::with_capacity(wallet_config.num_wallets as usize);
     for wallet in &wallets {
         let coins: Vec<(UtxoId, Coin)> = setup_single_asset_coins(
             wallet.address(),
             Default::default(),
-            config.coins_per_wallet,
-            config.coin_amount,
+            wallet_config.coins_per_wallet,
+            wallet_config.coin_amount,
         );
         all_coins.extend(coins);
     }
 
-    let (provider, _) = setup_test_provider(all_coins, None).await;
+    let (provider, _) = setup_test_provider(all_coins, provider_config).await;
 
     wallets
         .iter_mut()
@@ -143,21 +110,22 @@ pub async fn setup_test_provider(
 
 #[cfg(test)]
 mod tests {
-    use crate::{launch_provider_and_get_wallets, WalletsConfig};
+    use crate::{launch_custom_provider_and_get_wallets, WalletsConfig};
+    use fuels_core::errors::Error;
 
     #[tokio::test]
-    async fn test_wallet_config() {
+    async fn test_wallet_config() -> Result<(), Error> {
         let num_wallets = 2;
         let num_coins = 3;
         let amount = 100;
         let config = WalletsConfig::new(Some(num_wallets), Some(num_coins), Some(amount));
 
-        let wallets = launch_provider_and_get_wallets(config).await;
+        let wallets = launch_custom_provider_and_get_wallets(config, None).await;
 
         assert_eq!(wallets.len(), num_wallets as usize);
 
         for wallet in &wallets {
-            let coins = wallet.get_coins().await.unwrap();
+            let coins = wallet.get_coins().await?;
 
             assert_eq!(coins.len(), num_coins as usize);
 
@@ -165,5 +133,6 @@ mod tests {
                 assert_eq!(coin.amount.0, amount);
             }
         }
+        Ok(())
     }
 }

--- a/packages/fuels-test-helpers/src/signers.rs
+++ b/packages/fuels-test-helpers/src/signers.rs
@@ -14,7 +14,6 @@ use fuels_signers::{provider::Provider, LocalWallet, Signer};
 
 use crate::{setup_single_asset_coins, setup_test_client, wallets_config::WalletsConfig};
 
-#[cfg(feature = "fuel-core-lib")]
 pub async fn launch_provider_and_get_wallet() -> LocalWallet {
     let mut wallets =
         launch_custom_provider_and_get_wallets(WalletsConfig::new_single(None, None), None).await;
@@ -60,14 +59,6 @@ pub async fn setup_test_provider(
 ) -> (Provider, SocketAddr) {
     let (client, addr) = setup_test_client(coins, node_config).await;
     (Provider::new(client), addr)
-}
-
-#[cfg(not(feature = "fuel-core-lib"))]
-pub async fn launch_provider_and_get_wallet() -> LocalWallet {
-    let mut wallets =
-        launch_custom_provider_and_get_wallets(WalletsConfig::new_single(None, None), None).await;
-
-    wallets.pop().unwrap()
 }
 
 #[cfg(not(feature = "fuel-core-lib"))]


### PR DESCRIPTION
Closes: https://github.com/FuelLabs/fuels-rs/issues/312

Changed the `launch_provider_and_get_single_wallet` to `launch_provider_and_get_wallet`.
Deleted `launch_provider_and_get_wallets` and `launch_custom_provider_and_get_single_wallet`.
Instead, we are going to use `launch_custom_provider_and_get_wallets` where we customize both the provider and wallet.