### PR TITLE
fix: string in array parsing

### DIFF
--- a/packages/fuels/tests/harness.rs
+++ b/packages/fuels/tests/harness.rs
@@ -2355,6 +2355,8 @@ async fn str_in_array() -> Result<(), Error> {
 
     assert_eq!(response.value, ["foo"]);
 
+    // This test is skipped because of a compiler error.
+    // See: https://github.com/FuelLabs/sway/issues/2410
     // let response = contract_instance
     //     .take_array_string_return_single_element(input)
     //     .call()

--- a/packages/fuels/tests/harness.rs
+++ b/packages/fuels/tests/harness.rs
@@ -2337,7 +2337,6 @@ async fn str_in_array() -> Result<(), Error> {
     )
     .await?;
 
-    // `SimpleContract` is the name of the contract
     let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet).build();
 
     let input = vec!["foo".to_string(), "bar".to_string(), "baz".to_string()];

--- a/packages/fuels/tests/harness.rs
+++ b/packages/fuels/tests/harness.rs
@@ -2304,3 +2304,48 @@ async fn test_contract_id_and_wallet_getters() {
         contract_id
     );
 }
+
+#[tokio::test]
+async fn str_in_array() -> Result<(), Error> {
+    abigen!(
+        MyContract,
+        "packages/fuels/tests/test_projects/str_in_array/out/debug/str_in_array-abi.json"
+    );
+
+    let wallet = launch_provider_and_get_wallet().await;
+
+    let contract_id = Contract::deploy(
+        "tests/test_projects/str_in_array/out/debug/str_in_array.bin",
+        &wallet,
+        TxParameters::default(),
+        StorageConfiguration::default(),
+    )
+    .await?;
+
+    // `SimpleContract` is the name of the contract
+    let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet).build();
+
+    let input = vec!["foo".to_string(), "bar".to_string(), "baz".to_string()];
+    let response = contract_instance
+        .take_array_string_shuffle(input.clone())
+        .call()
+        .await?;
+
+    assert_eq!(response.value, ["baz", "foo", "bar"]);
+
+    let response = contract_instance
+        .take_array_string_return_single(input.clone())
+        .call()
+        .await?;
+
+    assert_eq!(response.value, ["foo"]);
+
+    // let response = contract_instance
+    //     .take_array_string_return_single_element(input)
+    //     .call()
+    //     .await?;
+
+    // assert_eq!(response.value, "baz");
+
+    Ok(())
+}

--- a/packages/fuels/tests/test_projects/str_in_array/Forc.toml
+++ b/packages/fuels/tests/test_projects/str_in_array/Forc.toml
@@ -1,0 +1,7 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "str_in_array"
+
+[dependencies]

--- a/packages/fuels/tests/test_projects/str_in_array/src/main.sw
+++ b/packages/fuels/tests/test_projects/str_in_array/src/main.sw
@@ -1,0 +1,21 @@
+contract;
+
+abi TestContract {
+    fn take_array_string_shuffle(a: [str[3]; 3]) -> [str[3]; 3];
+    fn take_array_string_return_single(a: [str[3]; 3]) -> [str[3]; 1];
+    fn take_array_string_return_single_element(a: [str[3]; 3]) -> str[3];
+}
+
+impl TestContract for Contract {
+    fn take_array_string_shuffle(a: [str[3]; 3]) -> [str[3]; 3] {
+        [a[2], a[0], a[1]]
+    }
+
+    fn take_array_string_return_single(a: [str[3]; 3]) -> [str[3]; 1] {
+        [a[0]]
+    }
+
+    fn take_array_string_return_single_element(a: [str[3]; 3]) -> str[3] {
+        a[1]
+    }
+}


### PR DESCRIPTION
closes: https://github.com/FuelLabs/fuels-rs/issues/505

There was a bug in the parsing logic of arrays and strings.
I have taken the test_project created by @QuinnLee and removed the part with primitive types inside arrays, as we have tested them already.