### PR TITLE
Distinguish between a `Wallet`'s `Locked` and `Unlocked` states

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -12,6 +12,7 @@
   - [Managing wallets](./getting-started/managing-wallets.md)
     - [Creating a wallet from a private key](./wallets/private-keys.md)
     - [Creating a wallet from mnemonic phrases](./wallets/mnemonic-wallet.md)
+    - [Wallet Access](./wallets/access.md)
     - [Encrypting and storing wallets](./wallets/encrypting-and-storing.md)
     - [Checking balances and coins](./wallets/checking-balances-and-coins.md)
     - [Setting up test wallets](./wallets/test-wallets.md)

--- a/docs/src/getting-started/managing-wallets.md
+++ b/docs/src/getting-started/managing-wallets.md
@@ -7,8 +7,6 @@ You can use wallets for many important things, for instance:
 3. Signing messages and transactions;
 4. Paying for network fees when sending transactions or deploying smart contracts.
 
-The SDK gives you many different ways to create wallets. Let's explore these different ways.
-
-The following sub-chapters walk you through the different ways of creating wallets.
+The SDK gives you many different ways to create and access wallets. Let's explore these different approaches in the following sub-chapters.
 
 > **Note:** Keep in mind that you should never share your private/secret key. And in the case of wallets that were derived from a mnemonic phrase, never share your mnemonic phrase. If you're planning on storing the wallet on disk, do not store the plain private/secret key and do not store the plain mnemonic phrase. Instead, use `Wallet::encrypt` to encrypt its content first before saving it to disk.

--- a/docs/src/wallets/access.md
+++ b/docs/src/wallets/access.md
@@ -49,5 +49,5 @@ is stored in memory.
 When designing APIs that accept a `Wallet` as an input, we should think
 carefully about the kind of access that we require. API developers should aim to
 minimise their usage of `Unlocked` wallets in order to ensure private keys are
-stored in memory no longer than necessary in order to reduce the surface area
-for attacks and vulnerabilities in downstream libraries and applications.
+stored in memory no longer than necessary to reduce the surface area for attacks
+and vulnerabilities in downstream libraries and applications.

--- a/docs/src/wallets/access.md
+++ b/docs/src/wallets/access.md
@@ -1,0 +1,53 @@
+# Wallet Access
+
+The kinds of operations we can perform with a `Wallet` instance depend on
+whether or not we have access to the wallet's private key.
+
+In order to differentiate between `Wallet` instances that know their private key
+and those that do not, we use the `Unlocked` and `Locked` states respectively.
+
+## Wallet States
+
+An `Unlocked` wallet (i.e. a wallet of type `Wallet<Unlocked>`) is a wallet
+whose private key is known and stored internally in memory. A wallet must be in
+the `Unlocked` state in order to perform operations that involve [signing
+transactions](./signing.md).
+
+A `Locked` wallet (i.e. a wallet of type `Wallet<Locked>`) is a wallet whose
+private key is *not* known or stored in memory. Instead, a locked wallet only
+knows its public address. A locked wallet cannot be used to sign transactions,
+however it may still perform a whole suite of useful operations including
+listing transactions, assets, querying balances, and so on.
+
+If a wallet's type is unspecified its state is `Locked` by default. That is, the
+type `Wallet` (without providing any type arguments) is equivalent to
+`Wallet<Locked>`. This default is aimed at encouraging users to prefer the
+safer `Locked` state by default and to ensure that users remain conscious and
+aware when holding their wallet's private key in memory.
+
+## Transitioning States
+
+A `Locked` wallet can be unlocked by providing the private key:
+
+```rust,ignore
+let unlocked_wallet = locked_wallet.unlock(private_key);
+```
+
+An `Unlocked` wallet can be locked using the `lock` method:
+
+```rust,ignore
+let locked_wallet = unlocked_wallet.lock();
+```
+
+Most `Wallet` constructors that create or generate a new wallet are returned in
+the `Unlocked` state. Consider `lock`ing the wallet after the new private key
+has been handled in order to reduce the scope in which the wallet's private key
+is stored in memory.
+
+## Design Guidelines
+
+When designing APIs that accept a `Wallet` as an input, we should think
+carefully about the kind of access that we require. API developers should aim to
+minimise their usage of `Unlocked` wallets in order to ensure private keys are
+stored in memory no longer than necessary in order to reduce the surface area
+for attacks and vulnerabilities in downstream libraries and applications.

--- a/docs/src/wallets/access.md
+++ b/docs/src/wallets/access.md
@@ -4,50 +4,50 @@ The kinds of operations we can perform with a `Wallet` instance depend on
 whether or not we have access to the wallet's private key.
 
 In order to differentiate between `Wallet` instances that know their private key
-and those that do not, we use the `Unlocked` and `Locked` states respectively.
+and those that do not, we use the `WalletUnlocked` and `Wallet` types
+respectively.
 
 ## Wallet States
 
