### PR TITLE
refactor: tests return Result<> when applicable

### DIFF
--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -4,18 +4,19 @@ use fuels::prelude::Error;
 #[tokio::test]
 #[cfg(feature = "fuel-core-lib")]
 // ANCHOR: instantiate_client
-async fn instantiate_client() {
+async fn instantiate_client() -> Result<(), Error> {
     use fuels::client::FuelClient;
     use fuels::node::service::{Config, FuelService};
 
-    let server = FuelService::new_node(Config::local_node()).await.unwrap();
+    let server = FuelService::new_node(Config::local_node()).await?;
     let client = FuelClient::from(server.bound_address);
-    assert!(client.health().await.unwrap());
+    assert!(client.health().await?);
+    Ok(())
 }
 // ANCHOR_END: instantiate_client
 
 #[tokio::test]
-async fn deploy_contract() {
+async fn deploy_contract() -> Result<(), Error> {
     use fuels::prelude::*;
 
     // ANCHOR: deploy_contract
@@ -50,8 +51,8 @@ async fn deploy_contract() {
                 Some(maturity)
             )
         )
-        .await
-        .unwrap();
+        .await?;
+
     println!("Contract deployed @ {:x}", contract_id);
     // ANCHOR_END: deploy_contract
 
@@ -62,24 +63,20 @@ async fn deploy_contract() {
     let response = contract_instance
         .initialize_counter(42) // Build the ABI call
         .call() // Perform the network call
-        .await
-        .unwrap();
+        .await?;
 
     assert_eq!(42, response.value);
 
-    let response = contract_instance
-        .increment_counter(10)
-        .call()
-        .await
-        .unwrap();
+    let response = contract_instance.increment_counter(10).call().await?;
 
     assert_eq!(52, response.value);
     // ANCHOR_END: use_deployed_contract
+    Ok(())
 }
 
 #[tokio::test]
 // ANCHOR: deploy_with_salt
-async fn deploy_with_salt() {
+async fn deploy_with_salt() -> Result<(), Error> {
     use fuels::prelude::*;
     use rand::prelude::{Rng, SeedableRng, StdRng};
 
@@ -95,8 +92,7 @@ async fn deploy_with_salt() {
             &wallet,
             TxParameters::default(),
         )
-        .await
-        .unwrap();
+        .await?;
 
     println!("Contract deployed @ {:x}", contract_id_1);
 
@@ -109,18 +105,18 @@ async fn deploy_with_salt() {
             TxParameters::default(),
             Salt::from(salt),
         )
-        .await
-        .unwrap();
+        .await?;
 
     println!("Contract deployed @ {:x}", contract_id_2);
 
     assert_ne!(contract_id_1, contract_id_2);
+    Ok(())
 }
 // ANCHOR_END: deploy_with_salt
 
 #[tokio::test]
 // ANCHOR: deploy_with_multiple_wallets
-async fn deploy_with_multiple_wallets() {
+async fn deploy_with_multiple_wallets() -> Result<(), Error> {
     use fuels::prelude::*;
 
     abigen!(
@@ -135,8 +131,7 @@ async fn deploy_with_multiple_wallets() {
             &wallets[0],
             TxParameters::default(),
         )
-        .await
-        .unwrap();
+        .await?;
 
     println!("Contract deployed @ {:x}", contract_id_1);
     let contract_instance_1 = MyContract::new(contract_id_1.to_string(), wallets[0].clone());
@@ -145,8 +140,7 @@ async fn deploy_with_multiple_wallets() {
         .initialize_counter(42) // Build the ABI call
         .tx_params(TxParameters::new(None, Some(1_000_000), None, None))
         .call() // Perform the network call
-        .await
-        .unwrap();
+        .await?;
 
     assert_eq!(42, response.value);
 
@@ -155,8 +149,7 @@ async fn deploy_with_multiple_wallets() {
             &wallets[1],
             TxParameters::default(),
         )
-        .await
-        .unwrap();
+        .await?;
 
     println!("Contract deployed @ {:x}", contract_id_2);
     let contract_instance_2 = MyContract::new(contract_id_2.to_string(), wallets[1].clone());
@@ -165,10 +158,10 @@ async fn deploy_with_multiple_wallets() {
         .initialize_counter(42) // Build the ABI call
         .tx_params(TxParameters::new(None, Some(1_000_000), None, None))
         .call() // Perform the network call
-        .await
-        .unwrap();
+        .await?;
 
     assert_eq!(42, response.value);
+    Ok(())
 }
 // ANCHOR_END: deploy_with_multiple_wallets
 
@@ -363,8 +356,7 @@ async fn call_params_gas() -> Result<(), Error> {
         &wallet,
         TxParameters::default(),
     )
-    .await
-    .unwrap();
+    .await?;
 
     let contract_instance = MyContract::new(contract_id.to_string(), wallet.clone());
 

--- a/packages/fuels-core/src/abi_decoder.rs
+++ b/packages/fuels-core/src/abi_decoder.rs
@@ -301,19 +301,21 @@ fn peek(data: &[u8], len: usize) -> Result<&[u8], CodecError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::errors::Error;
     use crate::EnumVariants;
 
     #[test]
-    fn decode_int() {
+    fn decode_int() -> Result<(), Error> {
         let data = [0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xff, 0xff];
 
-        let decoded = ABIDecoder::decode_single(&ParamType::U32, &data).unwrap();
+        let decoded = ABIDecoder::decode_single(&ParamType::U32, &data)?;
 
         assert_eq!(decoded, Token::U32(u32::MAX));
+        Ok(())
     }
 
     #[test]
-    fn decode_multiple_int() {
+    fn decode_multiple_int() -> Result<(), Error> {
         let types = vec![
             ParamType::U32,
             ParamType::U8,
@@ -326,7 +328,7 @@ mod tests {
             0xff,
         ];
 
-        let decoded = ABIDecoder::decode(&types, &data).unwrap();
+        let decoded = ABIDecoder::decode(&types, &data)?;
 
         let expected = vec![
             Token::U32(u32::MAX),
@@ -335,37 +337,40 @@ mod tests {
             Token::U64(u64::MAX),
         ];
         assert_eq!(decoded, expected);
+        Ok(())
     }
 
     #[test]
-    fn decode_bool() {
+    fn decode_bool() -> Result<(), Error> {
         let types = vec![ParamType::Bool, ParamType::Bool];
         let data = [
             0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x01, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x00,
         ];
 
-        let decoded = ABIDecoder::decode(&types, &data).unwrap();
+        let decoded = ABIDecoder::decode(&types, &data)?;
 
         let expected = vec![Token::Bool(true), Token::Bool(false)];
 
         assert_eq!(decoded, expected);
+        Ok(())
     }
 
     #[test]
-    fn decode_b256() {
+    fn decode_b256() -> Result<(), Error> {
         let data = [
             0xd5, 0x57, 0x9c, 0x46, 0xdf, 0xcc, 0x7f, 0x18, 0x20, 0x70, 0x13, 0xe6, 0x5b, 0x44,
             0xe4, 0xcb, 0x4e, 0x2c, 0x22, 0x98, 0xf4, 0xac, 0x45, 0x7b, 0xa8, 0xf8, 0x27, 0x43,
             0xf3, 0x1e, 0x93, 0xb,
         ];
 
-        let decoded = ABIDecoder::decode_single(&ParamType::B256, &data).unwrap();
+        let decoded = ABIDecoder::decode_single(&ParamType::B256, &data)?;
 
         assert_eq!(decoded, Token::B256(data));
+        Ok(())
     }
 
     #[test]
-    fn decode_string() {
+    fn decode_string() -> Result<(), Error> {
         let types = vec![ParamType::String(23), ParamType::String(5)];
         let data = [
             0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x66, 0x75, 0x6c, 0x6c,
@@ -373,7 +378,7 @@ mod tests {
             0x6f, 0x0, 0x0, 0x0,
         ];
 
-        let decoded = ABIDecoder::decode(&types, &data).unwrap();
+        let decoded = ABIDecoder::decode(&types, &data)?;
 
         let expected = vec![
             Token::String("This is a full sentence".into()),
@@ -381,23 +386,25 @@ mod tests {
         ];
 
         assert_eq!(decoded, expected);
+        Ok(())
     }
     #[test]
-    fn decode_array() {
+    fn decode_array() -> Result<(), Error> {
         // Create a parameter type for u8[2].
         let types = vec![ParamType::Array(Box::new(ParamType::U8), 2)];
         let data = [
             0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2a,
         ];
 
-        let decoded = ABIDecoder::decode(&types, &data).unwrap();
+        let decoded = ABIDecoder::decode(&types, &data)?;
 
         let expected = vec![Token::Array(vec![Token::U8(255), Token::U8(42)])];
         assert_eq!(decoded, expected);
+        Ok(())
     }
 
     #[test]
-    fn decode_struct() {
+    fn decode_struct() -> Result<(), Error> {
         // Sway struct:
         // struct MyStruct {
         //     foo: u8,
@@ -409,22 +416,23 @@ mod tests {
         ];
         let param_type = ParamType::Struct(vec![ParamType::U8, ParamType::Bool]);
 
-        let decoded = ABIDecoder::decode_single(&param_type, &data).unwrap();
+        let decoded = ABIDecoder::decode_single(&param_type, &data)?;
 
         let expected = Token::Struct(vec![Token::U8(1), Token::Bool(true)]);
 
         assert_eq!(decoded, expected);
+        Ok(())
     }
 
     #[test]
-    fn decode_enum() {
+    fn decode_enum() -> Result<(), Error> {
         // Sway enum:
         // enum MyEnum {
         //     x: u32,
         //     y: bool,
         // }
 
-        let inner_enum_types = EnumVariants::new(vec![ParamType::U32, ParamType::Bool]).unwrap();
+        let inner_enum_types = EnumVariants::new(vec![ParamType::U32, ParamType::Bool])?;
         let types = vec![ParamType::Enum(inner_enum_types.clone())];
 
         // "0" discriminant and 42 enum value
@@ -432,14 +440,15 @@ mod tests {
             0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2a,
         ];
 
-        let decoded = ABIDecoder::decode(&types, &data).unwrap();
+        let decoded = ABIDecoder::decode(&types, &data)?;
 
         let expected = vec![Token::Enum(Box::new((0, Token::U32(42), inner_enum_types)))];
         assert_eq!(decoded, expected);
+        Ok(())
     }
 
     #[test]
-    fn decoder_will_skip_enum_padding_and_decode_next_arg() {
+    fn decoder_will_skip_enum_padding_and_decode_next_arg() -> Result<(), Error> {
         // struct MyStruct {
         //     par1: MyEnum,
         //     par2: u32
@@ -450,7 +459,7 @@ mod tests {
         //     y: u32,
         // }
 
-        let inner_enum_types = EnumVariants::new(vec![ParamType::B256, ParamType::U32]).unwrap();
+        let inner_enum_types = EnumVariants::new(vec![ParamType::B256, ParamType::U32])?;
 
         let struct_type = ParamType::Struct(vec![
             ParamType::Enum(inner_enum_types.clone()),
@@ -472,17 +481,18 @@ mod tests {
         .flatten()
         .collect();
 
-        let decoded = ABIDecoder::decode_single(&struct_type, &data).unwrap();
+        let decoded = ABIDecoder::decode_single(&struct_type, &data)?;
 
         let expected = Token::Struct(vec![
             Token::Enum(Box::new((1, Token::U32(12345), inner_enum_types))),
             Token::U32(54321),
         ]);
         assert_eq!(decoded, expected);
+        Ok(())
     }
 
     #[test]
-    fn decode_nested_struct() {
+    fn decode_nested_struct() -> Result<(), Error> {
         // Sway nested struct:
         // struct Foo {
         //     x: u16,
@@ -507,7 +517,7 @@ mod tests {
             0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2,
         ];
 
-        let decoded = ABIDecoder::decode_single(&nested_struct, &data).unwrap();
+        let decoded = ABIDecoder::decode_single(&nested_struct, &data)?;
 
         let my_nested_struct = vec![
             Token::U16(10),
@@ -518,10 +528,11 @@ mod tests {
         ];
 
         assert_eq!(decoded, Token::Struct(my_nested_struct));
+        Ok(())
     }
 
     #[test]
-    fn decode_comprehensive() {
+    fn decode_comprehensive() -> Result<(), Error> {
         // Sway nested struct:
         // struct Foo {
         //     x: u16,
@@ -566,7 +577,7 @@ mod tests {
             0x65, 0x6e, 0x74, 0x65, 0x6e, 0x63, 0x65, 0x0, // str[23]
         ];
 
-        let decoded = ABIDecoder::decode(&types, &data).unwrap();
+        let decoded = ABIDecoder::decode(&types, &data)?;
 
         // Expected tokens
         let foo = Token::Struct(vec![
@@ -590,35 +601,40 @@ mod tests {
         let expected: Vec<Token> = vec![foo, u8_arr, b256, s];
 
         assert_eq!(decoded, expected);
+        Ok(())
     }
+
     #[test]
-    fn units_in_structs_are_decoded_as_one_word() {
+    fn units_in_structs_are_decoded_as_one_word() -> Result<(), Error> {
         let data = [
             0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
         ];
         let struct_type = ParamType::Struct(vec![ParamType::Unit, ParamType::U64]);
 
-        let actual = ABIDecoder::decode_single(&struct_type, &data).unwrap();
+        let actual = ABIDecoder::decode_single(&struct_type, &data)?;
 
         let expected = Token::Struct(vec![Token::Unit, Token::U64(u64::MAX)]);
         assert_eq!(actual, expected);
+        Ok(())
     }
+
     #[test]
-    fn enums_with_all_unit_variants_are_decoded_from_one_word() {
+    fn enums_with_all_unit_variants_are_decoded_from_one_word() -> Result<(), Error> {
         let data = [0, 0, 0, 0, 0, 0, 0, 1];
-        let variants = EnumVariants::new(vec![ParamType::Unit, ParamType::Unit]).unwrap();
+        let variants = EnumVariants::new(vec![ParamType::Unit, ParamType::Unit])?;
         let enum_w_only_units = ParamType::Enum(variants.clone());
 
-        let result = ABIDecoder::decode_single(&enum_w_only_units, &data).unwrap();
+        let result = ABIDecoder::decode_single(&enum_w_only_units, &data)?;
 
         let expected_enum = Token::Enum(Box::new((1, Token::Unit, variants)));
         assert_eq!(result, expected_enum);
+        Ok(())
     }
 
     #[test]
-    fn out_of_bounds_discriminant_is_detected() {
+    fn out_of_bounds_discriminant_is_detected() -> Result<(), Error> {
         let data = [0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2];
-        let variants = EnumVariants::new(vec![ParamType::U32]).unwrap();
+        let variants = EnumVariants::new(vec![ParamType::U32])?;
         let enum_type = ParamType::Enum(variants);
 
         let result = ABIDecoder::decode_single(&enum_type, &data);
@@ -627,5 +643,6 @@ mod tests {
 
         let expected_msg = "Error while decoding an enum. The discriminant '1' doesn't point to any of the following variants: ";
         assert!(matches!(error, CodecError::InvalidData(str) if str.starts_with(expected_msg)));
+        Ok(())
     }
 }

--- a/packages/fuels-core/src/abi_encoder.rs
+++ b/packages/fuels-core/src/abi_encoder.rs
@@ -171,6 +171,7 @@ impl ABIEncoder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::errors::Error;
     use crate::{EnumVariants, ParamType};
     use std::slice;
 
@@ -189,7 +190,7 @@ mod tests {
     }
 
     #[test]
-    fn encode_function_with_u32_type() {
+    fn encode_function_with_u32_type() -> Result<(), Error> {
         // let json_abi =
         // r#"
         // [
@@ -213,16 +214,17 @@ mod tests {
 
         let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = ABIEncoder::encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args)?;
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
         assert_eq!(encoded_function_selector, expected_function_selector);
+        Ok(())
     }
 
     #[test]
-    fn encode_function_with_u32_type_multiple_args() {
+    fn encode_function_with_u32_type_multiple_args() -> Result<(), Error> {
         // let json_abi =
         // r#"
         // [
@@ -248,16 +250,17 @@ mod tests {
         let expected_fn_selector = [0x0, 0x0, 0x0, 0x0, 0xa7, 0x07, 0xb0, 0x8e];
 
         let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
-        let encoded = ABIEncoder::encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args)?;
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
         assert_eq!(encoded_function_selector, expected_fn_selector);
+        Ok(())
     }
 
     #[test]
-    fn encode_function_with_u64_type() {
+    fn encode_function_with_u64_type() -> Result<(), Error> {
         // let json_abi =
         // r#"
         // [
@@ -281,16 +284,17 @@ mod tests {
 
         let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = ABIEncoder::encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args)?;
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
         assert_eq!(encoded_function_selector, expected_function_selector);
+        Ok(())
     }
 
     #[test]
-    fn encode_function_with_bool_type() {
+    fn encode_function_with_bool_type() -> Result<(), Error> {
         // let json_abi =
         // r#"
         // [
@@ -314,16 +318,17 @@ mod tests {
 
         let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = ABIEncoder::encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args)?;
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
         assert_eq!(encoded_function_selector, expected_function_selector);
+        Ok(())
     }
 
     #[test]
-    fn encode_function_with_two_different_type() {
+    fn encode_function_with_two_different_type() -> Result<(), Error> {
         // let json_abi =
         // r#"
         // [
@@ -350,16 +355,17 @@ mod tests {
 
         let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = ABIEncoder::encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args)?;
 
         println!("Encoded ABI for ({}) {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
         assert_eq!(encoded_function_selector, expected_function_selector);
+        Ok(())
     }
 
     #[test]
-    fn encode_function_with_byte_type() {
+    fn encode_function_with_byte_type() -> Result<(), Error> {
         // let json_abi =
         // r#"
         // [
@@ -383,16 +389,17 @@ mod tests {
 
         let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = ABIEncoder::encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args)?;
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
         assert_eq!(encoded_function_selector, expected_function_selector);
+        Ok(())
     }
 
     #[test]
-    fn encode_function_with_bits256_type() {
+    fn encode_function_with_bits256_type() -> Result<(), Error> {
         // let json_abi =
         // r#"
         // [
@@ -426,16 +433,17 @@ mod tests {
 
         let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = ABIEncoder::encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args)?;
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
         assert_eq!(encoded_function_selector, expected_function_selector);
+        Ok(())
     }
 
     #[test]
-    fn encode_function_with_array_type() {
+    fn encode_function_with_array_type() -> Result<(), Error> {
         // let json_abi =
         // r#"
         // [
@@ -469,16 +477,17 @@ mod tests {
 
         let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = ABIEncoder::encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args)?;
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
         assert_eq!(encoded_function_selector, expected_function_selector);
+        Ok(())
     }
 
     #[test]
-    fn encode_function_with_string_type() {
+    fn encode_function_with_string_type() -> Result<(), Error> {
         // let json_abi =
         // r#"
         // [
@@ -504,16 +513,17 @@ mod tests {
 
         let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = ABIEncoder::encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args)?;
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
         assert_eq!(encoded_function_selector, expected_function_selector);
+        Ok(())
     }
 
     #[test]
-    fn encode_function_with_struct() {
+    fn encode_function_with_struct() -> Result<(), Error> {
         // let json_abi =
         // r#"
         // [
@@ -550,7 +560,7 @@ mod tests {
 
         let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = ABIEncoder::encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args)?;
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
@@ -558,10 +568,11 @@ mod tests {
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
         assert_eq!(encoded_function_selector, expected_function_selector);
+        Ok(())
     }
 
     #[test]
-    fn encode_function_with_enum() {
+    fn encode_function_with_enum() -> Result<(), Error> {
         // let json_abi =
         // r#"
         // [
@@ -581,7 +592,7 @@ mod tests {
         //     x: u32,
         //     y: bool,
         // }
-        let params = EnumVariants::new(vec![ParamType::U32, ParamType::Bool]).unwrap();
+        let params = EnumVariants::new(vec![ParamType::U32, ParamType::Bool])?;
 
         // An `EnumSelector` indicating that we've chosen the first Enum variant,
         // whose value is 42 of the type ParamType::U32 and that the Enum could
@@ -601,22 +612,23 @@ mod tests {
 
         let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = ABIEncoder::encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args)?;
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
         assert_eq!(encoded_function_selector, expected_function_selector);
+        Ok(())
     }
 
     // The encoding follows the ABI specs defined  [here](https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md)
     #[test]
-    fn enums_are_sized_to_fit_the_biggest_variant() {
+    fn enums_are_sized_to_fit_the_biggest_variant() -> Result<(), Error> {
         // Our enum has two variants: B256, and U64. So the enum will set aside
         // 256b of space or 4 WORDS because that is the space needed to fit the
         // largest variant(B256).
-        let enum_variants = EnumVariants::new(vec![ParamType::B256, ParamType::U64]).unwrap();
+        let enum_variants = EnumVariants::new(vec![ParamType::B256, ParamType::U64])?;
         let enum_selector = Box::new((1, Token::U64(42), enum_variants));
 
-        let encoded = ABIEncoder::encode(slice::from_ref(&Token::Enum(enum_selector))).unwrap();
+        let encoded = ABIEncoder::encode(slice::from_ref(&Token::Enum(enum_selector)))?;
 
         let enum_discriminant_enc = vec![0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1];
         let u64_enc = vec![0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2a];
@@ -630,18 +642,18 @@ mod tests {
             .collect();
 
         assert_eq!(hex::encode(expected), hex::encode(encoded));
+        Ok(())
     }
 
     #[test]
-    fn encoding_enums_with_deeply_nested_types() {
+    fn encoding_enums_with_deeply_nested_types() -> Result<(), Error> {
         /*
         enum DeeperEnum {
             v1: bool,
             v2: str[10]
         }
          */
-        let deeper_enum_variants =
-            EnumVariants::new(vec![ParamType::Bool, ParamType::String(10)]).unwrap();
+        let deeper_enum_variants = EnumVariants::new(vec![ParamType::Bool, ParamType::String(10)])?;
         let deeper_enum_token = Token::String("0123456789".to_owned());
         let str_enc = vec![
             b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', 0x0, 0x0, 0x0, 0x0, 0x0,
@@ -676,12 +688,12 @@ mod tests {
         */
 
         let top_level_enum_variants =
-            EnumVariants::new(vec![struct_a_type, ParamType::Bool, ParamType::U64]).unwrap();
+            EnumVariants::new(vec![struct_a_type, ParamType::Bool, ParamType::U64])?;
         let top_level_enum_token =
             Token::Enum(Box::new((0, struct_a_token, top_level_enum_variants)));
         let top_lvl_discriminant_enc = vec![0x0; 8];
 
-        let encoded = ABIEncoder::encode(slice::from_ref(&top_level_enum_token)).unwrap();
+        let encoded = ABIEncoder::encode(slice::from_ref(&top_level_enum_token))?;
 
         let correct_encoding: Vec<u8> = [
             top_lvl_discriminant_enc,
@@ -694,10 +706,11 @@ mod tests {
         .collect();
 
         assert_eq!(hex::encode(correct_encoding), hex::encode(encoded));
+        Ok(())
     }
 
     #[test]
-    fn encode_function_with_nested_structs() {
+    fn encode_function_with_nested_structs() -> Result<(), Error> {
         // let json_abi =
         // r#"
         // [
@@ -740,16 +753,17 @@ mod tests {
 
         let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = ABIEncoder::encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args)?;
 
         println!("Encoded ABI for ({}): {:#0x?}", sway_fn, encoded);
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
         assert_eq!(encoded_function_selector, expected_function_selector);
+        Ok(())
     }
 
     #[test]
-    fn encode_comprehensive_function() {
+    fn encode_comprehensive_function() -> Result<(), Error> {
         // let json_abi =
         // r#"
         // [
@@ -831,38 +845,41 @@ mod tests {
 
         let encoded_function_selector = ABIEncoder::encode_function_selector(sway_fn);
 
-        let encoded = ABIEncoder::encode(&args).unwrap();
+        let encoded = ABIEncoder::encode(&args)?;
 
         assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
         assert_eq!(encoded_function_selector, expected_function_selector);
+        Ok(())
     }
 
     #[test]
-    fn enums_with_only_unit_variants_are_encoded_in_one_word() {
+    fn enums_with_only_unit_variants_are_encoded_in_one_word() -> Result<(), Error> {
         let expected = [0, 0, 0, 0, 0, 0, 0, 1];
 
         let enum_selector = Box::new((
             1,
             Token::Unit,
-            EnumVariants::new(vec![ParamType::Unit, ParamType::Unit]).unwrap(),
+            EnumVariants::new(vec![ParamType::Unit, ParamType::Unit])?,
         ));
 
-        let actual = ABIEncoder::encode(&[Token::Enum(enum_selector)]).unwrap();
+        let actual = ABIEncoder::encode(&[Token::Enum(enum_selector)])?;
 
         assert_eq!(actual, expected);
+        Ok(())
     }
 
     #[test]
-    fn units_in_composite_types_are_encoded_in_one_word() {
+    fn units_in_composite_types_are_encoded_in_one_word() -> Result<(), Error> {
         let expected = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5];
 
-        let actual =
-            ABIEncoder::encode(&[Token::Struct(vec![Token::Unit, Token::U32(5)])]).unwrap();
+        let actual = ABIEncoder::encode(&[Token::Struct(vec![Token::Unit, Token::U32(5)])])?;
 
         assert_eq!(actual, expected);
+        Ok(())
     }
+
     #[test]
-    fn enums_with_units_are_correctly_padded() {
+    fn enums_with_units_are_correctly_padded() -> Result<(), Error> {
         let discriminant = vec![0, 0, 0, 0, 0, 0, 0, 1];
         let padding = vec![0; 32];
         let expected: Vec<u8> = [discriminant, padding].into_iter().flatten().collect();
@@ -870,11 +887,12 @@ mod tests {
         let enum_selector = Box::new((
             1,
             Token::Unit,
-            EnumVariants::new(vec![ParamType::B256, ParamType::Unit]).unwrap(),
+            EnumVariants::new(vec![ParamType::B256, ParamType::Unit])?,
         ));
 
-        let actual = ABIEncoder::encode(&[Token::Enum(enum_selector)]).unwrap();
+        let actual = ABIEncoder::encode(&[Token::Enum(enum_selector)])?;
 
         assert_eq!(actual, expected);
+        Ok(())
     }
 }

--- a/packages/fuels-core/src/encoding_utils.rs
+++ b/packages/fuels-core/src/encoding_utils.rs
@@ -49,6 +49,7 @@ mod tests {
     const WIDTH_OF_U32: usize = 1;
     const WIDTH_OF_BOOL: usize = 1;
     use crate::encoding_utils::compute_encoding_width;
+    use crate::errors::Error;
     use crate::{EnumVariants, ParamType};
 
     #[test]
@@ -87,15 +88,16 @@ mod tests {
     }
 
     #[test]
-    fn enums_are_as_big_as_their_biggest_variant_plus_a_word() {
+    fn enums_are_as_big_as_their_biggest_variant_plus_a_word() -> Result<(), Error> {
         let inner_struct = ParamType::Struct(vec![ParamType::B256]);
-        let param = ParamType::Enum(EnumVariants::new(vec![ParamType::U32, inner_struct]).unwrap());
+        let param = ParamType::Enum(EnumVariants::new(vec![ParamType::U32, inner_struct])?);
 
         let width = compute_encoding_width(&param);
 
         const INNER_STRUCT_SIZE: usize = WIDTH_OF_B256;
         const EXPECTED_WIDTH: usize = INNER_STRUCT_SIZE + 1;
         assert_eq!(EXPECTED_WIDTH, width);
+        Ok(())
     }
 
     #[test]

--- a/packages/fuels-test-helpers/src/lib.rs
+++ b/packages/fuels-test-helpers/src/lib.rs
@@ -211,12 +211,12 @@ mod tests {
     use std::net::Ipv4Addr;
 
     #[tokio::test]
-    async fn test_setup_single_asset_coins() {
+    async fn test_setup_single_asset_coins() -> Result<(), rand::Error> {
         let mut rng = rand::thread_rng();
         let mut address = Address::zeroed();
-        address.try_fill(&mut rng).unwrap();
+        address.try_fill(&mut rng)?;
         let mut asset_id = AssetId::zeroed();
-        asset_id.try_fill(&mut rng).unwrap();
+        asset_id.try_fill(&mut rng)?;
         let number_of_coins = 11;
         let amount_per_coin = 10;
         let coins = setup_single_asset_coins(address, asset_id, number_of_coins, amount_per_coin);
@@ -226,13 +226,14 @@ mod tests {
             assert_eq!(coin.amount, amount_per_coin);
             assert_eq!(coin.owner, address);
         }
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_setup_multiple_assets_coins() {
+    async fn test_setup_multiple_assets_coins() -> Result<(), rand::Error> {
         let mut rng = rand::thread_rng();
         let mut address = Address::zeroed();
-        address.try_fill(&mut rng).unwrap();
+        address.try_fill(&mut rng)?;
         let number_of_assets = 7;
         let coins_per_asset = 10;
         let amount_per_coin = 13;
@@ -260,10 +261,11 @@ mod tests {
                 assert_eq!(coin.amount, amount_per_coin);
             }
         }
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_setup_test_client_custom_config() {
+    async fn test_setup_test_client_custom_config() -> Result<(), rand::Error> {
         let socket = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 5000);
 
         let wallet = LocalWallet::new_random(None);
@@ -283,5 +285,6 @@ mod tests {
         let wallets = setup_test_client(coins, Some(config)).await;
 
         assert_eq!(wallets.1, socket);
+        Ok(())
     }
 }

--- a/packages/fuels-test-helpers/src/script.rs
+++ b/packages/fuels-test-helpers/src/script.rs
@@ -69,7 +69,7 @@ mod tests {
         let correct_hex =
             hex::decode("ef86afa9696cf0dc6385e2c407a6e159a1103cefb7e2ae0636fb33d3cb2a9e4a");
 
-        assert_eq!(correct_hex.unwrap(), return_val[0].data().unwrap());
+        assert_eq!(correct_hex?, return_val[0].data().unwrap());
         // ANCHOR_END: run_compiled_script
         Ok(())
     }


### PR DESCRIPTION
closes: https://github.com/FuelLabs/fuels-rs/issues/395

All tests in `fuels-rs` that used unwrap() on a Result<> now have a Result<> return type.

As the issue was unassigned, I took it but later I saw that @thdaraujo already did the `harness.rs` file.
Do we have a way to assign issues to people outside of the organization ?