### PR TITLE
Add StringToken import to WASM

### DIFF
--- a/packages/fuels-core/src/code_gen/abigen.rs
+++ b/packages/fuels-core/src/code_gen/abigen.rs
@@ -82,7 +82,7 @@ impl Abigen {
             (
                 quote! {
                     use alloc::{vec, vec::Vec};
-                    use fuels_core::{EnumSelector, Parameterize, Tokenizable, Token, try_from_bytes};
+                    use fuels_core::{EnumSelector, StringToken, Parameterize, Tokenizable, Token, try_from_bytes};
                     use fuels_types::errors::Error as SDKError;
                     use fuels_types::param_types::{ParamType, EnumVariants};
                 },


### PR DESCRIPTION
Was getting compile errors while upgrading to the latest SDK. StringToken import was missing. #576 