### PR TITLE
fix: make generated module public

### DIFF
--- a/contract.patch
+++ b/contract.patch
@@ -1,0 +1,142 @@
+diff --git a/packages/fuels-contract/src/contract.rs b/packages/fuels-contract/src/contract.rs
+index 2eef7bc..902e007 100644
+--- a/packages/fuels-contract/src/contract.rs
++++ b/packages/fuels-contract/src/contract.rs
+@@ -452,44 +452,41 @@ where
+ #[derive(Debug)]
+ #[must_use = "contract calls do nothing unless you `call` them"]
+ /// Helper that handles bundling multiple calls into a single transaction
+-pub struct MultiContractCallHandler<D> {
+-    pub contract_calls: Vec<ContractCall>,
++pub struct MultiContractCallHandler {
++    pub contract_calls: Option<Vec<ContractCall>>,
+     pub tx_parameters: TxParameters,
+     pub wallet: LocalWallet,
+     pub fuel_client: FuelClient,
+-    pub datatype: PhantomData<D>,
+ }
+ 
+-impl<D> MultiContractCallHandler<D>
+-where
+-    D: Detokenize + Debug,
+-{
+-    pub fn new(call_handlers: Vec<ContractCallHandler<D>>, wallet: LocalWallet) -> Self {
+-        let contract_calls = call_handlers
+-            .into_iter()
+-            .map(|handler| handler.contract_call)
+-            .collect();
++impl MultiContractCallHandler {
++    pub fn new(wallet: LocalWallet) -> Self {
++        // let contract_calls = call_handlers
++        //     .into_iter()
++        //     .map(|handler| handler.contract_call)
++        //     .collect();
+ 
+         Self {
+-            contract_calls,
++            contract_calls: None,
+             tx_parameters: TxParameters::default(),
+             fuel_client: wallet.get_provider().unwrap().client.clone(),
+             wallet,
+-            datatype: PhantomData,
+         }
+     }
+ 
+     /// Adds a contract call to be bundled in the transaction
+     /// Note that this is a builder method
+-    pub fn add_call(mut self, call_handler: ContractCallHandler<D>) -> Self {
+-        self.contract_calls.push(call_handler.contract_call);
+-
++    pub fn add_call<D: Detokenize>(&mut self, call_handler: ContractCallHandler<D>) -> &mut Self {
++        match self.contract_calls.as_mut() {
++            Some(c) => c.push(call_handler.contract_call),
++            None => self.contract_calls = Some(vec![call_handler.contract_call]),
++        }
+         self
+     }
+ 
+     /// Sets the transaction parameters for a given transaction.
+     /// Note that this is a builder method
+-    pub fn tx_params(mut self, params: TxParameters) -> Self {
++    pub fn tx_params(&mut self, params: TxParameters) -> &mut Self {
+         self.tx_parameters = params;
+         self
+     }
+@@ -497,7 +494,7 @@ where
+     /// Returns the script that executes the contract calls
+     pub async fn get_script(&self) -> Script {
+         Script::from_contract_calls(
+-            self.contract_calls.iter().collect(),
++            self.contract_calls.as_ref().unwrap().iter().collect(),
+             &self.tx_parameters,
+             &self.wallet,
+         )
+@@ -505,19 +502,19 @@ where
+     }
+ 
+     /// Call contract methods on the node, in a state-modifying manner.
+-    pub async fn call(self) -> Result<MultiCallResponse<D>, Error> {
++    pub async fn call<D: Detokenize + Debug>(&self) -> Result<D, Error> {
+         Self::call_or_simulate(self, false).await
+     }
+ 
+     /// Call contract methods on the node, in a simulated manner, meaning the state of the
+     /// blockchain is *not* modified but simulated.
+     /// It is the same as the `call` method because the API is more user-friendly this way.
+-    pub async fn simulate(self) -> Result<MultiCallResponse<D>, Error> {
++    pub async fn simulate<D: Detokenize + Debug>(&self) -> Result<D, Error> {
+         Self::call_or_simulate(self, true).await
+     }
+ 
+     #[tracing::instrument]
+-    async fn call_or_simulate(self, simulate: bool) -> Result<MultiCallResponse<D>, Error> {
++    async fn call_or_simulate<D: Detokenize + Debug>(&self, simulate: bool) -> Result<D, Error> {
+         let script = self.get_script().await;
+ 
+         let receipts = if simulate {
+@@ -532,21 +529,32 @@ where
+     }
+ 
+     /// Create a MultiCallResponse from call receipts
+-    pub fn get_response(&self, mut receipts: Vec<Receipt>) -> Result<MultiCallResponse<D>, Error> {
+-        let mut values = vec![];
+-
+-        for call in self.contract_calls.iter() {
+-            let decoded_value = if call.output_params.is_empty() {
+-                None
+-            } else {
+-                let decoded = call.get_decoded_output(&mut receipts)?;
+-                Some(D::from_tokens(decoded)?)
+-            };
+-
+-            values.push(decoded_value);
++    pub fn get_response<D: Detokenize + Debug>(
++        &self,
++        mut receipts: Vec<Receipt>,
++    ) -> Result<D, Error> {
++        let mut final_tokens = vec![];
++
++        for call in self.contract_calls.as_ref().unwrap().iter() {
++            let decoded = call.get_decoded_output(&mut receipts)?;
++
++            final_tokens.extend(decoded.clone());
++            // let data = D::from_tokens(tokens)?;
++            //dbg!(&data);
++
++            //Some(D::from_tokens(decoded).expect("AM I HERE?"))
+         }
+ 
+-        Ok(MultiCallResponse::new(values, receipts))
++        dbg!(&final_tokens);
++
++        let tokens_as_tuple = vec![Token::Tuple(final_tokens)];
++
++        dbg!(&tokens_as_tuple);
++
++        let t = D::from_tokens(tokens_as_tuple).expect("oops");
++        dbg!(&t);
++
++        Ok(t)
+     }
+ }
+ 

--- a/packages/fuels-core/src/code_gen/abigen.rs
+++ b/packages/fuels-core/src/code_gen/abigen.rs
@@ -145,7 +145,7 @@ impl Abigen {
             pub use #name_mod::*;
 
             #[allow(clippy::too_many_arguments)]
-            mod #name_mod {
+            pub mod #name_mod {
                 #![allow(clippy::enum_variant_names)]
                 #![allow(dead_code)]
                 #![allow(unused_imports)]


### PR DESCRIPTION
This is a nice-to-have in case users want to directly access the generated `mod` in other files.