### PR TITLE
feat: add vm-backtrace flag for local node

### DIFF
--- a/packages/fuels-test-helpers/src/node.rs
+++ b/packages/fuels-test-helpers/src/node.rs
@@ -30,6 +30,7 @@ pub struct Config {
     pub utxo_validation: bool,
     pub predicates: bool,
     pub manual_blocks_enabled: bool,
+    pub vm_backtrace: bool,
     pub silent: bool,
 }
 
@@ -40,6 +41,7 @@ impl Config {
             utxo_validation: false,
             predicates: false,
             manual_blocks_enabled: false,
+            vm_backtrace: false,
             silent: true,
         }
     }
@@ -276,6 +278,10 @@ pub async fn new_fuel_node(
 
         if config.manual_blocks_enabled {
             args.push("--manual_blocks_enabled");
+        }
+
+        if config.vm_backtrace {
+            args.push("--vm-backtrace");
         }
 
         let mut command = Command::new("fuel-core");


### PR DESCRIPTION
closes:https://github.com/FuelLabs/fuels-rs/issues/489

In https://github.com/FuelLabs/fuels-rs/pull/527 we refactored how the `Config` was used. To add new flags, we just have to extend it. For example, in this RP I added `vm_backtrace`

```rust
#[derive(Clone, Copy, Debug)]
pub struct Config {
    pub addr: SocketAddr,
    pub utxo_validation: bool,
    pub predicates: bool,
    pub manual_blocks_enabled: bool,
    pub vm_backtrace: bool,
    pub silent: bool,
}

impl Config {
    pub fn local_node() -> Self {
        Self {
            addr: SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 0),
            utxo_validation: false,
            predicates: false,
            manual_blocks_enabled: false,
            vm_backtrace: false,
            silent: true,
        }
    }
}
```

and later we can use this flag when starting the node:

```rust
        if config.vm_backtrace {
            args.push("--vm-backtrace");
        }
```
For now we have covered all the available flags and I would like to close the issue.