### PR TITLE
Fix deunified build ignoring workspace package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: ${{ matrix.command }}
-          args: ${{ matrix.args }}
+          args: "-p ${{ matrix.package }} ${{ matrix.args }}"
 
   publish:
     needs: cargo-verifications


### PR DESCRIPTION
While the deunified build created a number of parallel jobs, the package field wasn't properly passed to certain jobs as expected, leading to redundant checks.