### PR TITLE
feat: add options and results support

### DIFF
--- a/packages/fuels-core/src/code_gen/abigen.rs
+++ b/packages/fuels-core/src/code_gen/abigen.rs
@@ -1,9 +1,6 @@
 use std::collections::HashMap;
 
 use crate::code_gen::bindings::ContractBindings;
-use crate::constants::{
-    ADDRESS_NATIVE_TYPE, CONTRACT_ID_NATIVE_TYPE, OPTION_NATIVE_TYPE, RESULT_NATIVE_TYPE,
-};
 use crate::source::Source;
 use crate::utils::ident;
 use fuels_types::errors::Error;
@@ -216,16 +213,22 @@ impl Abigen {
         Ok(structs)
     }
 
-    // Checks whether the given type field is a Native type.
+    // Checks whether the given type field is a native type.
     // It's expected to come in as `"struct T"` or `"enum T"`.
-    // `T` is a VM or Rust native type if it matches exactly one of
+    // `T` is a native `high-level language` or Rust type if it matches exactly one of
     // the reserved strings, such as "Address", "ContractId", "Option" or "Result"
     pub fn is_native_type(type_field: &str) -> bool {
+        const CONTRACT_ID_NATIVE_TYPE: &str = "ContractId";
+        const ADDRESS_NATIVE_TYPE: &str = "Address";
+        const OPTION_NATIVE_TYPE: &str = "Option";
+        const RESULT_NATIVE_TYPE: &str = "Result";
+
         let split: Vec<&str> = type_field.split_whitespace().collect();
 
         if split.len() > 2 {
             return false;
         }
+
         split[1] == CONTRACT_ID_NATIVE_TYPE
             || split[1] == ADDRESS_NATIVE_TYPE
             || split[1] == OPTION_NATIVE_TYPE

--- a/packages/fuels-core/src/code_gen/abigen.rs
+++ b/packages/fuels-core/src/code_gen/abigen.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
 use crate::code_gen::bindings::ContractBindings;
-use crate::constants::{ADDRESS_SWAY_NATIVE_TYPE, CONTRACT_ID_SWAY_NATIVE_TYPE};
+use crate::constants::{
+    ADDRESS_NATIVE_TYPE, CONTRACT_ID_NATIVE_TYPE, OPTION_NATIVE_TYPE, RESULT_NATIVE_TYPE,
+};
 use crate::source::Source;
 use crate::utils::ident;
 use fuels_types::errors::Error;
@@ -198,10 +200,10 @@ impl Abigen {
                 continue;
             }
 
-            // Skip custom type generation if the custom type is a Sway-native type.
-            // This means ABI methods receiving or returning a Sway-native type
+            // Skip custom type generation if the custom type is a native type.
+            // This means ABI methods receiving or returning a native type
             // can receive or return that native type directly.
-            if Abigen::is_sway_native_type(&prop.type_field) {
+            if Abigen::is_native_type(&prop.type_field) {
                 continue;
             }
 
@@ -214,17 +216,20 @@ impl Abigen {
         Ok(structs)
     }
 
-    // Checks whether the given type field is a Sway-native type.
+    // Checks whether the given type field is a Native type.
     // It's expected to come in as `"struct T"` or `"enum T"`.
-    // `T` is a Sway-native type if it matches exactly one of
-    // the reserved strings, such as "Address" or "ContractId".
-    fn is_sway_native_type(type_field: &str) -> bool {
+    // `T` is a VM or Rust native type if it matches exactly one of
+    // the reserved strings, such as "Address", "ContractId", "Option" or "Result"
+    pub fn is_native_type(type_field: &str) -> bool {
         let split: Vec<&str> = type_field.split_whitespace().collect();
 
         if split.len() > 2 {
             return false;
         }
-        split[1] == CONTRACT_ID_SWAY_NATIVE_TYPE || split[1] == ADDRESS_SWAY_NATIVE_TYPE
+        split[1] == CONTRACT_ID_NATIVE_TYPE
+            || split[1] == ADDRESS_NATIVE_TYPE
+            || split[1] == OPTION_NATIVE_TYPE
+            || split[1] == RESULT_NATIVE_TYPE
     }
 
     fn abi_enums(&self) -> Result<TokenStream, Error> {
@@ -234,7 +239,7 @@ impl Abigen {
         let mut seen_enum: Vec<&str> = vec![];
 
         for prop in &self.abi.types {
-            if !prop.is_enum_type() {
+            if !prop.is_enum_type() || prop.is_option() || prop.is_result() {
                 continue;
             }
 

--- a/packages/fuels-core/src/constants.rs
+++ b/packages/fuels-core/src/constants.rs
@@ -16,5 +16,7 @@ pub const DEFAULT_GAS_ESTIMATION_TOLERANCE: f64 = 0.2;
 pub const GAS_PRICE_FACTOR: u64 = 1_000_000_000;
 pub const MAX_GAS_PER_TX: u64 = 100_000_000;
 
-pub const CONTRACT_ID_SWAY_NATIVE_TYPE: &str = "ContractId";
-pub const ADDRESS_SWAY_NATIVE_TYPE: &str = "Address";
+pub const CONTRACT_ID_NATIVE_TYPE: &str = "ContractId";
+pub const ADDRESS_NATIVE_TYPE: &str = "Address";
+pub const OPTION_NATIVE_TYPE: &str = "Option";
+pub const RESULT_NATIVE_TYPE: &str = "Result";

--- a/packages/fuels-core/src/constants.rs
+++ b/packages/fuels-core/src/constants.rs
@@ -15,8 +15,3 @@ pub const BASE_ASSET_ID: AssetId = AssetId::new([0u8; 32]);
 pub const DEFAULT_GAS_ESTIMATION_TOLERANCE: f64 = 0.2;
 pub const GAS_PRICE_FACTOR: u64 = 1_000_000_000;
 pub const MAX_GAS_PER_TX: u64 = 100_000_000;
-
-pub const CONTRACT_ID_NATIVE_TYPE: &str = "ContractId";
-pub const ADDRESS_NATIVE_TYPE: &str = "Address";
-pub const OPTION_NATIVE_TYPE: &str = "Option";
-pub const RESULT_NATIVE_TYPE: &str = "Result";

--- a/packages/fuels-core/src/lib.rs
+++ b/packages/fuels-core/src/lib.rs
@@ -397,7 +397,7 @@ where
             let selector = (dis, tok, variants);
             Token::Enum(Box::new(selector))
         } else {
-            panic!("should never happen");
+            panic!("should never happen as Option::param_type() returns valid Enum variants");
         }
     }
 }
@@ -433,7 +433,7 @@ where
             let selector = (dis, tok, variants);
             Token::Enum(Box::new(selector))
         } else {
-            panic!("should never happen");
+            panic!("should never happen as Result::param_type() returns valid Enum variants");
         }
     }
 }
@@ -503,8 +503,9 @@ where
     T: Parameterize + Tokenizable,
 {
     fn param_type() -> ParamType {
-        let types = vec![ParamType::Unit, T::param_type()];
-        let variants = EnumVariants::new(types).expect("should never happen");
+        let param_types = vec![ParamType::Unit, T::param_type()];
+        let variants = EnumVariants::new(param_types)
+            .expect("should never happen as we provided valid Option param types");
         ParamType::Enum(variants)
     }
 }
@@ -515,8 +516,9 @@ where
     E: Parameterize + Tokenizable,
 {
     fn param_type() -> ParamType {
-        let types = vec![T::param_type(), E::param_type()];
-        let variants = EnumVariants::new(types).expect("should never happen");
+        let param_types = vec![T::param_type(), E::param_type()];
+        let variants = EnumVariants::new(param_types)
+            .expect("should never happen as we provided valid Result param types");
         ParamType::Enum(variants)
     }
 }

--- a/packages/fuels-core/src/lib.rs
+++ b/packages/fuels-core/src/lib.rs
@@ -503,9 +503,7 @@ where
     T: Parameterize + Tokenizable,
 {
     fn param_type() -> ParamType {
-        let mut types = Vec::new();
-        types.push(ParamType::Unit);
-        types.push(T::param_type());
+        let types = vec![ParamType::Unit, T::param_type()];
         let variants = EnumVariants::new(types).expect("should never happen");
         ParamType::Enum(variants)
     }
@@ -517,9 +515,7 @@ where
     E: Parameterize + Tokenizable,
 {
     fn param_type() -> ParamType {
-        let mut types = Vec::new();
-        types.push(T::param_type());
-        types.push(E::param_type());
+        let types = vec![T::param_type(), E::param_type()];
         let variants = EnumVariants::new(types).expect("should never happen");
         ParamType::Enum(variants)
     }

--- a/packages/fuels-types/src/lib.rs
+++ b/packages/fuels-types/src/lib.rs
@@ -13,13 +13,6 @@ pub mod param_types;
 pub mod parse_param;
 pub mod utils;
 
-// Both those constants are used to determine if a type field represents an `Enum` or a `Struct`.
-// Since it would have the format `struct foo` or `enum bar`, there is a whitespace.
-pub const STRUCT_KEYWORD: &str = "struct ";
-pub const ENUM_KEYWORD: &str = "enum ";
-pub const OPTION_KEYWORD: &str = "Option";
-pub const RESULT_KEYWORD: &str = "Result";
-
 #[derive(Debug, Clone, Copy, ToString, PartialEq, Eq)]
 #[strum(serialize_all = "lowercase")]
 pub enum CustomType {
@@ -69,18 +62,22 @@ pub struct TypeApplication {
 
 impl TypeDeclaration {
     pub fn is_enum_type(&self) -> bool {
+        const ENUM_KEYWORD: &str = "enum ";
         self.type_field.starts_with(ENUM_KEYWORD)
     }
 
     pub fn is_struct_type(&self) -> bool {
+        const STRUCT_KEYWORD: &str = "struct ";
         self.type_field.starts_with(STRUCT_KEYWORD)
     }
 
     pub fn is_option(&self) -> bool {
+        const OPTION_KEYWORD: &str = "Option";
         self.type_field.ends_with(OPTION_KEYWORD)
     }
 
     pub fn is_result(&self) -> bool {
+        const RESULT_KEYWORD: &str = "Result";
         self.type_field.ends_with(RESULT_KEYWORD)
     }
 }

--- a/packages/fuels-types/src/lib.rs
+++ b/packages/fuels-types/src/lib.rs
@@ -17,6 +17,8 @@ pub mod utils;
 // Since it would have the format `struct foo` or `enum bar`, there is a whitespace.
 pub const STRUCT_KEYWORD: &str = "struct ";
 pub const ENUM_KEYWORD: &str = "enum ";
+pub const OPTION_KEYWORD: &str = "Option";
+pub const RESULT_KEYWORD: &str = "Result";
 
 #[derive(Debug, Clone, Copy, ToString, PartialEq, Eq)]
 #[strum(serialize_all = "lowercase")]
@@ -69,7 +71,16 @@ impl TypeDeclaration {
     pub fn is_enum_type(&self) -> bool {
         self.type_field.starts_with(ENUM_KEYWORD)
     }
+
     pub fn is_struct_type(&self) -> bool {
         self.type_field.starts_with(STRUCT_KEYWORD)
+    }
+
+    pub fn is_option(&self) -> bool {
+        self.type_field.ends_with(OPTION_KEYWORD)
+    }
+
+    pub fn is_result(&self) -> bool {
+        self.type_field.ends_with(RESULT_KEYWORD)
     }
 }

--- a/packages/fuels-types/src/lib.rs
+++ b/packages/fuels-types/src/lib.rs
@@ -72,12 +72,12 @@ impl TypeDeclaration {
     }
 
     pub fn is_option(&self) -> bool {
-        const OPTION_KEYWORD: &str = "Option";
+        const OPTION_KEYWORD: &str = " Option";
         self.type_field.ends_with(OPTION_KEYWORD)
     }
 
     pub fn is_result(&self) -> bool {
-        const RESULT_KEYWORD: &str = "Result";
+        const RESULT_KEYWORD: &str = " Result";
         self.type_field.ends_with(RESULT_KEYWORD)
     }
 }

--- a/packages/fuels/tests/harness.rs
+++ b/packages/fuels/tests/harness.rs
@@ -3849,7 +3849,7 @@ async fn test_gas_forwarded_defaults_to_tx_limit() -> Result<(), Error> {
 }
 
 #[tokio::test]
-async fn test_rust_option_can_be_decoded() -> Result<(), Error> {
+async fn test_rust_option_can_be_decoded() -> Result<(), Box<dyn std::error::Error>> {
     abigen!(
         MyContract,
         "packages/fuels/tests/test_projects/options/out/debug/options-abi.json"
@@ -3867,13 +3867,16 @@ async fn test_rust_option_can_be_decoded() -> Result<(), Error> {
 
     let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
 
+    let expected_address =
+        Address::from_str("0xd58573593432a30a800f97ad32f877425c223a9e427ab557aab5d5bb89156db0")?;
+
     let s = TestStruct {
-        option: Some(Address::zeroed()),
+        option: Some(expected_address),
     };
 
-    let e = TestEnum::EnumOption(Some(Address::zeroed()));
+    let e = TestEnum::EnumOption(Some(expected_address));
 
-    let expected_some_address = Some(Address::zeroed());
+    let expected_some_address = Some(expected_address);
     let response = contract_instance.get_some_address().call().await?;
 
     assert_eq!(response.value, expected_some_address);
@@ -3901,7 +3904,7 @@ async fn test_rust_option_can_be_decoded() -> Result<(), Error> {
 }
 
 #[tokio::test]
-async fn test_rust_option_can_be_encoded() -> Result<(), Error> {
+async fn test_rust_option_can_be_encoded() -> Result<(), Box<dyn std::error::Error>> {
     abigen!(
         MyContract,
         "packages/fuels/tests/test_projects/options/out/debug/options-abi.json"
@@ -3917,11 +3920,14 @@ async fn test_rust_option_can_be_encoded() -> Result<(), Error> {
     )
     .await?;
 
+    let expected_address =
+        Address::from_str("0xd58573593432a30a800f97ad32f877425c223a9e427ab557aab5d5bb89156db0")?;
+
     let s = TestStruct {
-        option: Some(Address::zeroed()),
+        option: Some(expected_address),
     };
 
-    let e = TestEnum::EnumOption(Some(Address::zeroed()));
+    let e = TestEnum::EnumOption(Some(expected_address));
 
     let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
     let expected_u64 = Some(36);
@@ -3954,7 +3960,7 @@ async fn test_rust_option_can_be_encoded() -> Result<(), Error> {
 }
 
 #[tokio::test]
-async fn test_rust_result_can_be_decoded() -> Result<(), Error> {
+async fn test_rust_result_can_be_decoded() -> Result<(), Box<dyn std::error::Error>> {
     abigen!(
         MyContract,
         "packages/fuels/tests/test_projects/results/out/debug/results-abi.json"
@@ -3972,13 +3978,16 @@ async fn test_rust_result_can_be_decoded() -> Result<(), Error> {
 
     let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
 
+    let expected_address =
+        Address::from_str("0xd58573593432a30a800f97ad32f877425c223a9e427ab557aab5d5bb89156db0")?;
+
     let s = TestStruct {
-        option: Some(Address::zeroed()),
+        option: Some(expected_address),
     };
 
-    let e = TestEnum::EnumOption(Some(Address::zeroed()));
+    let e = TestEnum::EnumOption(Some(expected_address));
 
-    let expected_ok_address = Ok(Address::zeroed());
+    let expected_ok_address = Ok(expected_address);
     let response = contract_instance.get_ok_address().call().await?;
 
     assert_eq!(response.value, expected_ok_address);
@@ -4006,7 +4015,7 @@ async fn test_rust_result_can_be_decoded() -> Result<(), Error> {
 }
 
 #[tokio::test]
-async fn test_rust_result_can_be_encoded() -> Result<(), Error> {
+async fn test_rust_result_can_be_encoded() -> Result<(), Box<dyn std::error::Error>> {
     abigen!(
         MyContract,
         "packages/fuels/tests/test_projects/results/out/debug/results-abi.json"
@@ -4024,7 +4033,10 @@ async fn test_rust_result_can_be_encoded() -> Result<(), Error> {
 
     let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
 
-    let expected_ok_address = Ok(Address::zeroed());
+    let expected_address =
+        Address::from_str("0xd58573593432a30a800f97ad32f877425c223a9e427ab557aab5d5bb89156db0")?;
+
+    let expected_ok_address = Ok(expected_address);
     let response = contract_instance
         .input_ok(expected_ok_address)
         .call()

--- a/packages/fuels/tests/harness.rs
+++ b/packages/fuels/tests/harness.rs
@@ -3847,3 +3847,195 @@ async fn test_gas_forwarded_defaults_to_tx_limit() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_rust_option_can_be_decoded() -> Result<(), Error> {
+    abigen!(
+        MyContract,
+        "packages/fuels/tests/test_projects/options/out/debug/options-abi.json"
+    );
+
+    let wallet = launch_provider_and_get_wallet().await;
+
+    let contract_id = Contract::deploy(
+        "tests/test_projects/options/out/debug/options.bin",
+        &wallet,
+        TxParameters::default(),
+        StorageConfiguration::default(),
+    )
+    .await?;
+
+    let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
+
+    let s = TestStruct {
+        option: Some(Address::zeroed()),
+    };
+
+    let e = TestEnum::EnumOption(Some(Address::zeroed()));
+
+    let expected_some_address = Some(Address::zeroed());
+    let response = contract_instance.get_some_address().call().await?;
+
+    assert_eq!(response.value, expected_some_address);
+
+    let expected_some_u64 = Some(10);
+    let response = contract_instance.get_some_u64().call().await?;
+
+    assert_eq!(response.value, expected_some_u64);
+
+    let response = contract_instance.get_some_struct().call().await?;
+    assert_eq!(response.value, Some(s.clone()));
+
+    let response = contract_instance.get_some_enum().call().await?;
+    assert_eq!(response.value, Some(e.clone()));
+
+    let response = contract_instance.get_some_tuple().call().await?;
+    assert_eq!(response.value, Some((s.clone(), e.clone())));
+
+    let expected_none = None;
+    let response = contract_instance.get_none().call().await?;
+
+    assert_eq!(response.value, expected_none);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rust_option_can_be_encoded() -> Result<(), Error> {
+    abigen!(
+        MyContract,
+        "packages/fuels/tests/test_projects/options/out/debug/options-abi.json"
+    );
+
+    let wallet = launch_provider_and_get_wallet().await;
+
+    let contract_id = Contract::deploy(
+        "tests/test_projects/options/out/debug/options.bin",
+        &wallet,
+        TxParameters::default(),
+        StorageConfiguration::default(),
+    )
+    .await?;
+
+    let s = TestStruct {
+        option: Some(Address::zeroed()),
+    };
+
+    let e = TestEnum::EnumOption(Some(Address::zeroed()));
+
+    let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
+    let expected_u64 = Some(36);
+    let response = contract_instance
+        .input_primitive(expected_u64)
+        .call()
+        .await?;
+
+    assert!(response.value);
+
+    let expected_struct = Some(s);
+    let response = contract_instance
+        .input_struct(expected_struct)
+        .call()
+        .await?;
+
+    assert!(response.value);
+
+    let expected_enum = Some(e);
+    let response = contract_instance.input_enum(expected_enum).call().await?;
+
+    assert!(response.value);
+
+    let expected_none = None;
+    let response = contract_instance.input_none(expected_none).call().await?;
+
+    assert!(response.value);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rust_result_can_be_decoded() -> Result<(), Error> {
+    abigen!(
+        MyContract,
+        "packages/fuels/tests/test_projects/results/out/debug/results-abi.json"
+    );
+
+    let wallet = launch_provider_and_get_wallet().await;
+
+    let contract_id = Contract::deploy(
+        "tests/test_projects/results/out/debug/results.bin",
+        &wallet,
+        TxParameters::default(),
+        StorageConfiguration::default(),
+    )
+    .await?;
+
+    let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
+
+    let s = TestStruct {
+        option: Some(Address::zeroed()),
+    };
+
+    let e = TestEnum::EnumOption(Some(Address::zeroed()));
+
+    let expected_ok_address = Ok(Address::zeroed());
+    let response = contract_instance.get_ok_address().call().await?;
+
+    assert_eq!(response.value, expected_ok_address);
+
+    let expected_some_u64 = Ok(10);
+    let response = contract_instance.get_ok_u64().call().await?;
+
+    assert_eq!(response.value, expected_some_u64);
+
+    let response = contract_instance.get_ok_struct().call().await?;
+    assert_eq!(response.value, Ok(s.clone()));
+
+    let response = contract_instance.get_ok_enum().call().await?;
+    assert_eq!(response.value, Ok(e.clone()));
+
+    let response = contract_instance.get_ok_tuple().call().await?;
+    assert_eq!(response.value, Ok((s, e)));
+
+    let expected_error = Err(TestError::NoAddress("error".try_into().unwrap()));
+    let response = contract_instance.get_error().call().await?;
+
+    assert_eq!(response.value, expected_error);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rust_result_can_be_encoded() -> Result<(), Error> {
+    abigen!(
+        MyContract,
+        "packages/fuels/tests/test_projects/results/out/debug/results-abi.json"
+    );
+
+    let wallet = launch_provider_and_get_wallet().await;
+
+    let contract_id = Contract::deploy(
+        "tests/test_projects/results/out/debug/results.bin",
+        &wallet,
+        TxParameters::default(),
+        StorageConfiguration::default(),
+    )
+    .await?;
+
+    let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
+
+    let expected_ok_address = Ok(Address::zeroed());
+    let response = contract_instance
+        .input_ok(expected_ok_address)
+        .call()
+        .await?;
+
+    assert!(response.value);
+
+    let expected_error = Err(TestError::NoAddress("error".try_into().unwrap()));
+    let response = contract_instance.input_error(expected_error).call().await?;
+
+    assert!(response.value);
+
+    Ok(())
+}

--- a/packages/fuels/tests/test_projects/options/Forc.toml
+++ b/packages/fuels/tests/test_projects/options/Forc.toml
@@ -1,0 +1,7 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "options"
+
+[dependencies]

--- a/packages/fuels/tests/test_projects/options/src/main.sw
+++ b/packages/fuels/tests/test_projects/options/src/main.sw
@@ -1,0 +1,90 @@
+contract;
+
+use std::{
+    address::Address,
+    constants::ZERO_B256,
+    option::Option,
+};
+
+struct TestStruct {
+    option: Option<Address>
+}
+
+enum TestEnum {
+    EnumOption: Option<Address>
+}
+
+abi MyContract {
+    fn get_some_u64() -> Option<u64>;
+    fn get_some_address() -> Option<Address>;
+    fn get_some_struct() -> Option<TestStruct>;
+    fn get_some_enum() -> Option<TestEnum>;
+    fn get_some_tuple() -> Option<(TestStruct, TestEnum)>;
+    fn get_none() -> Option<Address>;
+    fn input_primitive(s: Option<u64>) -> bool;
+    fn input_struct(s: Option<TestStruct>) -> bool;
+    fn input_enum(e: Option<TestEnum>) -> bool;
+    fn input_none(none: Option<Address>) -> bool;
+}
+
+impl MyContract for Contract {
+    fn get_some_u64() -> Option<u64> {
+        Option::Some(10)
+    }
+
+    fn get_some_address() -> Option<Address> {
+        Option::Some(~Address::from(ZERO_B256))
+    }
+
+    fn get_some_struct() -> Option<TestStruct> {
+        Option::Some(TestStruct{option: Option::Some(~Address::from(ZERO_B256))})
+    }
+
+    fn get_some_enum() -> Option<TestEnum> {
+        Option::Some(TestEnum::EnumOption(Option::Some(~Address::from(ZERO_B256))))
+    }
+
+    fn get_some_tuple() -> Option<(TestStruct, TestEnum)> {
+        let s = TestStruct{option: Option::Some(~Address::from(ZERO_B256))};
+        let e = TestEnum::EnumOption(Option::Some(~Address::from(ZERO_B256)));
+        Option::Some((s,e))
+    }
+
+    fn get_none() -> Option<Address> {
+        Option::None
+    }
+
+    fn input_primitive(input: Option<u64>) -> bool{
+        if let Option::Some(u) = input {
+            return u == 36;
+        }
+        false
+    }
+
+    fn input_struct(input: Option<TestStruct>) -> bool {
+        if let Option::Some(s) = input {
+            if let Option::Some(a) = s.option {
+                return a == ~Address::from(ZERO_B256);
+            }
+        }
+        false
+    }
+
+    fn input_enum(input: Option<TestEnum>) -> bool {
+        if let Option::Some(test_enum) = input {
+            if let TestEnum::EnumOption(option) = test_enum {
+                if let Option::Some(a) = option {
+                    return a == ~Address::from(ZERO_B256);
+                }
+            }
+        }
+        false
+    }
+
+    fn input_none(none: Option<Address>) -> bool {
+        if let Option::None = none {
+            return true;
+        }
+        false
+    }
+}

--- a/packages/fuels/tests/test_projects/options/src/main.sw
+++ b/packages/fuels/tests/test_projects/options/src/main.sw
@@ -2,7 +2,6 @@ contract;
 
 use std::{
     address::Address,
-    constants::ZERO_B256,
     option::Option,
 };
 
@@ -13,6 +12,8 @@ struct TestStruct {
 enum TestEnum {
     EnumOption: Option<Address>
 }
+
+const ADDR = 0xd58573593432a30a800f97ad32f877425c223a9e427ab557aab5d5bb89156db0;
 
 abi MyContract {
     fn get_some_u64() -> Option<u64>;
@@ -33,20 +34,20 @@ impl MyContract for Contract {
     }
 
     fn get_some_address() -> Option<Address> {
-        Option::Some(~Address::from(ZERO_B256))
+        Option::Some(~Address::from(ADDR))
     }
 
     fn get_some_struct() -> Option<TestStruct> {
-        Option::Some(TestStruct{option: Option::Some(~Address::from(ZERO_B256))})
+        Option::Some(TestStruct{option: Option::Some(~Address::from(ADDR))})
     }
 
     fn get_some_enum() -> Option<TestEnum> {
-        Option::Some(TestEnum::EnumOption(Option::Some(~Address::from(ZERO_B256))))
+        Option::Some(TestEnum::EnumOption(Option::Some(~Address::from(ADDR))))
     }
 
     fn get_some_tuple() -> Option<(TestStruct, TestEnum)> {
-        let s = TestStruct{option: Option::Some(~Address::from(ZERO_B256))};
-        let e = TestEnum::EnumOption(Option::Some(~Address::from(ZERO_B256)));
+        let s = TestStruct{option: Option::Some(~Address::from(ADDR))};
+        let e = TestEnum::EnumOption(Option::Some(~Address::from(ADDR)));
         Option::Some((s,e))
     }
 
@@ -64,7 +65,7 @@ impl MyContract for Contract {
     fn input_struct(input: Option<TestStruct>) -> bool {
         if let Option::Some(s) = input {
             if let Option::Some(a) = s.option {
-                return a == ~Address::from(ZERO_B256);
+                return a == ~Address::from(ADDR);
             }
         }
         false
@@ -74,7 +75,7 @@ impl MyContract for Contract {
         if let Option::Some(test_enum) = input {
             if let TestEnum::EnumOption(option) = test_enum {
                 if let Option::Some(a) = option {
-                    return a == ~Address::from(ZERO_B256);
+                    return a == ~Address::from(ADDR);
                 }
             }
         }

--- a/packages/fuels/tests/test_projects/results/Forc.toml
+++ b/packages/fuels/tests/test_projects/results/Forc.toml
@@ -1,0 +1,7 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "results"
+
+[dependencies]

--- a/packages/fuels/tests/test_projects/results/src/main.sw
+++ b/packages/fuels/tests/test_projects/results/src/main.sw
@@ -2,7 +2,6 @@ contract;
 
 use std::{
     address::Address,
-    constants::ZERO_B256,
     result::Result,
     option::Option
 };
@@ -18,6 +17,8 @@ enum TestEnum {
 pub enum TestError {
     NoAddress: str[5],
 }
+
+const ADDR = 0xd58573593432a30a800f97ad32f877425c223a9e427ab557aab5d5bb89156db0;
 
 abi MyContract {
     fn get_ok_u64() -> Result<u64, TestError>;
@@ -37,20 +38,20 @@ impl MyContract for Contract {
     }
 
     fn get_ok_address() -> Result<Address, TestError> {
-        Result::Ok(~Address::from(ZERO_B256))
+        Result::Ok(~Address::from(ADDR))
     }
 
     fn get_ok_struct() -> Result<TestStruct, TestError> {
-        Result::Ok(TestStruct{option: Option::Some(~Address::from(ZERO_B256))})
+        Result::Ok(TestStruct{option: Option::Some(~Address::from(ADDR))})
     }
 
     fn get_ok_enum() -> Result<TestEnum, TestError> {
-        Result::Ok(TestEnum::EnumOption(Option::Some(~Address::from(ZERO_B256))))
+        Result::Ok(TestEnum::EnumOption(Option::Some(~Address::from(ADDR))))
     }
 
     fn get_ok_tuple() -> Result<(TestStruct, TestEnum), TestError> {
-        let s = TestStruct{option: Option::Some(~Address::from(ZERO_B256))};
-        let e = TestEnum::EnumOption(Option::Some(~Address::from(ZERO_B256)));
+        let s = TestStruct{option: Option::Some(~Address::from(ADDR))};
+        let e = TestEnum::EnumOption(Option::Some(~Address::from(ADDR)));
         Result::Ok((s,e))
     }
 
@@ -60,7 +61,7 @@ impl MyContract for Contract {
 
     fn input_ok(ok_address: Result<Address, TestError>) -> bool {
         if let Result::Ok(a) = ok_address {
-            return a == ~Address::from(ZERO_B256);
+            return a == ~Address::from(ADDR);
         }
         false
     }

--- a/packages/fuels/tests/test_projects/results/src/main.sw
+++ b/packages/fuels/tests/test_projects/results/src/main.sw
@@ -1,0 +1,76 @@
+contract;
+
+use std::{
+    address::Address,
+    constants::ZERO_B256,
+    result::Result,
+    option::Option
+};
+
+struct TestStruct {
+    option: Option<Address>
+}
+
+enum TestEnum {
+    EnumOption: Option<Address>
+}
+
+pub enum TestError {
+    NoAddress: str[5],
+}
+
+abi MyContract {
+    fn get_ok_u64() -> Result<u64, TestError>;
+    fn get_ok_address() -> Result<Address, TestError>;
+    fn get_ok_struct() -> Result<TestStruct, TestError>;
+    fn get_ok_enum() -> Result<TestEnum, TestError>;
+    fn get_ok_tuple() -> Result<(TestStruct, TestEnum), TestError>;
+    fn get_error() -> Result<Address, TestError>;
+    fn input_ok(ok_address: Result<Address, TestError>) -> bool;
+    fn input_error(test_error: Result<Address, TestError>) -> bool;
+
+}
+
+impl MyContract for Contract {
+    fn get_ok_u64() -> Result<u64, TestError> {
+        Result::Ok(10)
+    }
+
+    fn get_ok_address() -> Result<Address, TestError> {
+        Result::Ok(~Address::from(ZERO_B256))
+    }
+
+    fn get_ok_struct() -> Result<TestStruct, TestError> {
+        Result::Ok(TestStruct{option: Option::Some(~Address::from(ZERO_B256))})
+    }
+
+    fn get_ok_enum() -> Result<TestEnum, TestError> {
+        Result::Ok(TestEnum::EnumOption(Option::Some(~Address::from(ZERO_B256))))
+    }
+
+    fn get_ok_tuple() -> Result<(TestStruct, TestEnum), TestError> {
+        let s = TestStruct{option: Option::Some(~Address::from(ZERO_B256))};
+        let e = TestEnum::EnumOption(Option::Some(~Address::from(ZERO_B256)));
+        Result::Ok((s,e))
+    }
+
+    fn get_error() -> Result<Address, TestError> {
+        Result::Err(TestError::NoAddress("error"))
+    }
+
+    fn input_ok(ok_address: Result<Address, TestError>) -> bool {
+        if let Result::Ok(a) = ok_address {
+            return a == ~Address::from(ZERO_B256);
+        }
+        false
+    }
+
+    fn input_error(test_result: Result<Address, TestError>) -> bool {
+        if let Result::Err(test_error) = test_result {
+            if let TestError::NoAddress(_err_msg) = test_error {
+                return true
+            }
+        }
+        false
+    }
+}


### PR DESCRIPTION
Closes: https://github.com/FuelLabs/fuels-rs/issues/421, https://github.com/FuelLabs/fuels-rs/issues/420, https://github.com/FuelLabs/fuels-rs/issues/415

This PR adds support for native rust `Options` and `Results` inside the SDK. We can now work with Sway contracts like:

```rust
struct TestStruct {
    option: Option<Address>
}

enum TestEnum {
    EnumOption: Option<Address>
}

abi MyContract {
    fn get_some_u64() -> Option<u64>;
    fn get_some_address() -> Option<Address>;
    fn get_some_struct() -> Option<TestStruct>;
    fn get_some_enum() -> Option<TestEnum>;
    fn get_some_tuple() -> Option<(TestStruct, TestEnum)>;
    fn get_none() -> Option<Address>;
    fn input_primitive(s: Option<u64>) -> bool;
    fn input_struct(s: Option<TestStruct>) -> bool;
    fn input_enum(e: Option<TestEnum>) -> bool;
    fn input_none(none: Option<Address>) -> bool;
}
```
and

```rust
struct TestStruct {
    option: Option<Address>
}

enum TestEnum {
    EnumOption: Option<Address>
}

pub enum TestError {
    NoAddress: str[5],
}

abi MyContract {
    fn get_ok_u64() -> Result<u64, TestError>;
    fn get_ok_address() -> Result<Address, TestError>;
    fn get_ok_struct() -> Result<TestStruct, TestError>;
    fn get_ok_enum() -> Result<TestEnum, TestError>;
    fn get_ok_tuple() -> Result<(TestStruct, TestEnum), TestError>;
    fn get_error() -> Result<Address, TestError>;
    fn input_ok(ok_address: Result<Address, TestError>) -> bool;
    fn input_error(test_error: Result<Address, TestError>) -> bool;
}
```