### PR TITLE
chore: use `concurrency` to cancel previous CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
@@ -16,16 +20,7 @@ env:
   FORC_VERSION: 0.16.0
 
 jobs:
-  cancel-previous-runs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
   setup-test-projects:
-    needs: cancel-previous-runs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -69,7 +64,6 @@ jobs:
             !packages/fuels-abigen-macro/tests/test_projects/**/.gitignore
 
   get-workspace-members:
-    needs: cancel-previous-runs
     runs-on: ubuntu-latest
     outputs:
       members: ${{ steps.set-members.outputs.members }}
@@ -85,7 +79,6 @@ jobs:
           echo "::set-output name=members::$members"
 
   verify-rust-version:
-    needs: cancel-previous-runs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
(This PR is a port of https://github.com/FuelLabs/fuels-ts/pull/361.)

From this SO page, it seems like the way we cancel previous runs is outdated and GitHub's native `concurrency` setting is the current practice: https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre