### PR TITLE
Set fuel-core stdin/stdout stream to null

### DIFF
--- a/packages/fuels-test-helpers/src/node.rs
+++ b/packages/fuels-test-helpers/src/node.rs
@@ -15,6 +15,7 @@ use serde::{Deserializer, Serializer};
 use serde_json::{json, Value};
 use serde_with::{serde_as, skip_serializing_none};
 use serde_with::{DeserializeAs, SerializeAs};
+use std::process::Stdio;
 use tempfile::NamedTempFile;
 use tokio::process::Command;
 
@@ -221,6 +222,8 @@ pub fn spawn_fuel_service(config_with_coins: Value, free_port: Port) {
             .arg("--db-type")
             .arg("in-memory")
             .kill_on_drop(true)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
             .spawn()
             .expect("error: Couldn't read fuel-core: No such file or directory. Please check if fuel-core library is installed. \
         Try this https://fuellabs.github.io/sway/latest/introduction/installation.html");


### PR DESCRIPTION
When running `forc test` there are some spammy console logs originating from fuel_core.

This will void `stdin` and `stdout` stream and should remove those logs (`stderr` is left for better diagnostic).


![1 (1)](https://user-images.githubusercontent.com/13179220/179424920-1b0b4d40-34bc-4513-aec6-8a8b54e427aa.png)
