### PR TITLE
b256 in a tuple with other custom types breaks `abigen!`

### DIFF
--- a/packages/fuels-core/Cargo.toml
+++ b/packages/fuels-core/Cargo.toml
@@ -19,6 +19,7 @@ itertools = "0.10"
 proc-macro2 = "1.0"
 quote = "1.0"
 rand = { version = "0.8.4" }
+regex = "1.6.0"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = { version = "1.0.64", default-features = true }
 sha2 = "0.9.5"


### PR DESCRIPTION
closes: #470 

To be deemed as a hotfix as we should give this more thought to whether it might crop up in other weird places.