### PR TITLE
fix: abigen enum with string or array

### DIFF
--- a/packages/fuels-abigen-macro/tests/harness.rs
+++ b/packages/fuels-abigen-macro/tests/harness.rs
@@ -1996,3 +1996,40 @@ async fn can_use_try_into_to_construct_enum_from_bytes() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn string_and_array_inside_enum() -> Result<(), Error> {
+    abigen!(
+        MyContract,
+        "packages/fuels-abigen-macro/tests/test_projects/string_and_array_inside_enum/out/debug\
+        /string_and_array_inside_enum-abi.json"
+    );
+
+    let wallet = launch_provider_and_get_wallet().await;
+
+    let id = Contract::deploy(
+        "tests/test_projects/string_and_array_inside_enum/out/debug/string_and_array_inside_enum.bin",
+        &wallet,
+        TxParameters::default(),
+    )
+        .await?;
+
+    let instance = MyContract::new(id.to_string(), wallet.clone());
+
+    let enum_string = SomeEnum::SomeStr("asdf".to_owned());
+    let enum_array = SomeEnum::SomeArr(vec![1,2,3,4]);
+
+    let response = instance
+        .get_enum_str(enum_string.clone())
+        .call()
+        .await?;
+    assert_eq!(response.value, enum_string);
+
+    let response = instance
+        .get_enum_arr(enum_array.clone())
+        .call()
+        .await?;
+    assert_eq!(response.value, enum_array);
+
+    Ok(())
+}

--- a/packages/fuels-abigen-macro/tests/test_projects/string_and_array_inside_enum/Forc.toml
+++ b/packages/fuels-abigen-macro/tests/test_projects/string_and_array_inside_enum/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "string_and_array_inside_enum"
+entry = "main.sw"
+
+[dependencies]
+

--- a/packages/fuels-abigen-macro/tests/test_projects/string_and_array_inside_enum/src/main.sw
+++ b/packages/fuels-abigen-macro/tests/test_projects/string_and_array_inside_enum/src/main.sw
@@ -1,0 +1,21 @@
+contract;
+
+enum SomeEnum {
+	SomeStr: str[4],
+	SomeArr: [u64; 4]
+}
+
+abi MyContract {
+    fn get_enum_str(my_enum: SomeEnum) -> SomeEnum;
+    fn get_enum_arr(my_enum: SomeEnum) -> SomeEnum;
+}
+
+impl MyContract for Contract {
+    fn get_enum_str(my_enum: SomeEnum) -> SomeEnum {
+        my_enum
+    }
+
+    fn get_enum_arr(my_enum: SomeEnum) -> SomeEnum {
+        my_enum
+    }
+}


### PR DESCRIPTION
Closes #438 

Prior to this, abigen would try to convert `String(4)` to `Ident` when trying to generate the `Tokenizable` trait for the custom enum defined in sway.

This PR introduces a special case for enum variant generation in abigen where `String` is converted to Ident, and `String(4)` is kept to generate `ParamType::String(4)` in `Parametrize` and `method_hash`.

This PR also introduces special case handling for arrays inside of enum variants since this led to similar errors.

The above approach is similar to how we handle strings and arrays in structs.