### PR TITLE
refactor: add an `asset_id` argument to `get_coins` API

### DIFF
--- a/docs/src/providers/querying.md
+++ b/docs/src/providers/querying.md
@@ -18,7 +18,7 @@ You might need to set up a test blockchain first. You can skip this step if you'
 
 ## Get all coins from an address
 
-This method returns all coins from a wallet, including spent ones.
+This method returns all coins (of a given asset ID) from a wallet, including spent ones.
 
 ```rust,ignore
 {{#include ../../../examples/providers/src/lib.rs:get_coins}}
@@ -26,7 +26,7 @@ This method returns all coins from a wallet, including spent ones.
 
 ## Get spendable coins from an address
 
-The last argument says how much you want to spend. This method returns only spendable, i.e., unspent coins. If you ask for more spendable than the amount of unspent coins you have, it returns an error.
+The last argument says how much you want to spend. This method returns only spendable, i.e., unspent coins (of a given asset ID). If you ask for more spendable than the amount of unspent coins you have, it returns an error.
 
 ```rust,ignore
 {{#include ../../../examples/providers/src/lib.rs:get_spendable_coins}}

--- a/examples/providers/src/lib.rs
+++ b/examples/providers/src/lib.rs
@@ -51,7 +51,7 @@ mod tests {
         // ANCHOR_END: setup_test_blockchain
 
         // ANCHOR: get_coins
-        let coins = provider.get_coins(wallet.address()).await?;
+        let coins = provider.get_coins(wallet.address(), BASE_ASSET_ID).await?;
         assert_eq!(coins.len(), 1);
         // ANCHOR_END: get_coins
 

--- a/examples/wallets/src/lib.rs
+++ b/examples/wallets/src/lib.rs
@@ -134,7 +134,7 @@ mod tests {
             .transfer(wallets[1].address(), 1, asset_id, TxParameters::default())
             .await?;
 
-        let wallet_2_final_coins = wallets[1].get_coins(&BASE_ASSET_ID).await?;
+        let wallet_2_final_coins = wallets[1].get_coins(BASE_ASSET_ID).await?;
 
         // Check that wallet 2 now has 2 coins
         assert_eq!(wallet_2_final_coins.len(), 2);

--- a/examples/wallets/src/lib.rs
+++ b/examples/wallets/src/lib.rs
@@ -134,7 +134,7 @@ mod tests {
             .transfer(wallets[1].address(), 1, asset_id, TxParameters::default())
             .await?;
 
-        let wallet_2_final_coins = wallets[1].get_coins().await?;
+        let wallet_2_final_coins = wallets[1].get_coins(&BASE_ASSET_ID).await?;
 
         // Check that wallet 2 now has 2 coins
         assert_eq!(wallet_2_final_coins.len(), 2);

--- a/packages/fuels-contract/src/script.rs
+++ b/packages/fuels-contract/src/script.rs
@@ -226,7 +226,7 @@ impl Script {
         for asset_id in asset_ids.iter() {
             spendables.extend(
                 wallet
-                    .get_spendable_coins(asset_id, DEFAULT_SPENDABLE_COIN_AMOUNT as u64)
+                    .get_spendable_coins(*asset_id, DEFAULT_SPENDABLE_COIN_AMOUNT as u64)
                     .await
                     .unwrap(),
             );

--- a/packages/fuels-signers/src/lib.rs
+++ b/packages/fuels-signers/src/lib.rs
@@ -141,7 +141,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_transaction() -> Result<(), fuels_types::errors::Error> {
+    async fn send_transfer_transactions() -> Result<(), fuels_types::errors::Error> {
         // Setup two sets of coins, one for each wallet, each containing 1 coin with 1 amount.
         let mut wallet_1 = LocalWallet::new_random(None);
         let mut wallet_2 = LocalWallet::new_random(None);
@@ -158,8 +158,8 @@ mod tests {
         wallet_1.set_provider(provider.clone());
         wallet_2.set_provider(provider);
 
-        let wallet_1_initial_coins = wallet_1.get_coins().await?;
-        let wallet_2_initial_coins = wallet_2.get_coins().await?;
+        let wallet_1_initial_coins = wallet_1.get_coins(&BASE_ASSET_ID).await?;
+        let wallet_2_initial_coins = wallet_2.get_coins(&BASE_ASSET_ID).await?;
 
         // Check initial wallet state.
         assert_eq!(wallet_1_initial_coins.len(), 1);
@@ -194,12 +194,15 @@ mod tests {
         assert_eq!(res.transaction.gas_price(), gas_price);
         assert_eq!(res.transaction.maturity(), maturity);
 
-        // Currently ignoring the effect on wallet 1, as coins aren't being marked as spent for now.
-        let _wallet_1_final_coins = wallet_1.get_coins().await?;
-        let wallet_2_final_coins = wallet_2.get_coins().await?;
+        let wallet_1_spendable_coins = wallet_1.get_spendable_coins(&BASE_ASSET_ID, 0).await?;
+        let wallet_1_all_coins = wallet_1.get_coins(&BASE_ASSET_ID).await?;
+        let wallet_2_all_coins = wallet_2.get_coins(&BASE_ASSET_ID).await?;
 
+        // wallet_1 has now only 1 unspent coin and 1 spent coin
+        assert_eq!(wallet_1_spendable_coins.len(), 1);
+        assert_eq!(wallet_1_all_coins.len(), 2);
         // Check that wallet two now has two coins.
-        assert_eq!(wallet_2_final_coins.len(), 2);
+        assert_eq!(wallet_2_all_coins.len(), 2);
 
         // Transferring more than balance should fail.
         let response = wallet_1
@@ -212,7 +215,7 @@ mod tests {
             .await;
 
         assert!(response.is_err());
-        let wallet_2_coins = wallet_2.get_coins().await?;
+        let wallet_2_coins = wallet_2.get_coins(&BASE_ASSET_ID).await?;
         assert_eq!(wallet_2_coins.len(), 2); // Not changed
         Ok(())
     }
@@ -234,8 +237,8 @@ mod tests {
         wallet_1.set_provider(provider.clone());
         wallet_2.set_provider(provider);
 
-        let wallet_1_initial_coins = wallet_1.get_coins().await?;
-        let wallet_2_initial_coins = wallet_2.get_coins().await?;
+        let wallet_1_initial_coins = wallet_1.get_coins(&BASE_ASSET_ID).await?;
+        let wallet_2_initial_coins = wallet_2.get_coins(&BASE_ASSET_ID).await?;
 
         assert_eq!(wallet_1_initial_coins.len(), 1);
         assert_eq!(wallet_2_initial_coins.len(), 1);
@@ -250,13 +253,13 @@ mod tests {
             )
             .await?;
 
-        let wallet_1_final_coins = wallet_1.get_coins().await?;
+        let wallet_1_final_coins = wallet_1.get_coins(&BASE_ASSET_ID).await?;
 
         // Assert that we've sent 2 from wallet 1, resulting in an amount of 3 in wallet 1.
         let resulting_amount = wallet_1_final_coins.first().unwrap();
         assert_eq!(resulting_amount.amount.0, 3);
 
-        let wallet_2_final_coins = wallet_2.get_coins().await?;
+        let wallet_2_final_coins = wallet_2.get_coins(&BASE_ASSET_ID).await?;
         assert_eq!(wallet_2_final_coins.len(), 2);
 
         // Check that wallet 2's amount is 7:

--- a/packages/fuels-signers/src/lib.rs
+++ b/packages/fuels-signers/src/lib.rs
@@ -158,8 +158,8 @@ mod tests {
         wallet_1.set_provider(provider.clone());
         wallet_2.set_provider(provider);
 
-        let wallet_1_initial_coins = wallet_1.get_coins(&BASE_ASSET_ID).await?;
-        let wallet_2_initial_coins = wallet_2.get_coins(&BASE_ASSET_ID).await?;
+        let wallet_1_initial_coins = wallet_1.get_coins(BASE_ASSET_ID).await?;
+        let wallet_2_initial_coins = wallet_2.get_coins(BASE_ASSET_ID).await?;
 
         // Check initial wallet state.
         assert_eq!(wallet_1_initial_coins.len(), 1);
@@ -195,8 +195,8 @@ mod tests {
         assert_eq!(res.transaction.maturity(), maturity);
 
         let wallet_1_spendable_coins = wallet_1.get_spendable_coins(&BASE_ASSET_ID, 0).await?;
-        let wallet_1_all_coins = wallet_1.get_coins(&BASE_ASSET_ID).await?;
-        let wallet_2_all_coins = wallet_2.get_coins(&BASE_ASSET_ID).await?;
+        let wallet_1_all_coins = wallet_1.get_coins(BASE_ASSET_ID).await?;
+        let wallet_2_all_coins = wallet_2.get_coins(BASE_ASSET_ID).await?;
 
         // wallet_1 has now only 1 spent coin (so 0 spendable)
         assert_eq!(wallet_1_spendable_coins.len(), 0);
@@ -215,7 +215,7 @@ mod tests {
             .await;
 
         assert!(response.is_err());
-        let wallet_2_coins = wallet_2.get_coins(&BASE_ASSET_ID).await?;
+        let wallet_2_coins = wallet_2.get_coins(BASE_ASSET_ID).await?;
         assert_eq!(wallet_2_coins.len(), 2); // Not changed
         Ok(())
     }
@@ -237,8 +237,8 @@ mod tests {
         wallet_1.set_provider(provider.clone());
         wallet_2.set_provider(provider);
 
-        let wallet_1_initial_coins = wallet_1.get_coins(&BASE_ASSET_ID).await?;
-        let wallet_2_initial_coins = wallet_2.get_coins(&BASE_ASSET_ID).await?;
+        let wallet_1_initial_coins = wallet_1.get_coins(BASE_ASSET_ID).await?;
+        let wallet_2_initial_coins = wallet_2.get_coins(BASE_ASSET_ID).await?;
 
         assert_eq!(wallet_1_initial_coins.len(), 1);
         assert_eq!(wallet_2_initial_coins.len(), 1);
@@ -253,13 +253,13 @@ mod tests {
             )
             .await?;
 
-        let wallet_1_final_coins = wallet_1.get_coins(&BASE_ASSET_ID).await?;
+        let wallet_1_final_coins = wallet_1.get_coins(BASE_ASSET_ID).await?;
 
         // Assert that we've sent 2 from wallet 1, resulting in an amount of 3 in wallet 1.
         let resulting_amount = wallet_1_final_coins.first().unwrap();
         assert_eq!(resulting_amount.amount.0, 3);
 
-        let wallet_2_final_coins = wallet_2.get_coins(&BASE_ASSET_ID).await?;
+        let wallet_2_final_coins = wallet_2.get_coins(BASE_ASSET_ID).await?;
         assert_eq!(wallet_2_final_coins.len(), 2);
 
         // Check that wallet 2's amount is 7:

--- a/packages/fuels-signers/src/lib.rs
+++ b/packages/fuels-signers/src/lib.rs
@@ -194,7 +194,7 @@ mod tests {
         assert_eq!(res.transaction.gas_price(), gas_price);
         assert_eq!(res.transaction.maturity(), maturity);
 
-        let wallet_1_spendable_coins = wallet_1.get_spendable_coins(&BASE_ASSET_ID, 0).await?;
+        let wallet_1_spendable_coins = wallet_1.get_spendable_coins(BASE_ASSET_ID, 0).await?;
         let wallet_1_all_coins = wallet_1.get_coins(BASE_ASSET_ID).await?;
         let wallet_2_all_coins = wallet_2.get_coins(BASE_ASSET_ID).await?;
 

--- a/packages/fuels-signers/src/lib.rs
+++ b/packages/fuels-signers/src/lib.rs
@@ -198,9 +198,9 @@ mod tests {
         let wallet_1_all_coins = wallet_1.get_coins(&BASE_ASSET_ID).await?;
         let wallet_2_all_coins = wallet_2.get_coins(&BASE_ASSET_ID).await?;
 
-        // wallet_1 has now only 1 unspent coin and 1 spent coin
-        assert_eq!(wallet_1_spendable_coins.len(), 1);
-        assert_eq!(wallet_1_all_coins.len(), 2);
+        // wallet_1 has now only 1 spent coin (so 0 spendable)
+        assert_eq!(wallet_1_spendable_coins.len(), 0);
+        assert_eq!(wallet_1_all_coins.len(), 1);
         // Check that wallet two now has two coins.
         assert_eq!(wallet_2_all_coins.len(), 2);
 

--- a/packages/fuels-signers/src/provider.rs
+++ b/packages/fuels-signers/src/provider.rs
@@ -132,9 +132,13 @@ impl Provider {
         Ok(self.client.dry_run(tx).await?)
     }
 
-    /// Gets all coins owned by address `from`, *even spent ones*. This returns actual coins
-    /// (UTXOs).
-    pub async fn get_coins(&self, from: &Bech32Address) -> Result<Vec<Coin>, ProviderError> {
+    /// Gets all coins owned by address `from`, with asset ID `asset_id`, *even spent ones*. This
+    /// returns actual coins (UTXOs).
+    pub async fn get_coins(
+        &self,
+        from: &Bech32Address,
+        asset_id: AssetId,
+    ) -> Result<Vec<Coin>, ProviderError> {
         let mut coins: Vec<Coin> = vec![];
 
         let mut cursor = None;
@@ -144,7 +148,7 @@ impl Provider {
                 .client
                 .coins(
                     &from.hash().to_string(),
-                    None,
+                    Some(&*asset_id.to_string()),
                     PaginationRequest {
                         cursor: cursor.clone(),
                         results: 100,

--- a/packages/fuels-signers/src/provider.rs
+++ b/packages/fuels-signers/src/provider.rs
@@ -148,7 +148,7 @@ impl Provider {
                 .client
                 .coins(
                     &from.hash().to_string(),
-                    Some(&*asset_id.to_string()),
+                    Some(&asset_id.to_string()),
                     PaginationRequest {
                         cursor: cursor.clone(),
                         results: 100,

--- a/packages/fuels-signers/src/wallet.rs
+++ b/packages/fuels-signers/src/wallet.rs
@@ -257,7 +257,7 @@ impl Wallet {
     ///        .await
     ///        .unwrap();
     ///
-    ///   let wallet_2_final_coins = wallet_2.get_coins().await.unwrap();
+    ///   let wallet_2_final_coins = wallet_2.get_coins(BASE_ASSET_ID).await.unwrap();
     ///
     ///   // Check that wallet two now has two coins
     ///   assert_eq!(wallet_2_final_coins.len(), 2);
@@ -371,9 +371,14 @@ impl Wallet {
         Ok(inputs)
     }
 
-    /// Gets all coins owned by the wallet, *even spent ones*. This returns actual coins (UTXOs).
-    pub async fn get_coins(&self) -> Result<Vec<Coin>, Error> {
-        Ok(self.get_provider()?.get_coins(self.address()).await?)
+    /// Gets all coins of asset `asset_id` owned by the wallet, *even spent ones* (this is useful
+    /// for some particular cases, but in general, you should use `get_spendable_coins`). This
+    /// returns actual coins (UTXOs).
+    pub async fn get_coins(&self, asset_id: &AssetId) -> Result<Vec<Coin>, Error> {
+        Ok(self
+            .get_provider()?
+            .get_coins(self.address(), *asset_id)
+            .await?)
     }
 
     /// Get some spendable coins of asset `asset_id` owned by the wallet that add up at least to

--- a/packages/fuels-signers/src/wallet.rs
+++ b/packages/fuels-signers/src/wallet.rs
@@ -355,7 +355,7 @@ impl Wallet {
         amount: u64,
         witness_index: u8,
     ) -> Result<Vec<Input>, Error> {
-        let spendable = self.get_spendable_coins(&asset_id, amount).await?;
+        let spendable = self.get_spendable_coins(asset_id, amount).await?;
         let mut inputs = vec![];
         for coin in spendable {
             let input_coin = Input::coin_signed(
@@ -374,10 +374,10 @@ impl Wallet {
     /// Gets all coins of asset `asset_id` owned by the wallet, *even spent ones* (this is useful
     /// for some particular cases, but in general, you should use `get_spendable_coins`). This
     /// returns actual coins (UTXOs).
-    pub async fn get_coins(&self, asset_id: &AssetId) -> Result<Vec<Coin>, Error> {
+    pub async fn get_coins(&self, asset_id: AssetId) -> Result<Vec<Coin>, Error> {
         Ok(self
             .get_provider()?
-            .get_coins(self.address(), *asset_id)
+            .get_coins(self.address(), asset_id)
             .await?)
     }
 
@@ -386,11 +386,11 @@ impl Wallet {
     /// of coins (UXTOs) is optimized to prevent dust accumulation.
     pub async fn get_spendable_coins(
         &self,
-        asset_id: &AssetId,
+        asset_id: AssetId,
         amount: u64,
     ) -> Result<Vec<Coin>, Error> {
         self.get_provider()?
-            .get_spendable_coins(self.address(), *asset_id, amount)
+            .get_spendable_coins(self.address(), asset_id, amount)
             .await
             .map_err(Into::into)
     }

--- a/packages/fuels-test-helpers/src/signers.rs
+++ b/packages/fuels-test-helpers/src/signers.rs
@@ -120,7 +120,7 @@ mod tests {
         assert_eq!(wallets.len(), num_wallets as usize);
 
         for wallet in &wallets {
-            let coins = wallet.get_coins().await?;
+            let coins = wallet.get_coins(&BASE_ASSET_ID).await?;
 
             assert_eq!(coins.len(), num_coins as usize);
 

--- a/packages/fuels-test-helpers/src/signers.rs
+++ b/packages/fuels-test-helpers/src/signers.rs
@@ -120,7 +120,7 @@ mod tests {
         assert_eq!(wallets.len(), num_wallets as usize);
 
         for wallet in &wallets {
-            let coins = wallet.get_coins(&BASE_ASSET_ID).await?;
+            let coins = wallet.get_coins(BASE_ASSET_ID).await?;
 
             assert_eq!(coins.len(), num_coins as usize);
 
@@ -167,7 +167,7 @@ mod tests {
         for asset in assets {
             for wallet in &wallets {
                 let coins = wallet
-                    .get_spendable_coins(&asset.id, asset.num_coins * asset.coin_amount)
+                    .get_spendable_coins(asset.id, asset.num_coins * asset.coin_amount)
                     .await?;
                 assert_eq!(coins.len() as u64, asset.num_coins);
 


### PR DESCRIPTION
* Previously, the `get_coins` methods only retrieved BASE_ASSET_ID
  coins. Now it retrieves coins of the argument `asset_id`.
