### PR TITLE
feat: add contract_id and wallet getters

### DIFF
--- a/packages/fuels-core/src/code_gen/abigen.rs
+++ b/packages/fuels-core/src/code_gen/abigen.rs
@@ -136,6 +136,14 @@ impl Abigen {
 
                     impl #name {
                         #contract_functions
+
+                        pub fn _get_contract_id(&self) -> ContractId {
+                            self.contract_id
+                        }
+
+                        pub fn _get_wallet(&self) -> LocalWallet {
+                            self.wallet.clone()
+                        }
                     }
 
                     pub struct #builder_name {

--- a/packages/fuels/tests/harness.rs
+++ b/packages/fuels/tests/harness.rs
@@ -2294,3 +2294,25 @@ async fn test_get_gas_used() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_contract_id_and_wallet_getters() {
+    // Generates the bindings from an ABI definition in a JSON file
+    // The generated bindings can be accessed through `SimpleContract`.
+    abigen!(
+        SimpleContract,
+        "packages/fuels/tests/takes_ints_returns_bool.json",
+    );
+
+    let wallet = launch_provider_and_get_wallet().await;
+    let contract_id =
+        String::from("0000000000000000000000000000000000000000000000000000000000000042");
+
+    let contract_instance = SimpleContractBuilder::new(contract_id.clone(), wallet.clone()).build();
+
+    assert_eq!(contract_instance._get_wallet().address(), wallet.address());
+    assert_eq!(
+        contract_instance._get_contract_id().to_string(),
+        contract_id
+    );
+}


### PR DESCRIPTION
should close: https://github.com/FuelLabs/fuels-rs/issues/485

I think we will again hit the naming problem with this approach.
Currently, I put leading underscores for the getters. 