-An `Unlocked` wallet (i.e. a wallet of type `Wallet<Unlocked>`) is a wallet
-whose private key is known and stored internally in memory. A wallet must be in
-the `Unlocked` state in order to perform operations that involve [signing
+The `WalletUnlocked` type represents a wallet whose private key is known and
+stored internally in memory. A wallet must be of type `WalletUnlocked` in order
+to perform operations that involve [signing messages or
 transactions](./signing.md).
 
-A `Locked` wallet (i.e. a wallet of type `Wallet<Locked>`) is a wallet whose
-private key is *not* known or stored in memory. Instead, a locked wallet only
-knows its public address. A locked wallet cannot be used to sign transactions,
-however it may still perform a whole suite of useful operations including
-listing transactions, assets, querying balances, and so on.
+The `Wallet` type represents a wallet whose private key is *not* known or stored
+in memory. Instead, `Wallet` only knows its public address. A `Wallet` cannot be
+used to sign transactions, however it may still perform a whole suite of useful
+operations including listing transactions, assets, querying balances, and so on.
 
-If a wallet's type is unspecified its state is `Locked` by default. That is, the
-type `Wallet` (without providing any type arguments) is equivalent to
-`Wallet<Locked>`. This default is aimed at encouraging users to prefer the
-safer `Locked` state by default and to ensure that users remain conscious and
-aware when holding their wallet's private key in memory.
+Note that the `WalletUnlocked` type provides a `Deref` implementation targeting
+its inner `Wallet` type. This means that all methods available on the `Wallet`
+type are also available on the `WalletUnlocked` type. In other words,
+`WalletUnlocked` can be thought of as a thin wrapper around `Wallet` that
+provides greater access via its private key.
 
 ## Transitioning States
 
-A `Locked` wallet can be unlocked by providing the private key:
+A `Wallet` instance can be unlocked by providing the private key:
 
 ```rust,ignore
-let unlocked_wallet = locked_wallet.unlock(private_key);
+let wallet_unlocked = wallet_locked.unlock(private_key);
 ```
 
-An `Unlocked` wallet can be locked using the `lock` method:
+A `WalletUnlocked` instance can be locked using the `lock` method:
 
 ```rust,ignore
-let locked_wallet = unlocked_wallet.lock();
+let wallet_locked = wallet_unlocked.lock();
 ```
 
-Most `Wallet` constructors that create or generate a new wallet are returned in
-the `Unlocked` state. Consider `lock`ing the wallet after the new private key
-has been handled in order to reduce the scope in which the wallet's private key
-is stored in memory.
+Most wallet constructors that create or generate a new wallet are provided on
+the `WalletUnlocked` type. Consider `lock`ing the wallet after the new private
+key has been handled in order to reduce the scope in which the wallet's private
+key is stored in memory.
 
 ## Design Guidelines
 
-When designing APIs that accept a `Wallet` as an input, we should think
-carefully about the kind of access that we require. API developers should aim to
-minimise their usage of `Unlocked` wallets in order to ensure private keys are
-stored in memory no longer than necessary to reduce the surface area for attacks
-and vulnerabilities in downstream libraries and applications.
+When designing APIs that accept a wallet as an input, we should think carefully
+about the kind of access that we require. API developers should aim to minimise
+their usage of `WalletUnlocked` in order to ensure private keys are stored in
+memory no longer than necessary to reduce the surface area for attacks and
+vulnerabilities in downstream libraries and applications.

--- a/docs/src/wallets/signing.md
+++ b/docs/src/wallets/signing.md
@@ -1,6 +1,6 @@
 # Signing
 
-Once you've instantiated your wallet using one of the previously discussed methods, you can sign a message with `wallet.sign_message`. Below is a full example of how to sign and recover a message.
+Once you've instantiated your wallet in an unlocked state using one of the previously discussed methods, you can sign a message with `wallet.sign_message`. Below is a full example of how to sign and recover a message.
 
 ```rust,ignore
 {{#include ../../../packages/fuels-signers/src/lib.rs:sign_message}}

--- a/examples/cookbook/src/lib.rs
+++ b/examples/cookbook/src/lib.rs
@@ -94,7 +94,7 @@ mod tests {
         // ANCHOR_END: custom_chain_consensus
 
         // ANCHOR: custom_chain_coins
-        let wallet = LocalWallet::new_random(None);
+        let wallet = WalletUnlocked::new_random(None);
         let coins = setup_single_asset_coins(
             wallet.address(),
             Default::default(),
@@ -119,8 +119,8 @@ mod tests {
         use std::str::FromStr;
 
         // ANCHOR: transfer_multiple_setup
-        let mut wallet_1 = LocalWallet::new_random(None);
-        let mut wallet_2 = LocalWallet::new_random(None);
+        let mut wallet_1 = WalletUnlocked::new_random(None);
+        let mut wallet_2 = WalletUnlocked::new_random(None);
 
         const NUM_ASSETS: u64 = 5;
         const AMOUNT: u64 = 100_000;

--- a/examples/providers/src/lib.rs
+++ b/examples/providers/src/lib.rs
@@ -18,7 +18,7 @@ mod tests {
         let provider = Provider::connect(server_address).await.unwrap();
 
         // Create the wallet.
-        let _wallet = LocalWallet::new_random(Some(provider));
+        let _wallet = WalletUnlocked::new_random(Some(provider));
         // ANCHOR_END: connect_to_node
     }
 
@@ -31,7 +31,7 @@ mod tests {
 
         // Create a random wallet (more on wallets later).
         // ANCHOR: setup_single_asset
-        let wallet = LocalWallet::new_random(None);
+        let wallet = WalletUnlocked::new_random(None);
 
         // How many coins in our wallet.
         let number_of_coins = 1;

--- a/examples/rust_bindings/src/rust_bindings_formatted.rs
+++ b/examples/rust_bindings/src/rust_bindings_formatted.rs
@@ -1,9 +1,9 @@
 pub struct MyContract {
     contract_id: ContractId,
-    wallet: LocalWallet,
+    wallet: LocalWallet<Unlocked>,
 }
 impl MyContract {
-    pub fn new(contract_id: String, wallet: LocalWallet) -> Self {
+    pub fn new(contract_id: String, wallet: LocalWallet<Unlocked>) -> Self {
         let contract_id = ContractId::from_str(&contract_id).expect("Invalid contract id");
         Self {
             contract_id,

--- a/examples/rust_bindings/src/rust_bindings_formatted.rs
+++ b/examples/rust_bindings/src/rust_bindings_formatted.rs
@@ -1,9 +1,9 @@
 pub struct MyContract {
     contract_id: ContractId,
-    wallet: LocalWallet<Unlocked>,
+    wallet: WalletUnlocked,
 }
 impl MyContract {
-    pub fn new(contract_id: String, wallet: LocalWallet<Unlocked>) -> Self {
+    pub fn new(contract_id: String, wallet: WalletUnlocked) -> Self {
         let contract_id = ContractId::from_str(&contract_id).expect("Invalid contract id");
         Self {
             contract_id,

--- a/examples/wallets/src/lib.rs
+++ b/examples/wallets/src/lib.rs
@@ -11,7 +11,7 @@ mod tests {
         let (provider, _address) = setup_test_provider(vec![], None).await;
 
         // Create the wallet.
-        let _wallet = LocalWallet::new_random(Some(provider));
+        let _wallet = WalletUnlocked::new_random(Some(provider));
         // ANCHOR_END: create_random_wallet
     }
 
@@ -31,7 +31,7 @@ mod tests {
         )?;
 
         // Create the wallet.
-        let _wallet = LocalWallet::new_from_private_key(secret, Some(provider));
+        let _wallet = WalletUnlocked::new_from_private_key(secret, Some(provider));
         // ANCHOR_END: create_wallet_from_secret_key
         Ok(())
     }
@@ -48,14 +48,14 @@ mod tests {
         let (provider, _address) = setup_test_provider(vec![], None).await;
 
         // Create first account from mnemonic phrase.
-        let _wallet = LocalWallet::new_from_mnemonic_phrase_with_path(
+        let _wallet = WalletUnlocked::new_from_mnemonic_phrase_with_path(
             phrase,
             Some(provider.clone()),
             "m/44'/1179993420'/0'/0/0",
         )?;
 
         // Or with the default derivation path
-        let wallet = LocalWallet::new_from_mnemonic_phrase(phrase, Some(provider))?;
+        let wallet = WalletUnlocked::new_from_mnemonic_phrase(phrase, Some(provider))?;
 
         let expected_address = "fuel17x9kg3k7hqf42396vqenukm4yf59e5k0vj4yunr4mae9zjv9pdjszy098t";
 
@@ -79,11 +79,11 @@ mod tests {
 
         // Create a wallet to be stored in the keystore.
         let (_wallet, uuid) =
-            LocalWallet::new_from_keystore(&dir, &mut rng, password, Some(provider.clone()))?;
+            WalletUnlocked::new_from_keystore(&dir, &mut rng, password, Some(provider.clone()))?;
 
         let path = dir.join(uuid);
 
-        let _recovered_wallet = LocalWallet::load_keystore(&path, password, Some(provider))?;
+        let _recovered_wallet = WalletUnlocked::load_keystore(&path, password, Some(provider))?;
         // ANCHOR_END: create_and_restore_json_wallet
         Ok(())
     }
@@ -102,7 +102,7 @@ mod tests {
         let (provider, _address) = setup_test_provider(vec![], None).await;
 
         // Create first account from mnemonic phrase.
-        let wallet = LocalWallet::new_from_mnemonic_phrase(phrase, Some(provider))?;
+        let wallet = WalletUnlocked::new_from_mnemonic_phrase(phrase, Some(provider))?;
 
         let password = "my_master_password";
 
@@ -214,7 +214,7 @@ mod tests {
         // ANCHOR: multiple_assets_wallet
         // ANCHOR: multiple_assets_coins
         use fuels::prelude::*;
-        let mut wallet = LocalWallet::new_random(None);
+        let mut wallet = WalletUnlocked::new_random(None);
         let num_assets = 5; // 5 different assets
         let coins_per_asset = 10; // Per asset id, 10 coins in the wallet
         let amount_per_coin = 15; // For each coin (UTXO) of the asset, amount of 15
@@ -239,7 +239,7 @@ mod tests {
         use fuels::prelude::*;
         use rand::Fill;
 
-        let mut wallet = LocalWallet::new_random(None);
+        let mut wallet = WalletUnlocked::new_random(None);
         let mut rng = rand::thread_rng();
 
         let asset_base = AssetConfig {

--- a/packages/fuels-contract/src/contract.rs
+++ b/packages/fuels-contract/src/contract.rs
@@ -22,8 +22,7 @@ use fuels_core::{
 };
 use fuels_signers::{
     provider::{Provider, TransactionCost},
-    wallet::Unlocked,
-    LocalWallet, Signer,
+    Signer, WalletUnlocked,
 };
 use fuels_types::bech32::Bech32ContractId;
 use fuels_types::{
@@ -46,7 +45,7 @@ pub struct CompiledContract {
 /// It allows doing calls without passing a wallet/signer each time.
 pub struct Contract {
     pub compiled_contract: CompiledContract,
-    pub wallet: LocalWallet<Unlocked>,
+    pub wallet: WalletUnlocked,
 }
 
 /// CallResponse is a struct that is returned by a call to the contract. Its value field
@@ -93,7 +92,7 @@ impl<D> CallResponse<D> {
 }
 
 impl Contract {
-    pub fn new(compiled_contract: CompiledContract, wallet: LocalWallet<Unlocked>) -> Self {
+    pub fn new(compiled_contract: CompiledContract, wallet: WalletUnlocked) -> Self {
         Self {
             compiled_contract,
             wallet,
@@ -129,7 +128,7 @@ impl Contract {
     pub fn method_hash<D: Tokenizable + Debug>(
         provider: &Provider,
         contract_id: Bech32ContractId,
-        wallet: &LocalWallet<Unlocked>,
+        wallet: &WalletUnlocked,
         signature: Selector,
         output_param: Option<ParamType>,
         args: &[Token],
@@ -185,7 +184,7 @@ impl Contract {
     /// Loads a compiled contract and deploys it to a running node
     pub async fn deploy(
         binary_filepath: &str,
-        wallet: &LocalWallet<Unlocked>,
+        wallet: &WalletUnlocked,
         params: TxParameters,
         storage_configuration: StorageConfiguration,
     ) -> Result<Bech32ContractId, Error> {
@@ -200,7 +199,7 @@ impl Contract {
     /// Loads a compiled contract with salt and deploys it to a running node
     pub async fn deploy_with_parameters(
         binary_filepath: &str,
-        wallet: &LocalWallet<Unlocked>,
+        wallet: &WalletUnlocked,
         params: TxParameters,
         storage_configuration: StorageConfiguration,
         salt: Salt,
@@ -234,7 +233,7 @@ impl Contract {
     /// wallet will also receive the change.
     pub async fn deploy_loaded(
         compiled_contract: &CompiledContract,
-        wallet: &LocalWallet<Unlocked>,
+        wallet: &WalletUnlocked,
         params: TxParameters,
     ) -> Result<Bech32ContractId, Error> {
         let (mut tx, contract_id) =
@@ -313,7 +312,7 @@ impl Contract {
     /// Crafts a transaction used to deploy a contract
     pub async fn contract_deployment_transaction(
         compiled_contract: &CompiledContract,
-        wallet: &LocalWallet<Unlocked>,
+        wallet: &WalletUnlocked,
         params: TxParameters,
     ) -> Result<(Transaction, Bech32ContractId), Error> {
         let bytecode_witness_index = 0;
@@ -438,7 +437,7 @@ impl ContractCall {
 pub struct ContractCallHandler<D> {
     pub contract_call: ContractCall,
     pub tx_parameters: TxParameters,
-    pub wallet: LocalWallet<Unlocked>,
+    pub wallet: WalletUnlocked,
     pub provider: Provider,
     pub datatype: PhantomData<D>,
 }
@@ -570,11 +569,11 @@ where
 pub struct MultiContractCallHandler {
     pub contract_calls: Option<Vec<ContractCall>>,
     pub tx_parameters: TxParameters,
-    pub wallet: LocalWallet<Unlocked>,
+    pub wallet: WalletUnlocked,
 }
 
 impl MultiContractCallHandler {
-    pub fn new(wallet: LocalWallet<Unlocked>) -> Self {
+    pub fn new(wallet: WalletUnlocked) -> Self {
         Self {
             contract_calls: None,
             tx_parameters: TxParameters::default(),

--- a/packages/fuels-contract/src/contract.rs
+++ b/packages/fuels-contract/src/contract.rs
@@ -22,6 +22,7 @@ use fuels_core::{
 };
 use fuels_signers::{
     provider::{Provider, TransactionCost},
+    wallet::Unlocked,
     LocalWallet, Signer,
 };
 use fuels_types::bech32::Bech32ContractId;
@@ -45,7 +46,7 @@ pub struct CompiledContract {
 /// It allows doing calls without passing a wallet/signer each time.
 pub struct Contract {
     pub compiled_contract: CompiledContract,
-    pub wallet: LocalWallet,
+    pub wallet: LocalWallet<Unlocked>,
 }
 
 /// CallResponse is a struct that is returned by a call to the contract. Its value field
@@ -92,7 +93,7 @@ impl<D> CallResponse<D> {
 }
 
 impl Contract {
-    pub fn new(compiled_contract: CompiledContract, wallet: LocalWallet) -> Self {
+    pub fn new(compiled_contract: CompiledContract, wallet: LocalWallet<Unlocked>) -> Self {
         Self {
             compiled_contract,
             wallet,
@@ -128,7 +129,7 @@ impl Contract {
     pub fn method_hash<D: Tokenizable + Debug>(
         provider: &Provider,
         contract_id: Bech32ContractId,
-        wallet: &LocalWallet,
+        wallet: &LocalWallet<Unlocked>,
         signature: Selector,
         output_param: Option<ParamType>,
         args: &[Token],
@@ -184,7 +185,7 @@ impl Contract {
     /// Loads a compiled contract and deploys it to a running node
     pub async fn deploy(
         binary_filepath: &str,
-        wallet: &LocalWallet,
+        wallet: &LocalWallet<Unlocked>,
         params: TxParameters,
         storage_configuration: StorageConfiguration,
     ) -> Result<Bech32ContractId, Error> {
@@ -199,7 +200,7 @@ impl Contract {
     /// Loads a compiled contract with salt and deploys it to a running node
     pub async fn deploy_with_parameters(
         binary_filepath: &str,
-        wallet: &LocalWallet,
+        wallet: &LocalWallet<Unlocked>,
         params: TxParameters,
         storage_configuration: StorageConfiguration,
         salt: Salt,
@@ -233,7 +234,7 @@ impl Contract {
     /// wallet will also receive the change.
     pub async fn deploy_loaded(
         compiled_contract: &CompiledContract,
-        wallet: &LocalWallet,
+        wallet: &LocalWallet<Unlocked>,
         params: TxParameters,
     ) -> Result<Bech32ContractId, Error> {
         let (mut tx, contract_id) =
@@ -312,7 +313,7 @@ impl Contract {
     /// Crafts a transaction used to deploy a contract
     pub async fn contract_deployment_transaction(
         compiled_contract: &CompiledContract,
-        wallet: &LocalWallet,
+        wallet: &LocalWallet<Unlocked>,
         params: TxParameters,
     ) -> Result<(Transaction, Bech32ContractId), Error> {
         let bytecode_witness_index = 0;
@@ -437,7 +438,7 @@ impl ContractCall {
 pub struct ContractCallHandler<D> {
     pub contract_call: ContractCall,
     pub tx_parameters: TxParameters,
-    pub wallet: LocalWallet,
+    pub wallet: LocalWallet<Unlocked>,
     pub provider: Provider,
     pub datatype: PhantomData<D>,
 }
@@ -569,11 +570,11 @@ where
 pub struct MultiContractCallHandler {
     pub contract_calls: Option<Vec<ContractCall>>,
     pub tx_parameters: TxParameters,
-    pub wallet: LocalWallet,
+    pub wallet: LocalWallet<Unlocked>,
 }
 
 impl MultiContractCallHandler {
-    pub fn new(wallet: LocalWallet) -> Self {
+    pub fn new(wallet: LocalWallet<Unlocked>) -> Self {
         Self {
             contract_calls: None,
             tx_parameters: TxParameters::default(),

--- a/packages/fuels-contract/src/script.rs
+++ b/packages/fuels-contract/src/script.rs
@@ -11,7 +11,7 @@ use fuel_gql_client::client::schema::coin::Coin;
 use fuels_core::constants::DEFAULT_SPENDABLE_COIN_AMOUNT;
 use fuels_core::parameters::TxParameters;
 use fuels_signers::provider::Provider;
-use fuels_signers::{wallet::Unlocked, LocalWallet, Signer};
+use fuels_signers::{Signer, WalletUnlocked};
 use fuels_types::bech32::Bech32Address;
 use fuels_types::{constants::WORD_SIZE, errors::Error};
 use futures::{stream, StreamExt};
@@ -53,7 +53,7 @@ impl Script {
     pub async fn from_contract_calls(
         calls: &[ContractCall],
         tx_parameters: &TxParameters,
-        wallet: &LocalWallet<Unlocked>,
+        wallet: &WalletUnlocked,
     ) -> Result<Self, Error> {
         let data_offset = Self::get_data_offset(calls.len());
 
@@ -85,7 +85,7 @@ impl Script {
     /// Calculates how much of each asset id the given calls require and
     /// proceeds to request spendable coins from `wallet` to cover that cost.
     async fn get_spendable_coins(
-        wallet: &LocalWallet<Unlocked>,
+        wallet: &WalletUnlocked,
         calls: &[ContractCall],
     ) -> Result<Vec<Coin>, Error> {
         stream::iter(Self::calculate_required_asset_amounts(calls))

--- a/packages/fuels-contract/src/script.rs
+++ b/packages/fuels-contract/src/script.rs
@@ -11,7 +11,7 @@ use fuel_gql_client::client::schema::coin::Coin;
 use fuels_core::constants::DEFAULT_SPENDABLE_COIN_AMOUNT;
 use fuels_core::parameters::TxParameters;
 use fuels_signers::provider::Provider;
-use fuels_signers::{LocalWallet, Signer};
+use fuels_signers::{wallet::Unlocked, LocalWallet, Signer};
 use fuels_types::bech32::Bech32Address;
 use fuels_types::{constants::WORD_SIZE, errors::Error};
 use futures::{stream, StreamExt};
@@ -53,7 +53,7 @@ impl Script {
     pub async fn from_contract_calls(
         calls: &[ContractCall],
         tx_parameters: &TxParameters,
-        wallet: &LocalWallet,
+        wallet: &LocalWallet<Unlocked>,
     ) -> Result<Self, Error> {
         let data_offset = Self::get_data_offset(calls.len());
 
@@ -85,7 +85,7 @@ impl Script {
     /// Calculates how much of each asset id the given calls require and
     /// proceeds to request spendable coins from `wallet` to cover that cost.
     async fn get_spendable_coins(
-        wallet: &LocalWallet,
+        wallet: &LocalWallet<Unlocked>,
         calls: &[ContractCall],
     ) -> Result<Vec<Coin>, Error> {
         stream::iter(Self::calculate_required_asset_amounts(calls))

--- a/packages/fuels-core/src/code_gen/abigen.rs
+++ b/packages/fuels-core/src/code_gen/abigen.rs
@@ -117,7 +117,7 @@ impl Abigen {
                 quote! {
                     use fuels::contract::contract::{Contract, ContractCallHandler};
                     use fuels::core::{EnumSelector, StringToken, Parameterize, Tokenizable, Token, try_from_bytes};
-                    use fuels::signers::{wallet::Unlocked, LocalWallet};
+                    use fuels::signers::{Wallet, WalletUnlocked};
                     use fuels::tx::{ContractId, Address};
                     use fuels::types::bech32::Bech32ContractId;
                     use fuels::types::errors::Error as SDKError;
@@ -127,7 +127,7 @@ impl Abigen {
                 quote! {
                     pub struct #name {
                         contract_id: Bech32ContractId,
-                        wallet: LocalWallet<Unlocked>
+                        wallet: WalletUnlocked
                     }
 
                     impl #name {
@@ -137,11 +137,11 @@ impl Abigen {
                             &self.contract_id
                         }
 
-                        pub fn _get_wallet(&self) -> LocalWallet<Unlocked> {
+                        pub fn _get_wallet(&self) -> WalletUnlocked {
                             self.wallet.clone()
                         }
 
-                        pub fn _with_wallet(&self, mut wallet: LocalWallet<Unlocked>) -> Result<Self, SDKError> {
+                        pub fn _with_wallet(&self, mut wallet: WalletUnlocked) -> Result<Self, SDKError> {
                            let provider = self.wallet.get_provider()?;
                            wallet.set_provider(provider.clone());
 
@@ -151,11 +151,11 @@ impl Abigen {
 
                     pub struct #builder_name {
                         contract_id: Bech32ContractId,
-                        wallet: LocalWallet<Unlocked>
+                        wallet: WalletUnlocked
                     }
 
                     impl #builder_name {
-                        pub fn new(contract_id: String, wallet: LocalWallet<Unlocked>) -> Self {
+                        pub fn new(contract_id: String, wallet: WalletUnlocked) -> Self {
                             let contract_id = Bech32ContractId::from_str(&contract_id).expect("Invalid contract id");
                             Self { contract_id, wallet }
                         }
@@ -165,7 +165,7 @@ impl Abigen {
                             self
                         }
 
-                        pub fn wallet(&mut self, wallet: LocalWallet<Unlocked>) -> &mut Self {
+                        pub fn wallet(&mut self, wallet: WalletUnlocked) -> &mut Self {
                             self.wallet = wallet;
                             self
                         }

--- a/packages/fuels-core/src/code_gen/abigen.rs
+++ b/packages/fuels-core/src/code_gen/abigen.rs
@@ -117,7 +117,7 @@ impl Abigen {
                 quote! {
                     use fuels::contract::contract::{Contract, ContractCallHandler};
                     use fuels::core::{EnumSelector, StringToken, Parameterize, Tokenizable, Token, try_from_bytes};
-                    use fuels::signers::LocalWallet;
+                    use fuels::signers::{wallet::Unlocked, LocalWallet};
                     use fuels::tx::{ContractId, Address};
                     use fuels::types::bech32::Bech32ContractId;
                     use fuels::types::errors::Error as SDKError;
@@ -127,7 +127,7 @@ impl Abigen {
                 quote! {
                     pub struct #name {
                         contract_id: Bech32ContractId,
-                        wallet: LocalWallet
+                        wallet: LocalWallet<Unlocked>
                     }
 
                     impl #name {
@@ -137,11 +137,11 @@ impl Abigen {
                             &self.contract_id
                         }
 
-                        pub fn _get_wallet(&self) -> LocalWallet {
+                        pub fn _get_wallet(&self) -> LocalWallet<Unlocked> {
                             self.wallet.clone()
                         }
 
-                        pub fn _with_wallet(&self, mut wallet: LocalWallet) -> Result<Self, SDKError> {
+                        pub fn _with_wallet(&self, mut wallet: LocalWallet<Unlocked>) -> Result<Self, SDKError> {
                            let provider = self.wallet.get_provider()?;
                            wallet.set_provider(provider.clone());
 
@@ -151,11 +151,11 @@ impl Abigen {
 
                     pub struct #builder_name {
                         contract_id: Bech32ContractId,
-                        wallet: LocalWallet
+                        wallet: LocalWallet<Unlocked>
                     }
 
                     impl #builder_name {
-                        pub fn new(contract_id: String, wallet: LocalWallet) -> Self {
+                        pub fn new(contract_id: String, wallet: LocalWallet<Unlocked>) -> Self {
                             let contract_id = Bech32ContractId::from_str(&contract_id).expect("Invalid contract id");
                             Self { contract_id, wallet }
                         }
@@ -165,7 +165,7 @@ impl Abigen {
                             self
                         }
 
-                        pub fn wallet(&mut self, wallet: LocalWallet) -> &mut Self {
+                        pub fn wallet(&mut self, wallet: LocalWallet<Unlocked>) -> &mut Self {
                             self.wallet = wallet;
                             self
                         }

--- a/packages/fuels-core/src/code_gen/flat_abigen.rs
+++ b/packages/fuels-core/src/code_gen/flat_abigen.rs
@@ -99,7 +99,7 @@ impl FlatAbigen {
                 quote! {
                     use fuels::contract::contract::{Contract, ContractCallHandler};
                     use fuels::core::{EnumSelector, StringToken, Parameterize, Tokenizable, Token, try_from_bytes};
-                    use fuels::signers::LocalWallet;
+                    use fuels::signers::WalletUnlocked;
                     use fuels::tx::{ContractId, Address};
                     use fuels::types::bech32::Bech32ContractId;
                     use fuels::types::errors::Error as SDKError;
@@ -109,7 +109,7 @@ impl FlatAbigen {
                 quote! {
                     pub struct #name {
                         contract_id: Bech32ContractId,
-                        wallet: LocalWallet
+                        wallet: WalletUnlocked
                     }
 
                     impl #name {
@@ -119,11 +119,11 @@ impl FlatAbigen {
                             &self.contract_id
                         }
 
-                        pub fn _get_wallet(&self) -> LocalWallet {
+                        pub fn _get_wallet(&self) -> WalletUnlocked {
                             self.wallet.clone()
                         }
 
-                        pub fn _with_wallet(&self, mut wallet: LocalWallet) -> Result<Self, SDKError> {
+                        pub fn _with_wallet(&self, mut wallet: WalletUnlocked) -> Result<Self, SDKError> {
                            let provider = self.wallet.get_provider()?;
                            wallet.set_provider(provider.clone());
 
@@ -133,11 +133,11 @@ impl FlatAbigen {
 
                     pub struct #builder_name {
                         contract_id: Bech32ContractId,
-                        wallet: LocalWallet
+                        wallet: WalletUnlocked
                     }
 
                     impl #builder_name {
-                        pub fn new(contract_id: String, wallet: LocalWallet) -> Self {
+                        pub fn new(contract_id: String, wallet: WalletUnlocked) -> Self {
                             let contract_id = Bech32ContractId::from_str(&contract_id).expect("Invalid contract id");
                             Self { contract_id, wallet }
                         }
@@ -147,7 +147,7 @@ impl FlatAbigen {
                             self
                         }
 
-                        pub fn wallet(&mut self, wallet: LocalWallet) -> &mut Self {
+                        pub fn wallet(&mut self, wallet: WalletUnlocked) -> &mut Self {
                             self.wallet = wallet;
                             self
                         }

--- a/packages/fuels-signers/src/lib.rs
+++ b/packages/fuels-signers/src/lib.rs
@@ -11,7 +11,7 @@ use fuels_types::bech32::Bech32Address;
 use std::error::Error;
 
 /// A wallet instantiated with a locally stored private key
-pub type LocalWallet = wallet::Wallet;
+pub type LocalWallet<T = wallet::Locked> = wallet::Wallet<T>;
 
 /// Trait for signing transactions and messages
 ///

--- a/packages/fuels-signers/src/lib.rs
+++ b/packages/fuels-signers/src/lib.rs
@@ -9,9 +9,7 @@ use fuel_crypto::Signature;
 use fuel_gql_client::fuel_tx::Transaction;
 use fuels_types::bech32::Bech32Address;
 use std::error::Error;
-
-/// A wallet instantiated with a locally stored private key
-pub type LocalWallet<T = wallet::Locked> = wallet::Wallet<T>;
+pub use wallet::{Wallet, WalletUnlocked};
 
 /// Trait for signing transactions and messages
 ///
@@ -47,7 +45,7 @@ mod tests {
     use std::str::FromStr;
 
     use crate::provider::Provider;
-    use crate::wallet::Wallet;
+    use crate::wallet::WalletUnlocked;
 
     use super::*;
 
@@ -61,7 +59,7 @@ mod tests {
         let secret = unsafe { SecretKey::from_bytes_unchecked(secret_seed) };
 
         // Create a wallet using the private key created above.
-        let wallet = Wallet::new_from_private_key(secret, None);
+        let wallet = WalletUnlocked::new_from_private_key(secret, None);
 
         let message = "my message";
 
@@ -88,7 +86,7 @@ mod tests {
         let secret = SecretKey::from_str(
             "5f70feeff1f229e4a95e1056e8b4d80d0b24b565674860cc213bdb07127ce1b1",
         )?;
-        let wallet = Wallet::new_from_private_key(secret, None);
+        let wallet = WalletUnlocked::new_from_private_key(secret, None);
 
         // Set up a dummy transaction.
         let input_coin = Input::coin_signed(
@@ -143,8 +141,8 @@ mod tests {
     #[tokio::test]
     async fn send_transfer_transactions() -> Result<(), fuels_types::errors::Error> {
         // Setup two sets of coins, one for each wallet, each containing 1 coin with 1 amount.
-        let mut wallet_1 = LocalWallet::new_random(None);
-        let mut wallet_2 = LocalWallet::new_random(None);
+        let mut wallet_1 = WalletUnlocked::new_random(None);
+        let mut wallet_2 = WalletUnlocked::new_random(None).lock();
 
         let mut coins_1 = setup_single_asset_coins(wallet_1.address(), BASE_ASSET_ID, 1, 1000000);
         let coins_2 = setup_single_asset_coins(wallet_2.address(), BASE_ASSET_ID, 1, 1000000);
@@ -223,8 +221,8 @@ mod tests {
     #[tokio::test]
     async fn transfer_coins_with_change() -> Result<(), fuels_types::errors::Error> {
         // Setup two sets of coins, one for each wallet, each containing 1 coin with 5 amounts each.
-        let mut wallet_1 = LocalWallet::new_random(None);
-        let mut wallet_2 = LocalWallet::new_random(None);
+        let mut wallet_1 = WalletUnlocked::new_random(None);
+        let mut wallet_2 = WalletUnlocked::new_random(None).lock();
 
         let mut coins_1 = setup_single_asset_coins(wallet_1.address(), BASE_ASSET_ID, 1, 5);
         let coins_2 = setup_single_asset_coins(wallet_2.address(), BASE_ASSET_ID, 1, 5);

--- a/packages/fuels-signers/src/provider.rs
+++ b/packages/fuels-signers/src/provider.rs
@@ -160,7 +160,7 @@ impl Provider {
     ///     let provider = Provider::connect(server_address).await.unwrap();
     ///
     ///     // Create the wallet.
-    ///     let _wallet = LocalWallet::new_random(Some(provider));
+    ///     let _wallet = WalletUnlocked::new_random(Some(provider));
     /// }
     /// ```
     pub async fn connect(socket: SocketAddr) -> Result<Provider, Error> {

--- a/packages/fuels-signers/src/wallet.rs
+++ b/packages/fuels-signers/src/wallet.rs
@@ -110,17 +110,6 @@ impl<T> Wallet<T> {
         &self.address
     }
 
-    /// Generates a random mnemonic phrase given a random number generator and
-    /// the number of words to generate, `count`.
-    pub fn generate_mnemonic_phrase<R: Rng>(
-        rng: &mut R,
-        count: usize,
-    ) -> Result<String, WalletError> {
-        Ok(fuel_crypto::FuelMnemonic::generate_mnemonic_phrase(
-            rng, count,
-        )?)
-    }
-
     pub async fn get_transactions(
         &self,
         request: PaginationRequest<String>,
@@ -553,6 +542,14 @@ impl<T> fmt::Debug for Wallet<T> {
     }
 }
 
+/// Generates a random mnemonic phrase given a random number generator and the number of words to
+/// generate, `count`.
+pub fn generate_mnemonic_phrase<R: Rng>(rng: &mut R, count: usize) -> Result<String, WalletError> {
+    Ok(fuel_crypto::FuelMnemonic::generate_mnemonic_phrase(
+        rng, count,
+    )?)
+}
+
 #[cfg(test)]
 #[cfg(feature = "test-helpers")]
 mod tests {
@@ -595,7 +592,7 @@ mod tests {
     async fn mnemonic_generation() -> Result<(), Error> {
         let provider = setup().await;
 
-        let mnemonic = Wallet::generate_mnemonic_phrase(&mut rand::thread_rng(), 12)?;
+        let mnemonic = generate_mnemonic_phrase(&mut rand::thread_rng(), 12)?;
 
         let _wallet = Wallet::new_from_mnemonic_phrase(&mnemonic, Some(provider))?;
         Ok(())

--- a/packages/fuels-signers/src/wallet.rs
+++ b/packages/fuels-signers/src/wallet.rs
@@ -17,9 +17,9 @@ use thiserror::Error;
 
 const DEFAULT_DERIVATION_PATH_PREFIX: &str = "m/44'/1179993420'/0'/0/";
 
-/// A FuelVM compatible wallet that can be used to list assets, balances and more.
+/// A FuelVM-compatible wallet that can be used to list assets, balances and more.
 ///
-/// Note that insances of the `Wallet` type only know their public address, and as a result can
+/// Note that instances of the `Wallet` type only know their public address, and as a result can
 /// only perform read-only operations.
 ///
 /// In order to sign messages or send transactions, a `Wallet` must first call [`Wallet::unlock`]

--- a/packages/fuels-test-helpers/src/lib.rs
+++ b/packages/fuels-test-helpers/src/lib.rs
@@ -208,7 +208,7 @@ mod tests {
     use fuels_contract::contract::Contract;
     use fuels_core::parameters::{StorageConfiguration, TxParameters};
     use fuels_signers::provider::Provider;
-    use fuels_signers::{LocalWallet, Signer};
+    use fuels_signers::LocalWallet;
     use fuels_types::bech32::FUEL_BECH32_HRP;
     use std::net::Ipv4Addr;
 

--- a/packages/fuels-test-helpers/src/lib.rs
+++ b/packages/fuels-test-helpers/src/lib.rs
@@ -208,7 +208,7 @@ mod tests {
     use fuels_contract::contract::Contract;
     use fuels_core::parameters::{StorageConfiguration, TxParameters};
     use fuels_signers::provider::Provider;
-    use fuels_signers::LocalWallet;
+    use fuels_signers::WalletUnlocked;
     use fuels_types::bech32::FUEL_BECH32_HRP;
     use std::net::Ipv4Addr;
 
@@ -326,7 +326,7 @@ mod tests {
     async fn test_setup_test_client_custom_config() -> Result<(), rand::Error> {
         let socket = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 5000);
 
-        let wallet = LocalWallet::new_random(None);
+        let wallet = WalletUnlocked::new_random(None);
 
         let coins: Vec<(UtxoId, Coin)> = setup_single_asset_coins(
             wallet.address(),
@@ -350,7 +350,7 @@ mod tests {
     async fn test_setup_test_client_consensus_parameters_config() {
         let consensus_parameters_config = ConsensusParameters::DEFAULT.with_max_gas_per_tx(1);
 
-        let mut wallet = LocalWallet::new_random(None);
+        let mut wallet = WalletUnlocked::new_random(None);
 
         let coins: Vec<(UtxoId, Coin)> = setup_single_asset_coins(
             wallet.address(),

--- a/packages/fuels-test-helpers/src/signers.rs
+++ b/packages/fuels-test-helpers/src/signers.rs
@@ -12,7 +12,7 @@ use fuel_core_interfaces::model::Coin;
 #[cfg(not(feature = "fuel-core-lib"))]
 use crate::node::Config;
 
-use fuels_signers::{provider::Provider, wallet::Unlocked, LocalWallet};
+use fuels_signers::{provider::Provider, WalletUnlocked};
 
 use crate::{setup_custom_assets_coins, setup_test_client, wallets_config::*};
 
@@ -30,7 +30,7 @@ use crate::{setup_custom_assets_coins, setup_test_client, wallets_config::*};
 ///   Ok(())
 /// }
 /// ```
-pub async fn launch_provider_and_get_wallet() -> LocalWallet<Unlocked> {
+pub async fn launch_provider_and_get_wallet() -> WalletUnlocked {
     let mut wallets =
         launch_custom_provider_and_get_wallets(WalletsConfig::new(Some(1), None, None), None).await;
 
@@ -60,7 +60,7 @@ pub async fn launch_provider_and_get_wallet() -> LocalWallet<Unlocked> {
 pub async fn launch_custom_provider_and_get_wallets(
     wallet_config: WalletsConfig,
     provider_config: Option<Config>,
-) -> Vec<LocalWallet<Unlocked>> {
+) -> Vec<WalletUnlocked> {
     const SIZE_SECRET_KEY: usize = size_of::<SecretKey>();
     const PADDING_BYTES: usize = SIZE_SECRET_KEY - size_of::<u64>();
     let mut secret_key: [u8; SIZE_SECRET_KEY] = [0; SIZE_SECRET_KEY];
@@ -69,7 +69,7 @@ pub async fn launch_custom_provider_and_get_wallets(
         .map(|wallet_counter| {
             secret_key[PADDING_BYTES..].copy_from_slice(&wallet_counter.to_be_bytes());
 
-            LocalWallet::new_from_private_key(
+            WalletUnlocked::new_from_private_key(
                 SecretKey::try_from(secret_key.as_slice())
                     .expect("This should never happen as we provide a [u8; SIZE_SECRET_KEY] array"),
                 None,

--- a/packages/fuels-test-helpers/src/signers.rs
+++ b/packages/fuels-test-helpers/src/signers.rs
@@ -12,7 +12,7 @@ use fuel_core_interfaces::model::Coin;
 #[cfg(not(feature = "fuel-core-lib"))]
 use crate::node::Config;
 
-use fuels_signers::{provider::Provider, LocalWallet, Signer};
+use fuels_signers::{provider::Provider, wallet::Unlocked, LocalWallet};
 
 use crate::{setup_custom_assets_coins, setup_test_client, wallets_config::*};
 
@@ -30,7 +30,7 @@ use crate::{setup_custom_assets_coins, setup_test_client, wallets_config::*};
 ///   Ok(())
 /// }
 /// ```
-pub async fn launch_provider_and_get_wallet() -> LocalWallet {
+pub async fn launch_provider_and_get_wallet() -> LocalWallet<Unlocked> {
     let mut wallets =
         launch_custom_provider_and_get_wallets(WalletsConfig::new(Some(1), None, None), None).await;
 
@@ -60,7 +60,7 @@ pub async fn launch_provider_and_get_wallet() -> LocalWallet {
 pub async fn launch_custom_provider_and_get_wallets(
     wallet_config: WalletsConfig,
     provider_config: Option<Config>,
-) -> Vec<LocalWallet> {
+) -> Vec<LocalWallet<Unlocked>> {
     const SIZE_SECRET_KEY: usize = size_of::<SecretKey>();
     const PADDING_BYTES: usize = SIZE_SECRET_KEY - size_of::<u64>();
     let mut secret_key: [u8; SIZE_SECRET_KEY] = [0; SIZE_SECRET_KEY];

--- a/packages/fuels-test-helpers/src/signers.rs
+++ b/packages/fuels-test-helpers/src/signers.rs
@@ -115,7 +115,6 @@ mod tests {
     use crate::{launch_custom_provider_and_get_wallets, AssetConfig, WalletsConfig};
     use fuels_core::constants::BASE_ASSET_ID;
     use fuels_signers::fuel_crypto::fuel_types::AssetId;
-    use fuels_signers::Signer;
     use fuels_types::errors::Error;
     use rand::Fill;
 

--- a/packages/fuels/src/lib.rs
+++ b/packages/fuels/src/lib.rs
@@ -70,10 +70,7 @@ pub mod prelude {
     pub use super::fuel_node::*;
     pub use super::fuels_abigen::abigen;
     pub use super::signers::provider::*;
-    pub use super::signers::{
-        wallet::{generate_mnemonic_phrase, Locked, Unlocked},
-        LocalWallet, Signer,
-    };
+    pub use super::signers::{wallet::generate_mnemonic_phrase, Signer, Wallet, WalletUnlocked};
     pub use super::test_helpers::Config;
     pub use super::test_helpers::*;
     pub use super::tx::Salt;

--- a/packages/fuels/src/lib.rs
+++ b/packages/fuels/src/lib.rs
@@ -71,7 +71,7 @@ pub mod prelude {
     pub use super::fuels_abigen::abigen;
     pub use super::signers::provider::*;
     pub use super::signers::{
-        wallet::{Locked, Unlocked},
+        wallet::{generate_mnemonic_phrase, Locked, Unlocked},
         LocalWallet, Signer,
     };
     pub use super::test_helpers::Config;

--- a/packages/fuels/src/lib.rs
+++ b/packages/fuels/src/lib.rs
@@ -70,7 +70,10 @@ pub mod prelude {
     pub use super::fuel_node::*;
     pub use super::fuels_abigen::abigen;
     pub use super::signers::provider::*;
-    pub use super::signers::{LocalWallet, Signer};
+    pub use super::signers::{
+        wallet::{Locked, Unlocked},
+        LocalWallet, Signer,
+    };
     pub use super::test_helpers::Config;
     pub use super::test_helpers::*;
     pub use super::tx::Salt;

--- a/packages/fuels/tests/harness.rs
+++ b/packages/fuels/tests/harness.rs
@@ -6,7 +6,7 @@ use fuels::contract::predicate::Predicate;
 use fuels::prelude::{
     abigen, launch_custom_provider_and_get_wallets, launch_provider_and_get_wallet,
     setup_multiple_assets_coins, setup_single_asset_coins, setup_test_provider, CallParameters,
-    Config, Contract, Error, LocalWallet, Provider, Salt, Signer, TxParameters, WalletsConfig,
+    Config, Contract, Error, LocalWallet, Provider, Salt, TxParameters, Unlocked, WalletsConfig,
     DEFAULT_COIN_AMOUNT, DEFAULT_NUM_COINS,
 };
 use fuels_core::abi_encoder::ABIEncoder;
@@ -2583,7 +2583,15 @@ async fn can_handle_sway_function_called_new() -> anyhow::Result<()> {
 
 async fn setup_predicate_test(
     file_path: &str,
-) -> Result<(Predicate, LocalWallet, LocalWallet, AssetId), Error> {
+) -> Result<
+    (
+        Predicate,
+        LocalWallet<Unlocked>,
+        LocalWallet<Unlocked>,
+        AssetId,
+    ),
+    Error,
+> {
     let predicate = Predicate::load_from(file_path)?;
 
     let mut wallets = launch_custom_provider_and_get_wallets(

--- a/packages/fuels/tests/harness.rs
+++ b/packages/fuels/tests/harness.rs
@@ -6,7 +6,7 @@ use fuels::contract::predicate::Predicate;
 use fuels::prelude::{
     abigen, launch_custom_provider_and_get_wallets, launch_provider_and_get_wallet,
     setup_multiple_assets_coins, setup_single_asset_coins, setup_test_provider, CallParameters,
-    Config, Contract, Error, LocalWallet, Provider, Salt, TxParameters, Unlocked, WalletsConfig,
+    Config, Contract, Error, Provider, Salt, TxParameters, WalletUnlocked, WalletsConfig,
     DEFAULT_COIN_AMOUNT, DEFAULT_NUM_COINS,
 };
 use fuels_core::abi_encoder::ABIEncoder;
@@ -1256,7 +1256,7 @@ async fn test_provider_launch_and_connect() -> Result<(), Error> {
         "packages/fuels/tests/test_projects/contract_test/out/debug/contract_test-flat-abi.json"
     );
 
-    let mut wallet = LocalWallet::new_random(None);
+    let mut wallet = WalletUnlocked::new_random(None);
 
     let coins = setup_single_asset_coins(
         wallet.address(),
@@ -1362,7 +1362,7 @@ async fn test_gas_errors() -> Result<(), Error> {
         "packages/fuels/tests/test_projects/contract_test/out/debug/contract_test-flat-abi.json"
     );
 
-    let mut wallet = LocalWallet::new_random(None);
+    let mut wallet = WalletUnlocked::new_random(None);
     let number_of_coins = 1;
     let amount_per_coin = 1_000_000;
     let coins = setup_single_asset_coins(
@@ -1843,7 +1843,7 @@ async fn test_logd_receipts() -> Result<(), Error> {
 #[tokio::test]
 async fn test_wallet_balance_api() -> Result<(), Error> {
     // Single asset
-    let mut wallet = LocalWallet::new_random(None);
+    let mut wallet = WalletUnlocked::new_random(None);
     let number_of_coins = 21;
     let amount_per_coin = 11;
     let coins = setup_single_asset_coins(
@@ -2583,15 +2583,7 @@ async fn can_handle_sway_function_called_new() -> anyhow::Result<()> {
 
 async fn setup_predicate_test(
     file_path: &str,
-) -> Result<
-    (
-        Predicate,
-        LocalWallet<Unlocked>,
-        LocalWallet<Unlocked>,
-        AssetId,
-    ),
-    Error,
-> {
+) -> Result<(Predicate, WalletUnlocked, WalletUnlocked, AssetId), Error> {
     let predicate = Predicate::load_from(file_path)?;
 
     let mut wallets = launch_custom_provider_and_get_wallets(
@@ -2957,7 +2949,7 @@ async fn test_network_error() -> Result<(), anyhow::Error> {
         "packages/fuels/tests/test_projects/contract_test/out/debug/contract_test-flat-abi.json"
     );
 
-    let mut wallet = LocalWallet::new_random(None);
+    let mut wallet = WalletUnlocked::new_random(None);
 
     let config = CoreConfig::local_node();
     let service = FuelService::new_node(config).await?;


### PR DESCRIPTION
This PR was motivated by work @kayagokalp and I are doing on the
following:
https://github.com/FuelLabs/sway/issues/2413

We noticed that in order to perform any operations using a `Wallet`, the
private key must be known, even if those operations were simply
retrieving asset balances or a list of transactions.

This PR aims to draw a clearer distinction between Wallet methods that
require access to a private key and those that do not. The idea is to
encourage users of the API to be conscious of when their wallet is in an
unlocked state (i.e. their private key resides in memory) and when it
does not.

To achieve this, we turn `Wallet` into a session type, parameterised
over its state which can be either `Locked` or `Unlocked`.

The default state is `Locked` in the case that the parameter is not
specified for `Wallet` or `LocalWallet`, meaning that if users require
holding the wallet in an unlocked state they must specify the type
explicitly, e.g. `Wallet<Unlocked>`. I think this explicitness can
assist us in maintaining awareness of the state of the wallet that we
require in our downstream APIs.

Users should generally prefer using the `Wallet` in a locked state (the
default) and should ideally only `unlock` the wallet for the duration
that they need to perform operations requiring the private key. Users
can now construct a `Wallet` in a `Locked` state, e.g.
`Wallet::from_address(public_addr, provider)` and access the various
useful read-only operations without knowing the private key or having it
stored in memory.

As a follow-up to this work, we should take a closer look at the usage
of `LocalWallet` in downstream crates (including `fuels-contract`) to
see if we can refactor these to use the wallet in a `Locked` state more
often, only moving into the `Unlocked` state when absolutely necessary.