### PR TITLE
fix: enable skipped test for strings in arrays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   RUSTFLAGS: "-D warnings"
   FUEL_CORE_VERSION: 0.9.6
   RUST_VERSION: 1.61.0
-  FORC_VERSION: 0.19.0
+  FORC_VERSION: 0.19.1
 
 jobs:
   setup-test-projects:
@@ -149,7 +149,7 @@ jobs:
         if: ${{ matrix.command == 'test' }}
         run: |
           curl -sSLf https://github.com/FuelLabs/fuel-core/releases/download/v${{ env.FUEL_CORE_VERSION }}/fuel-core-${{ env.FUEL_CORE_VERSION }}-x86_64-unknown-linux-gnu.tar.gz -L -o fuel-core.tar.gz
-          tar -xvf fuel-core.tar.gz          
+          tar -xvf fuel-core.tar.gz
           chmod +x fuel-core-${{ env.FUEL_CORE_VERSION }}-x86_64-unknown-linux-gnu/fuel-core
           mv fuel-core-${{ env.FUEL_CORE_VERSION }}-x86_64-unknown-linux-gnu/fuel-core /usr/local/bin/fuel-core
 

--- a/packages/fuels/tests/harness.rs
+++ b/packages/fuels/tests/harness.rs
@@ -2354,14 +2354,12 @@ async fn str_in_array() -> Result<(), Error> {
 
     assert_eq!(response.value, ["foo"]);
 
-    // This test is skipped because of a compiler error.
-    // See: https://github.com/FuelLabs/sway/issues/2410
-    // let response = contract_instance
-    //     .take_array_string_return_single_element(input)
-    //     .call()
-    //     .await?;
+    let response = contract_instance
+        .take_array_string_return_single_element(input)
+        .call()
+        .await?;
 
-    // assert_eq!(response.value, "baz");
+    assert_eq!(response.value, "bar");
 
     Ok(())
 }


### PR DESCRIPTION
closes: https://github.com/FuelLabs/fuels-rs/issues/509

The compiler error was fixed and we can now run the full test.