### PR TITLE
refactor: move function selector methods out of `ABIParser` struct

### DIFF
--- a/packages/fuels-core/src/code_gen/abigen.rs
+++ b/packages/fuels-core/src/code_gen/abigen.rs
@@ -6,7 +6,6 @@ use crate::code_gen::custom_types_gen::{
 };
 use crate::code_gen::functions_gen::expand_function;
 use crate::constants::{ADDRESS_SWAY_NATIVE_TYPE, CONTRACT_ID_SWAY_NATIVE_TYPE};
-use crate::json_abi::ABIParser;
 use crate::source::Source;
 use crate::utils::ident;
 use fuels_types::errors::Error;
@@ -17,9 +16,6 @@ use quote::quote;
 pub struct Abigen {
     /// The parsed ABI.
     abi: JsonABI,
-
-    /// The parser used to transform the JSON format into `JsonABI`
-    abi_parser: ABIParser,
 
     /// The contract name as an identifier.
     contract_name: Ident,
@@ -67,7 +63,6 @@ impl Abigen {
                 .collect(),
             abi: parsed_abi,
             contract_name: ident(contract_name),
-            abi_parser: ABIParser::new(),
             rustfmt: true,
             no_std: false,
         })
@@ -198,12 +193,7 @@ impl Abigen {
         let mut tokenized_functions = Vec::new();
 
         for function in &self.abi {
-            let tokenized_fn = expand_function(
-                function,
-                &self.abi_parser,
-                &self.custom_enums,
-                &self.custom_structs,
-            )?;
+            let tokenized_fn = expand_function(function, &self.custom_enums, &self.custom_structs)?;
             tokenized_functions.push(tokenized_fn);
         }
 

--- a/packages/fuels-core/src/code_gen/custom_types_gen.rs
+++ b/packages/fuels-core/src/code_gen/custom_types_gen.rs
@@ -1,7 +1,8 @@
 use crate::types::expand_type;
-use crate::utils::{has_array_format, ident};
+use crate::utils::ident;
 use crate::ParamType;
 use fuels_types::errors::Error;
+use fuels_types::utils::has_array_format;
 use fuels_types::{CustomType, Property};
 use inflector::Inflector;
 use proc_macro2::TokenStream;

--- a/packages/fuels-core/src/code_gen/functions_gen.rs
+++ b/packages/fuels-core/src/code_gen/functions_gen.rs
@@ -1,10 +1,10 @@
 use crate::code_gen::custom_types_gen::extract_custom_type_name_from_abi_property;
 use crate::code_gen::docs_gen::expand_doc;
-use crate::json_abi::ABIParser;
 use crate::types::expand_type;
 use crate::utils::{first_four_bytes_of_sha256_hash, ident, safe_ident};
 use crate::{ParamType, Selector};
 use fuels_types::errors::Error;
+use fuels_types::function_selector::build_fn_selector;
 use fuels_types::{CustomType, Function, Property, ENUM_KEYWORD, STRUCT_KEYWORD};
 use inflector::Inflector;
 use proc_macro2::{Literal, TokenStream};
@@ -24,7 +24,6 @@ use std::collections::HashMap;
 /// [`Contract`]: crate::contract::Contract
 pub fn expand_function(
     function: &Function,
-    abi_parser: &ABIParser,
     custom_enums: &HashMap<String, Property>,
     custom_structs: &HashMap<String, Property>,
 ) -> Result<TokenStream, Error> {
@@ -33,7 +32,7 @@ pub fn expand_function(
     }
 
     let name = safe_ident(&function.name);
-    let fn_signature = abi_parser.build_fn_selector(&function.name, &function.inputs)?;
+    let fn_signature = build_fn_selector(&function.name, &function.inputs)?;
 
     let encoded = first_four_bytes_of_sha256_hash(&fn_signature);
 
@@ -372,12 +371,7 @@ mod tests {
             type_field: String::from("bool"),
             components: None,
         });
-        let result = expand_function(
-            &the_function,
-            &ABIParser::new(),
-            &Default::default(),
-            &Default::default(),
-        );
+        let result = expand_function(&the_function, &Default::default(), &Default::default());
         let expected = TokenStream::from_str(
             r#"
             #[doc = "Calls the contract's `HelloWorld` (0x0000000097d4de45) function"]
@@ -465,8 +459,7 @@ mod tests {
                 components: None,
             },
         );
-        let abi_parser = ABIParser::new();
-        let result = expand_function(&the_function, &abi_parser, &custom_enums, &custom_structs);
+        let result = expand_function(&the_function, &custom_enums, &custom_structs);
         // Some more editing was required because it is not rustfmt-compatible (adding/removing parentheses or commas)
         let expected = TokenStream::from_str(
             r#"

--- a/packages/fuels-core/src/utils.rs
+++ b/packages/fuels-core/src/utils.rs
@@ -28,7 +28,3 @@ pub fn ident(name: &str) -> Ident {
 pub fn safe_ident(name: &str) -> Ident {
     syn::parse_str::<SynIdent>(name).unwrap_or_else(|_| ident(&format!("{}_", name)))
 }
-
-pub fn has_array_format(element: &str) -> bool {
-    element.starts_with('[') && element.ends_with(']')
-}

--- a/packages/fuels-types/src/function_selector.rs
+++ b/packages/fuels-types/src/function_selector.rs
@@ -1,0 +1,107 @@
+use crate::errors::Error;
+use crate::utils::has_array_format;
+use crate::Property;
+
+pub struct FunctionSelector {
+    pub signature: String,
+    pub encoded_selector: String,
+    pub final_selector: Vec<u8>,
+}
+
+/// Builds a string representation of a function selector,
+/// i.e: <fn_name>(<type_1>, <type_2>, ..., <type_n>)
+pub fn build_fn_selector(fn_name: &str, params: &[Property]) -> Result<String, Error> {
+    let fn_selector = fn_name.to_owned();
+
+    let mut result: String = format!("{}(", fn_selector);
+
+    for (idx, param) in params.iter().enumerate() {
+        result.push_str(&build_fn_selector_params(param));
+        if idx + 1 < params.len() {
+            result.push(',');
+        }
+    }
+
+    result.push(')');
+
+    Ok(result)
+}
+
+fn build_fn_selector_params(prop: &Property) -> String {
+    let mut result: String = String::new();
+
+    if prop.is_custom_type() {
+        // Custom type, need to break down inner fields.
+        // Will return `"e(field_1,field_2,...,field_n)"` if the type is an `Enum`,
+        // `"s(field_1,field_2,...,field_n)"` if the type is a `Struct`,
+        // `"a[type;length]"` if the type is an `Array`,
+        // `(type_1,type_2,...,type_n)` if the type is a `Tuple`.
+        if prop.is_struct_type() {
+            result.push_str("s(");
+        } else if prop.is_enum_type() {
+            result.push_str("e(");
+        } else if prop.has_custom_type_in_array() {
+            result.push_str("a[");
+        } else if prop.has_custom_type_in_tuple() {
+            result.push('(');
+        } else {
+            panic!("unexpected custom type");
+        }
+
+        for (idx, component) in prop
+            .components
+            .as_ref()
+            .expect("No components found")
+            .iter()
+            .enumerate()
+        {
+            result.push_str(&build_fn_selector_params(component));
+
+            if idx + 1 < prop.components.as_ref().unwrap().len() {
+                result.push(',');
+            }
+        }
+
+        if result.starts_with("a[") {
+            let array_type_field = prop.type_field.clone();
+
+            // Type field, in this case, looks like
+            // "[struct Person; 2]" and we want to extract the
+            // length, which in this example is 2.
+            // First, get the last part after `;`: `"<length>]"`.
+            let mut array_length = array_type_field.split(';').collect::<Vec<&str>>()[1]
+                .trim()
+                .to_string();
+
+            array_length.pop(); // Remove the trailing "]"
+
+            // Make sure the length is a valid number.
+            let array_length = array_length.parse::<usize>().expect("Invalid array length");
+
+            result.push(';');
+            result.push_str(array_length.to_string().as_str());
+            result.push(']');
+        } else {
+            result.push(')');
+        }
+    } else {
+        // Not a custom type.
+        let param_str_no_whitespace: String = prop
+            .type_field
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+
+        // Check if the parameter is an array.
+        if has_array_format(&param_str_no_whitespace) {
+            // The representation of an array in a function selector should be `a[<type>;<length>]`.
+            // Because this is coming in as `[<type>;<length>]` (not prefixed with an 'a'), here
+            // we must prefix it with an 'a' so the function selector will be properly encoded.
+            let array = format!("{}{}", "a", param_str_no_whitespace);
+            result.push_str(array.as_str());
+        } else {
+            result.push_str(&param_str_no_whitespace);
+        }
+    }
+    result
+}

--- a/packages/fuels-types/src/lib.rs
+++ b/packages/fuels-types/src/lib.rs
@@ -8,8 +8,10 @@ use strum_macros::ToString;
 
 pub mod constants;
 pub mod errors;
+pub mod function_selector;
 pub mod param_types;
 pub mod parse_param;
+pub mod utils;
 /// Fuel ABI representation in JSON, originally specified here:
 ///
 /// https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md

--- a/packages/fuels-types/src/utils.rs
+++ b/packages/fuels-types/src/utils.rs
@@ -1,0 +1,3 @@
+pub fn has_array_format(element: &str) -> bool {
+    element.starts_with('[') && element.ends_with(']')
+}


### PR DESCRIPTION
* These methods will ultimately be used inside the Sway repository, and
  they didn't use the ABIParser fields.
