### PR TITLE
fix: remove spam from `fuel-core` when running tests

### DIFF
--- a/packages/fuels-test-helpers/src/lib.rs
+++ b/packages/fuels-test-helpers/src/lib.rs
@@ -199,6 +199,7 @@ pub async fn setup_test_client(
         consensus_parameters_config,
         srv_address,
         manual_blocks_enabled,
+        true,
     )
     .await;
 

--- a/packages/fuels-test-helpers/src/node.rs
+++ b/packages/fuels-test-helpers/src/node.rs
@@ -266,13 +266,12 @@ pub async fn new_fuel_node(
         }
 
         let mut command = Command::new("fuel-core");
+        command.stdin(Stdio::null());
         if silent {
-            command
-                .stdin(Stdio::null())
-                .stdout(Stdio::null())
-                .stderr(Stdio::null());
+            command.stdout(Stdio::null()).stderr(Stdio::null());
         }
-        let mut running_node =command.args(args)
+        let mut running_node = command
+            .args(args)
             .kill_on_drop(true)
             .spawn()
             .expect("error: Couldn't read fuel-core: No such file or directory. Please check if fuel-core library is installed. \

--- a/packages/fuels-test-helpers/src/node.rs
+++ b/packages/fuels-test-helpers/src/node.rs
@@ -268,6 +268,7 @@ pub async fn new_fuel_node(
             .kill_on_drop(true)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .spawn()
             .expect("error: Couldn't read fuel-core: No such file or directory. Please check if fuel-core library is installed. \
         Try this https://fuellabs.github.io/sway/latest/introduction/installation.html");


### PR DESCRIPTION
* This PR closes #495 by adding the `silent` option for running a Fuel node, which is enabled by default.
