### PR TITLE
ci: remove the `--no-default-features` flag for running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,8 @@ jobs:
             args: --all-targets --all-features
           - command: test
             args: --all-targets --all-features
+          - command: test
+            args: --all-targets
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,6 @@ jobs:
             args: --all-targets --all-features
           - command: test
             args: --all-targets --all-features
-          - command: test
-            args: --all-targets --no-default-features
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
This is actually not useful and prevents some tests from running as they should.
