### PR TITLE
doc: update launch functions reference after refactor

### DIFF
--- a/docs/src/getting-started/basics.md
+++ b/docs/src/getting-started/basics.md
@@ -4,7 +4,7 @@ At a high level, the Fuel Rust SDK can be used to build Rust-based applications 
 
 For this interaction to work, the SDK must be able to communicate to a `fuel-core` node; you have two options at your disposal:
 
-1. Use the SDK's native `launch_provider_and_get_single_wallet()` that runs a short-lived test Fuel node;
+1. Use the SDK's native `launch_provider_and_get_wallet()` that runs a short-lived test Fuel node;
 2. Run a Fuel node outside your SDK code (using `fuel-core`) and point your SDK to that node's IP and port.
 
 The first option is ideal for contract testing, as you can quickly spin up and tear down nodes between specific test cases.


### PR DESCRIPTION
In my last PR https://github.com/FuelLabs/fuels-rs/pull/422 I forgot to update the fuels-rs book.
Luckily, we need to update only one mention of the refactored functions as the examples were already updated.