### PR TITLE
docs: update wallet get balance and types docs

### DIFF
--- a/docs/src/types/bytes32.md
+++ b/docs/src/types/bytes32.md
@@ -8,6 +8,12 @@ These are the main ways of creating a `Bytes32`:
 {{#include ../../../examples/types/src/lib.rs:bytes32}}
 ```
 
-However, there are more ways to achieve that and `Bytes32` implements many more useful traits, see the [fuel-types documentation](https://docs.rs/fuel-types/latest/fuel_types/struct.Bytes32.html).
+`Bytes32` also implements _fmt's_ `Debug`, `Display`, `LowerHex` and `UpperHex` traits. For example, you can get the display and hex representations with:
+
+```rust,ignore
+{{#include ../../../examples/types/src/lib.rs:bytes32_format}}
+```
+
+For a full list of implemented methods and traits, see the [fuel-types documentation](https://docs.rs/fuel-types/latest/fuel_types/struct.Bytes32.html).
 
 > **Note:** In Fuel, there's a special type called `b256`, which is similar to `Bytes32`; also used to represent hashes, and it holds a 256-bit value. In Rust, through the SDK, this is represented as `Bits256(value)` where `value` is a `[u8; 32]`. If your contract method takes a `b256` as input, all you need to do is pass a `Bits256([u8; 32])` when calling it from the SDK.

--- a/docs/src/wallets/checking-balances-and-coins.md
+++ b/docs/src/wallets/checking-balances-and-coins.md
@@ -12,4 +12,8 @@ If you want to query all the balances (i.e., get the balance for each asset ID i
 {{#include ../../../examples/wallets/src/lib.rs:get_balances}}
 ```
 
-The return type is a `HashMap`, where the key is the _asset ID_, and the value is the corresponding balance.
+The return type is a `HashMap`, where the key is the _asset ID's_ hex string, and the value is the corresponding balance. For example, we can get the base asset balance with:
+
+```rust,ignore
+{{#include ../../../examples/wallets/src/lib.rs:get_balance_hashmap}}
+```

--- a/examples/types/src/lib.rs
+++ b/examples/types/src/lib.rs
@@ -29,6 +29,15 @@ mod tests {
         let b256 = Bytes32::from_str(hex_string).expect("failed to create Bytes32 from string");
         assert_eq!([0u8; 32], *b256);
         // ANCHOR_END: bytes32
+
+        // ANCHOR: bytes32_format
+        let b256_string = b256.to_string();
+        let b256_hex_string = format!("{:#x}", b256);
+        // ANCHOR_END: bytes32_format
+
+        assert_eq!(hex_string[2..], b256_string);
+        assert_eq!(hex_string, b256_hex_string);
+
         Ok(())
     }
     #[tokio::test]

--- a/examples/wallets/src/lib.rs
+++ b/examples/wallets/src/lib.rs
@@ -281,7 +281,9 @@ mod tests {
     #[tokio::test]
     #[allow(unused_variables)]
     async fn get_balances() -> Result<(), Error> {
-        use fuels::prelude::{launch_provider_and_get_wallet, BASE_ASSET_ID};
+        use fuels::prelude::{
+            launch_provider_and_get_wallet, BASE_ASSET_ID, DEFAULT_COIN_AMOUNT, DEFAULT_NUM_COINS,
+        };
         use fuels::tx::AssetId;
         use std::collections::HashMap;
 
@@ -293,6 +295,14 @@ mod tests {
         // ANCHOR: get_balances
         let balances: HashMap<String, u64> = wallet.get_balances().await?;
         // ANCHOR_END: get_balances
+
+        // ANCHOR: get_balance_hashmap
+        let asset_id_key = format!("{:#x}", asset_id);
+        let asset_balance = balances.get(&asset_id_key).unwrap();
+        // ANCHOR_END: get_balance_hashmap
+
+        assert_eq!(*asset_balance, DEFAULT_COIN_AMOUNT * DEFAULT_NUM_COINS);
+
         Ok(())
     }
 }


### PR DESCRIPTION
closes: https://github.com/FuelLabs/fuels-rs/issues/584

- Added an example how to get a specific asset balance when using `wallet.get_balances()`.
- Refactored the `get_balance()` test and added `format!("{:#x}", asset_id)`.
- Update the Bytes32 documentation and show how we can get the hex string. 