### PR TITLE
refactor!: add methods() to contract abigen

### DIFF
--- a/docs/src/calling-contracts/calls-with-different-wallets.md
+++ b/docs/src/calling-contracts/calls-with-different-wallets.md
@@ -1,6 +1,6 @@
 # Calls with different wallets
 
-You can use the `_with_wallet()` method on an existing contract instance as a shorthand for creating a new instance connected to the provided wallet. This lets you make contracts calls with different wallets in a chain like fashion.
+You can use the `with_wallet()` method on an existing contract instance as a shorthand for creating a new instance connected to the provided wallet. This lets you make contracts calls with different wallets in a chain like fashion.
 
 ```rust,ignore
 {{#include ../../../examples/contracts/src/lib.rs:connect_wallet}}

--- a/docs/src/contracts/the-setup-contract-test-macro.md
+++ b/docs/src/contracts/the-setup-contract-test-macro.md
@@ -22,13 +22,13 @@ The input of the macro are the contract instance variable name, wallet variable 
 
 >**Note** The same contract can be deployed several times as the macro deploys the contracts with salt. You can also deploy different contracts to the same provider using a shared wallet.
 
-If you want to deploy contracts to the same provider you have to set the wallet name of the first macro to `wallet` and all the remaining wallet names to `None`. The first macro will create `wallet` and bring it into context and the other macros will use it instead of creating new ones. Let's see it in an example.
+If you want to deploy contracts to the same provider, you have to set the wallet name of the first macro to `wallet` and all the remaining wallet names to `None`. The first macro will create `wallet` and bring it into context, and the other macros will use it instead of creating new ones. Let's see it in an example.
 
 ```rust,ignore
 {{#include ../../../packages/fuels/tests/harness.rs:contract_setup_macro_multi}}
 ```
 
-In this example, three contracts are deploy on the same provider using the `wallet`. The second and third macro use the same contract but they have different IDs because of the deployment with salt. Both of them can call the first contract by using its ID.
+In this example, three contracts are deployed on the same provider using the `wallet`. The second and third macro use the same contract but have different IDs because of the deployment with salt. Both of them can call the first contract by using its ID.
 
 In addition, you can manually create the `wallet` variable and then use it inside the macro. This is useful if you want to create custom wallets or providers, but still want to use the macro to reduce boilerplate code. Below is an example of this approach.
 

--- a/docs/src/contracts/the-setup-contract-test-macro.md
+++ b/docs/src/contracts/the-setup-contract-test-macro.md
@@ -22,9 +22,16 @@ The input of the macro are the contract instance variable name, wallet variable 
 
 >**Note** The same contract can be deployed several times as the macro deploys the contracts with salt. You can also deploy different contracts to the same provider using a shared wallet.
 
-If you want to deploy contract to the same provider you have to set the wallet name of the first macro to `shared_wallet` and all the remaining wallet names to `None`. The first macro will create `shared_wallet` and bring it into context and the other macros will use it instead of creating new ones. Let's see it in an example.
+If you want to deploy contracts to the same provider you have to set the wallet name of the first macro to `wallet` and all the remaining wallet names to `None`. The first macro will create `wallet` and bring it into context and the other macros will use it instead of creating new ones. Let's see it in an example.
 
 ```rust,ignore
 {{#include ../../../packages/fuels/tests/harness.rs:contract_setup_macro_multi}}
 ```
-In this example, three contracts are deploy on the same provider using the `shared_wallet`. The second and third macro use the same contract but they have different IDs because of the deployment with salt. Both of them can call the first contract by using its ID.
+
+In this example, three contracts are deploy on the same provider using the `wallet`. The second and third macro use the same contract but they have different IDs because of the deployment with salt. Both of them can call the first contract by using its ID.
+
+In addition, you can manually create the `wallet` variable and then use it inside the macro. This is useful if you want to create custom wallets or providers, but still want to use the macro to reduce boilerplate code. Below is an example of this approach.
+
+```rust,ignore
+{{#include ../../../packages/fuels/tests/harness.rs:contract_setup_macro_manual_wallet}}
+```

--- a/docs/src/cookbook/deposit-and-withdraw.md
+++ b/docs/src/cookbook/deposit-and-withdraw.md
@@ -20,7 +20,7 @@ Next, we set up a wallet with custom-defined assets. We give our wallet some of 
 {{#include ../../../examples/cookbook/src/lib.rs:liquidity_wallet}}
 ```
 
-Having launched a provider and created the wallet, we can deploy our contract and create an instance of it:
+Having launched a provider and created the wallet, we can deploy our contract and create an instance of its methods:
 
 ```rust,ignore
 {{#include ../../../examples/cookbook/src/lib.rs:liquidity_deploy}}

--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -56,16 +56,21 @@ mod tests {
 
         // ANCHOR: use_deployed_contract
         // This is an instance of your contract which you can use to make calls to your functions
-        let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet).build();
+        let contract_instance = MyContract::new(contract_id.to_string(), wallet);
 
         let response = contract_instance
+            .methods()
             .initialize_counter(42) // Build the ABI call
             .call() // Perform the network call
             .await?;
 
         assert_eq!(42, response.value);
 
-        let response = contract_instance.increment_counter(10).call().await?;
+        let response = contract_instance
+            .methods()
+            .increment_counter(10)
+            .call()
+            .await?;
 
         assert_eq!(52, response.value);
         // ANCHOR_END: use_deployed_contract
@@ -84,7 +89,11 @@ mod tests {
             "packages/fuels/tests/test_projects/contract_test"
         );
 
-        let response = contract_instance.initialize_counter(42).call().await?;
+        let response = contract_instance
+            .methods()
+            .initialize_counter(42)
+            .call()
+            .await?;
 
         assert_eq!(42, response.value);
         // ANCHOR_END: deploy_contract_setup_macro_short
@@ -112,10 +121,11 @@ mod tests {
         .await?;
 
         // ANCHOR: contract_call_cost_estimation
-        let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet).build();
+        let contract_instance = MyContract::new(contract_id.to_string(), wallet);
 
         let tolerance = 0.0;
         let transaction_cost = contract_instance
+            .methods()
             .initialize_counter(42) // Build the ABI call
             .estimate_transaction_cost(Some(tolerance)) // Get estimated transaction cost
             .await?;
@@ -191,10 +201,10 @@ mod tests {
         .await?;
 
         println!("Contract deployed @ {contract_id_1}");
-        let contract_instance_1 =
-            MyContractBuilder::new(contract_id_1.to_string(), wallets[0].clone()).build();
+        let contract_instance_1 = MyContract::new(contract_id_1.to_string(), wallets[0].clone());
 
         let response = contract_instance_1
+            .methods()
             .initialize_counter(42) // Build the ABI call
             .tx_params(TxParameters::new(None, Some(1_000_000), None))
             .call() // Perform the network call
@@ -211,10 +221,10 @@ mod tests {
         .await?;
 
         println!("Contract deployed @ {contract_id_2}");
-        let contract_instance_2 =
-            MyContractBuilder::new(contract_id_2.to_string(), wallets[1].clone()).build();
+        let contract_instance_2 = MyContract::new(contract_id_2.to_string(), wallets[1].clone());
 
         let response = contract_instance_2
+            .methods()
             .initialize_counter(42) // Build the ABI call
             .tx_params(TxParameters::new(None, Some(1_000_000), None))
             .call() // Perform the network call
@@ -244,15 +254,14 @@ mod tests {
         .await?;
         println!("Contract deployed @ {contract_id}");
         // ANCHOR: instantiate_contract
-        let contract_instance =
-            MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
+        // ANCHOR: tx_parameters
+        let contract_methods = MyContract::new(contract_id.to_string(), wallet.clone()).methods();
         // ANCHOR_END: instantiate_contract
 
-        // ANCHOR: tx_parameters
         // In order: gas_price, gas_limit, and maturity
         let my_tx_params = TxParameters::new(None, Some(1_000_000), None);
 
-        let response = contract_instance
+        let response = contract_methods
             .initialize_counter(42) // Our contract method.
             .tx_params(my_tx_params) // Chain the tx params setting method.
             .call() // Perform the contract call.
@@ -261,7 +270,7 @@ mod tests {
         // ANCHOR_END: tx_parameters
 
         // ANCHOR: tx_parameters_default
-        let response = contract_instance
+        let response = contract_methods
             .initialize_counter(42)
             .tx_params(TxParameters::default())
             .call()
@@ -271,13 +280,14 @@ mod tests {
         // In order: gas_price, gas_limit, and maturity
         let my_tx_params = TxParameters::new(None, Some(1_000_000), None);
 
-        let response = contract_instance
+        let response = contract_methods
             .initialize_counter(42) // Our contract method.
             .tx_params(my_tx_params) // Chain the tx params setting method.
             .call() // Perform the contract call.
             .await?; // This is an async call, `.await` for it.
 
         // ANCHOR: call_parameters
+        let contract_methods = MyContract::new(contract_id.to_string(), wallet.clone()).methods();
 
         let tx_params = TxParameters::default();
 
@@ -285,7 +295,7 @@ mod tests {
         // this is a big number for checking that amount can be a u64
         let call_params = CallParameters::new(Some(1_000_000), None, None);
 
-        let response = contract_instance
+        let response = contract_methods
             .get_msg_amount() // Our contract method.
             .tx_params(tx_params) // Chain the tx params setting method.
             .call_params(call_params) // Chain the call params setting method.
@@ -293,7 +303,7 @@ mod tests {
             .await?;
         // ANCHOR_END: call_parameters
         // ANCHOR: call_parameters_default
-        let response = contract_instance
+        let response = contract_methods
             .initialize_counter(42)
             .call_params(CallParameters::default())
             .call()
@@ -322,18 +332,17 @@ mod tests {
         )
         .await?;
         println!("Contract deployed @ {contract_id}");
-        let contract_instance =
-            MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
+        let contract_methods = MyContract::new(contract_id.to_string(), wallet.clone()).methods();
         // ANCHOR: simulate
         // you would mint 100 coins if the transaction wasn't simulated
-        let counter = contract_instance.mint_coins(100).simulate().await?;
+        let counter = contract_methods.mint_coins(100).simulate().await?;
         // ANCHOR_END: simulate
-        let response = contract_instance.mint_coins(1_000_000).call().await?;
+        let response = contract_methods.mint_coins(1_000_000).call().await?;
         // ANCHOR: variable_outputs
         let address = wallet.address();
 
         // withdraw some tokens to wallet
-        let response = contract_instance
+        let response = contract_methods
             .transfer_coins_to_output(1_000_000, contract_id.into(), address.into())
             .append_variable_outputs(1)
             .call()
@@ -360,13 +369,13 @@ mod tests {
             StorageConfiguration::default(),
         )
         .await?;
-        let contract_instance = TestContractBuilder::new(contract_id.to_string(), wallet).build();
+        let contract_methods = TestContract::new(contract_id.to_string(), wallet).methods();
 
         // ANCHOR: good_practice
-        let response = contract_instance.increment_counter(162).call().await?;
+        let response = contract_methods.increment_counter(162).call().await?;
         // ANCHOR_END: good_practice
         // ANCHOR: contract_receipts
-        let response = contract_instance.increment_counter(162).call().await;
+        let response = contract_methods.increment_counter(162).call().await;
         match response {
             // The transaction is valid and executes to completion
             Ok(call_response) => {
@@ -401,7 +410,7 @@ mod tests {
         let contract_id =
             "fuel1vkm285ypjesypw7vhdlhnty3kjxxx4efckdycqh3ttna4xvmxtfs6murwy".to_string();
 
-        let connected_contract_instance = MyContractBuilder::new(contract_id, wallet).build();
+        let connected_contract_instance = MyContract::new(contract_id, wallet);
         // You can now use the `connected_contract_instance` just as you did above!
         // ANCHOR_END: deployed_contracts
         Ok(())
@@ -426,8 +435,7 @@ mod tests {
         )
         .await?;
 
-        let contract_instance =
-            MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
+        let contract_methods = MyContract::new(contract_id.to_string(), wallet.clone()).methods();
 
         // ANCHOR: call_params_gas
         // Set the transaction `gas_limit` to 1000 and `gas_forwarded` to 200 to specify that the
@@ -436,7 +444,7 @@ mod tests {
         let tx_params = TxParameters::new(None, Some(1000), None);
         let call_params = CallParameters::new(None, None, Some(200));
 
-        let response = contract_instance
+        let response = contract_methods
             .get_msg_amount() // Our contract method.
             .tx_params(tx_params) // Chain the tx params setting method.
             .call_params(call_params) // Chain the call params setting method.
@@ -467,11 +475,10 @@ mod tests {
         .await?;
 
         // ANCHOR: multi_call_prepare
-        let contract_instance =
-            MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
+        let contract_methods = MyContract::new(contract_id.to_string(), wallet.clone()).methods();
 
-        let call_handler_1 = contract_instance.initialize_counter(42);
-        let call_handler_2 = contract_instance.get_array([42; 2]);
+        let call_handler_1 = contract_methods.initialize_counter(42);
+        let call_handler_2 = contract_methods.get_array([42; 2]);
         // ANCHOR_END: multi_call_prepare
 
         // ANCHOR: multi_call_build
@@ -516,14 +523,13 @@ mod tests {
         )
         .await?;
 
-        let contract_instance =
-            MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
+        let contract_methods = MyContract::new(contract_id.to_string(), wallet.clone()).methods();
 
         // ANCHOR: multi_call_cost_estimation
         let mut multi_call_handler = MultiContractCallHandler::new(wallet.clone());
 
-        let call_handler_1 = contract_instance.initialize_counter(42);
-        let call_handler_2 = contract_instance.get_array([42; 2]);
+        let call_handler_1 = contract_methods.initialize_counter(42);
+        let call_handler_2 = contract_methods.get_array([42; 2]);
 
         multi_call_handler
             .add_call(call_handler_1)
@@ -564,12 +570,12 @@ mod tests {
 
         // ANCHOR: connect_wallet
         // Create contract instance with wallet_1
-        let contract_instance =
-            MyContractBuilder::new(contract_id.to_string(), wallet_1.clone()).build();
+        let contract_instance = MyContract::new(contract_id.to_string(), wallet_1.clone());
 
         // Perform contract call with wallet_2
         let response = contract_instance
-            ._with_wallet(wallet_2)? // Connect wallet_2
+            .with_wallet(wallet_2)? // Connect wallet_2
+            .methods()
             .get_msg_amount() // Our contract method.
             .call() // Perform the contract call.
             .await?; // This is an async call, `.await` for it.

--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -575,8 +575,8 @@ mod tests {
         // Perform contract call with wallet_2
         let response = contract_instance
             .with_wallet(wallet_2)? // Connect wallet_2
-            .methods()
-            .get_msg_amount() // Our contract method.
+            .methods() // Get contract methods
+            .get_msg_amount() // Our contract method
             .call() // Perform the contract call.
             .await?; // This is an async call, `.await` for it.
                      // ANCHOR_END: connect_wallet

--- a/examples/cookbook/src/lib.rs
+++ b/examples/cookbook/src/lib.rs
@@ -43,14 +43,13 @@ mod tests {
         )
         .await?;
 
-        let contract_instance =
-            MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
+        let contract_methods = MyContract::new(contract_id.to_string(), wallet.clone()).methods();
         // ANCHOR_END: liquidity_deploy
 
         // ANCHOR: liquidity_deposit
         let deposit_amount = 1_000_000;
         let call_params = CallParameters::new(Some(deposit_amount), Some(base_asset_id), None);
-        contract_instance
+        contract_methods
             .deposit(wallet.address().into())
             .call_params(call_params)
             .append_variable_outputs(1)
@@ -63,7 +62,7 @@ mod tests {
         let lp_token_balance = wallet.get_asset_balance(&lp_asset_id).await?;
 
         let call_params = CallParameters::new(Some(lp_token_balance), Some(lp_asset_id), None);
-        contract_instance
+        contract_methods
             .withdraw(wallet.address().into())
             .call_params(call_params)
             .append_variable_outputs(1)

--- a/packages/fuels-abigen-macro/src/lib.rs
+++ b/packages/fuels-abigen-macro/src/lib.rs
@@ -85,10 +85,7 @@ pub fn setup_contract_test(input: TokenStream) -> TokenStream {
     let salt: [u8; 32] = rng.gen();
 
     let contract_instance_name = Ident::new(&args.instance_name, Span::call_site());
-    let builder_struct_name = Ident::new(
-        &[&contract_struct_name, "Builder"].concat(),
-        Span::call_site(),
-    );
+    let contract_struct_name = Ident::new(&contract_struct_name, Span::call_site());
 
     // If the wallet name is None, do not launch a new provider and use the default `shared_wallet` name
     let (wallet_name, wallet_token_stream): (Ident, TokenStream) = if args.wallet_name == "None" {
@@ -105,7 +102,7 @@ pub fn setup_contract_test(input: TokenStream) -> TokenStream {
     };
 
     let contract_deploy_token_stream: TokenStream = quote! {
-        let #contract_instance_name = #builder_struct_name::new(
+        let #contract_instance_name = #contract_struct_name::new(
             Contract::deploy_with_parameters(
                 #bin_path,
                 &#wallet_name,
@@ -119,8 +116,7 @@ pub fn setup_contract_test(input: TokenStream) -> TokenStream {
             .expect("Failed to deploy the contract")
             .to_string(),
             #wallet_name.clone(),
-        )
-        .build();
+        );
     }
     .into();
 

--- a/packages/fuels-abigen-macro/src/lib.rs
+++ b/packages/fuels-abigen-macro/src/lib.rs
@@ -40,8 +40,8 @@ pub fn wasm_abigen(input: TokenStream) -> TokenStream {
 /// The names for the contract instance and wallet variables must be provided as inputs.
 /// This macro can be called multiple times inside a function if the variables names are changed.
 /// The same contract can be deployed multiple times as the macro uses deployment with salt.
-/// If however; you need to have a shared wallet between macros, the first macro must set the
-/// wallet name to `shared_wallet`. The other ones must set the wallet name to `None`.
+/// However, if you need to have a shared wallet between macros, the first macro must set the
+/// wallet name to `wallet`. The other ones must set the wallet name to `None`.
 #[proc_macro]
 pub fn setup_contract_test(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as Spanned<ContractTestArgs>);
@@ -87,12 +87,9 @@ pub fn setup_contract_test(input: TokenStream) -> TokenStream {
     let contract_instance_name = Ident::new(&args.instance_name, Span::call_site());
     let contract_struct_name = Ident::new(&contract_struct_name, Span::call_site());
 
-    // If the wallet name is None, do not launch a new provider and use the default `shared_wallet` name
+    // If the wallet name is None, do not launch a new provider and use the default `wallet` name
     let (wallet_name, wallet_token_stream): (Ident, TokenStream) = if args.wallet_name == "None" {
-        (
-            Ident::new("shared_wallet", Span::call_site()),
-            quote! {}.into(),
-        )
+        (Ident::new("wallet", Span::call_site()), quote! {}.into())
     } else {
         let wallet_name = Ident::new(&args.wallet_name, Span::call_site());
         (

--- a/packages/fuels-core/src/code_gen/abigen.rs
+++ b/packages/fuels-core/src/code_gen/abigen.rs
@@ -115,16 +115,6 @@ impl Abigen {
                             Self { contract_id, wallet }
                         }
 
-                        pub fn contract_id(&mut self, contract_id: String) -> &mut Self {
-                            self.contract_id = Bech32ContractId::from_str(&contract_id).expect("Invalid contract id");
-                            self
-                        }
-
-                        pub fn wallet(&mut self, wallet: WalletUnlocked) -> &mut Self {
-                            self.wallet = wallet;
-                            self
-                        }
-
                         pub fn get_contract_id(&self) -> &Bech32ContractId {
                             &self.contract_id
                         }

--- a/packages/fuels-core/src/code_gen/abigen.rs
+++ b/packages/fuels-core/src/code_gen/abigen.rs
@@ -67,7 +67,7 @@ impl Abigen {
     /// after it is called through a procedural macro (`abigen!()` in our case).
     pub fn expand(&self) -> Result<TokenStream, Error> {
         let name = &self.contract_name;
-        let builder_name = ident(&format!("{}Builder", name));
+        let methods_name = ident(&format!("{}Methods", name));
         let name_mod = ident(&format!(
             "{}_mod",
             self.contract_name.to_string().to_lowercase()
@@ -110,30 +110,6 @@ impl Abigen {
                     }
 
                     impl #name {
-                        #contract_functions
-
-                        pub fn _get_contract_id(&self) -> &Bech32ContractId {
-                            &self.contract_id
-                        }
-
-                        pub fn _get_wallet(&self) -> WalletUnlocked {
-                            self.wallet.clone()
-                        }
-
-                        pub fn _with_wallet(&self, mut wallet: WalletUnlocked) -> Result<Self, SDKError> {
-                           let provider = self.wallet.get_provider()?;
-                           wallet.set_provider(provider.clone());
-
-                           Ok(Self { contract_id: self.contract_id.clone(), wallet: wallet })
-                        }
-                    }
-
-                    pub struct #builder_name {
-                        contract_id: Bech32ContractId,
-                        wallet: WalletUnlocked
-                    }
-
-                    impl #builder_name {
                         pub fn new(contract_id: String, wallet: WalletUnlocked) -> Self {
                             let contract_id = Bech32ContractId::from_str(&contract_id).expect("Invalid contract id");
                             Self { contract_id, wallet }
@@ -149,9 +125,35 @@ impl Abigen {
                             self
                         }
 
-                        pub fn build(self) -> #name {
-                            #name { contract_id: self.contract_id, wallet: self.wallet }
+                        pub fn get_contract_id(&self) -> &Bech32ContractId {
+                            &self.contract_id
                         }
+
+                        pub fn get_wallet(&self) -> WalletUnlocked {
+                            self.wallet.clone()
+                        }
+
+                        pub fn with_wallet(&self, mut wallet: WalletUnlocked) -> Result<Self, SDKError> {
+                           let provider = self.wallet.get_provider()?;
+                           wallet.set_provider(provider.clone());
+
+                           Ok(Self { contract_id: self.contract_id.clone(), wallet: wallet })
+                        }
+
+                        pub fn methods(&self) -> #methods_name {
+                            #methods_name { contract_id: self.contract_id.clone(), wallet: self.wallet.clone() }
+                        }
+
+                    }
+
+                    pub struct #methods_name {
+                        contract_id: Bech32ContractId,
+                        wallet: WalletUnlocked
+                    }
+
+                    impl #methods_name {
+                        #contract_functions
+
                     }
                 },
             )

--- a/packages/fuels/tests/harness.rs
+++ b/packages/fuels/tests/harness.rs
@@ -59,9 +59,9 @@ async fn compile_bindings_from_contract_file() {
     let wallet = launch_provider_and_get_wallet().await;
 
     // `SimpleContract` is the name of the contract
-    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
+    let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
-    let call_handler = contract_methods.takes_ints_returns_bool(42);
+    let call_handler = contract_instance.methods().takes_ints_returns_bool(42);
 
     let encoded = format!(
         "{}{}",
@@ -118,9 +118,9 @@ async fn compile_bindings_from_inline_contract() -> Result<(), Error> {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
+    let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
-    let call_handler = contract_methods.takes_ints_returns_bool(42_u32);
+    let call_handler = contract_instance.methods().takes_ints_returns_bool(42_u32);
 
     let encoded = format!(
         "{}{}",
@@ -190,10 +190,10 @@ async fn compile_bindings_array_input() {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
+    let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
     let input = [1, 2, 3];
-    let call_handler = contract_methods.takes_array(input);
+    let call_handler = contract_instance.methods().takes_array(input);
 
     let encoded = format!(
         "{}{}",
@@ -264,10 +264,10 @@ async fn compile_bindings_bool_array_input() {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
+    let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
     let input = [true, false, true];
-    let call_handler = contract_methods.takes_array(input);
+    let call_handler = contract_instance.methods().takes_array(input);
 
     let encoded = format!(
         "{}{}",
@@ -326,9 +326,9 @@ async fn compile_bindings_byte_input() {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
+    let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
-    let call_handler = contract_methods.takes_byte(Byte(10u8));
+    let call_handler = contract_instance.methods().takes_byte(Byte(10u8));
 
     let encoded = format!(
         "{}{}",
@@ -384,10 +384,10 @@ async fn compile_bindings_string_input() {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
+    let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
     // ANCHOR: contract_takes_string
-    let call_handler = contract_methods.takes_string(
+    let call_handler = contract_instance.methods().takes_string(
         "This is a full sentence"
             .try_into()
             .expect("failed to convert string into SizedAsciiString"),
@@ -451,7 +451,7 @@ async fn compile_bindings_b256_input() {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
+    let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
     let mut hasher = Sha256::new();
     hasher.update("test string".as_bytes());
@@ -459,7 +459,7 @@ async fn compile_bindings_b256_input() {
     // ANCHOR: 256_arg
     let arg: [u8; 32] = hasher.finalize().into();
 
-    let call_handler = contract_methods.takes_b256(Bits256(arg));
+    let call_handler = contract_instance.methods().takes_b256(Bits256(arg));
     // ANCHOR_END: 256_arg
 
     let encoded = format!(
@@ -560,9 +560,9 @@ async fn compile_bindings_struct_input() {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
+    let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
-    let call_handler = contract_methods.takes_struct(input);
+    let call_handler = contract_instance.methods().takes_struct(input);
 
     let encoded = format!(
         "{}{}",
@@ -663,9 +663,9 @@ async fn compile_bindings_nested_struct_input() {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
+    let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
-    let call_handler = contract_methods.takes_nested_struct(input);
+    let call_handler = contract_instance.methods().takes_nested_struct(input);
 
     let encoded = format!(
         "{}{}",
@@ -746,9 +746,9 @@ async fn compile_bindings_enum_input() {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
+    let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
-    let call_handler = contract_methods.takes_enum(variant);
+    let call_handler = contract_instance.methods().takes_enum(variant);
 
     let encoded = format!(
         "{}{}",
@@ -839,9 +839,9 @@ async fn create_struct_from_decoded_tokens() -> Result<(), Error> {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
+    let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
-    let call_handler = contract_methods.takes_struct(struct_from_tokens);
+    let call_handler = contract_instance.methods().takes_struct(struct_from_tokens);
 
     let encoded = format!(
         "{}{}",
@@ -951,9 +951,11 @@ async fn create_nested_struct_from_decoded_tokens() -> Result<(), Error> {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
+    let contract_instance = SimpleContract::new(null_contract_id(), wallet);
 
-    let call_handler = contract_methods.takes_nested_struct(nested_struct_from_tokens);
+    let call_handler = contract_instance
+        .methods()
+        .takes_nested_struct(nested_struct_from_tokens);
 
     let encoded = format!(
         "{}{}",
@@ -1131,6 +1133,7 @@ async fn test_methods_typeless_argument() -> Result<(), Error> {
         .method_with_empty_argument()
         .call()
         .await?;
+
     assert_eq!(response.value, 63);
     Ok(())
 }
@@ -1213,19 +1216,20 @@ async fn test_provider_launch_and_connect() -> Result<(), Error> {
     )
     .await?;
 
-    let contract_instance_connected =
-        MyContract::new(contract_id.to_string(), wallet.clone()).methods();
+    let contract_instance_connected = MyContract::new(contract_id.to_string(), wallet.clone());
 
     let response = contract_instance_connected
+        .methods()
         .initialize_counter(42) // Build the ABI call
         .call() // Perform the network call
         .await?;
     assert_eq!(42, response.value);
 
     wallet.set_provider(launched_provider);
-    let contract_instance_launched = MyContract::new(contract_id.to_string(), wallet).methods();
+    let contract_instance_launched = MyContract::new(contract_id.to_string(), wallet);
 
     let response = contract_instance_launched
+        .methods()
         .increment_counter(10)
         .call()
         .await?;
@@ -1239,7 +1243,7 @@ async fn test_contract_calling_contract() -> Result<(), Error> {
     // Load and deploy the first compiled contract
     setup_contract_test!(
         foo_contract_instance,
-        shared_wallet,
+        wallet,
         "packages/fuels/tests/test_projects/foo_contract"
     );
     let foo_contract_id = foo_contract_instance.get_contract_id();
@@ -1274,15 +1278,15 @@ async fn test_contract_calling_contract() -> Result<(), Error> {
 #[tokio::test]
 async fn test_contract_setup_macro_deploy_with_salt() -> Result<(), Error> {
     // ANCHOR: contract_setup_macro_multi
-    // The first wallet name must be `shared_wallet`
+    // The first wallet name must be `wallet`
     setup_contract_test!(
         foo_contract_instance,
-        shared_wallet,
+        wallet,
         "packages/fuels/tests/test_projects/foo_contract"
     );
     let foo_contract_id = foo_contract_instance.get_contract_id();
 
-    // The macros that want to use the `shared_wallet` have to set
+    // The macros that want to use the `wallet` have to set
     // the wallet name to `None`
     setup_contract_test!(
         foo_caller_contract_instance,
@@ -1325,11 +1329,6 @@ async fn test_contract_setup_macro_deploy_with_salt() -> Result<(), Error> {
 
 #[tokio::test]
 async fn test_gas_errors() -> Result<(), Error> {
-    abigen!(
-        MyContract,
-        "packages/fuels/tests/test_projects/contract_test/out/debug/contract_test-abi.json"
-    );
-
     let mut wallet = WalletUnlocked::new_random(None);
     let number_of_coins = 1;
     let amount_per_coin = 1_000_000;
@@ -1343,19 +1342,16 @@ async fn test_gas_errors() -> Result<(), Error> {
     let (provider, _) = setup_test_provider(coins.clone(), vec![], None).await;
     wallet.set_provider(provider);
 
-    let contract_id = Contract::deploy(
-        "tests/test_projects/contract_test/out/debug/contract_test.bin",
-        &wallet,
-        TxParameters::default(),
-        StorageConfiguration::default(),
-    )
-    .await?;
-
-    let contract_methods = MyContract::new(contract_id.to_string(), wallet).methods();
+    setup_contract_test!(
+        contract_instance,
+        None,
+        "packages/fuels/tests/test_projects/contract_test"
+    );
 
     // Test running out of gas. Gas price as `None` will be 0.
     let gas_limit = 100;
-    let contract_instace_call = contract_methods
+    let contract_instace_call = contract_instance
+        .methods()
         .initialize_counter(42) // Build the ABI call
         .tx_params(TxParameters::new(None, Some(gas_limit), None));
 
@@ -1375,7 +1371,8 @@ async fn test_gas_errors() -> Result<(), Error> {
     assert!(response.to_string().starts_with(expected));
 
     // Test for insufficient base asset amount to pay for the transaction fee
-    let response = contract_methods
+    let response = contract_instance
+        .methods()
         .initialize_counter(42) // Build the ABI call
         .tx_params(TxParameters::new(Some(100_000_000_000), None, None))
         .call()
@@ -2099,9 +2096,10 @@ async fn test_storage_initialization() -> Result<(), Error> {
     .await?;
     // ANCHOR_END: manual_storage
 
-    let contract_methods = MyContract::new(contract_id.to_string(), wallet.clone()).methods();
+    let contract_instance = MyContract::new(contract_id.to_string(), wallet.clone());
 
-    let result = contract_methods
+    let result = contract_instance
+        .methods()
         .get_value_b256(Bits256(key.into()))
         .call()
         .await?
@@ -3162,27 +3160,21 @@ async fn strings_must_have_all_ascii_chars_custom_types() {
 
 #[tokio::test]
 async fn test_connect_wallet() -> anyhow::Result<()> {
-    abigen!(
-        MyContract,
-        "packages/fuels/tests/test_projects/contract_test/out/debug/contract_test-abi.json"
-    );
-
+    // ANCHOR: contract_setup_macro_manual_wallet
     let config = WalletsConfig::new(Some(2), Some(1), Some(DEFAULT_COIN_AMOUNT));
 
     let mut wallets = launch_custom_provider_and_get_wallets(config, None).await;
-    let wallet_1 = wallets.pop().unwrap();
+    let wallet = wallets.pop().unwrap();
     let wallet_2 = wallets.pop().unwrap();
 
-    let id = Contract::deploy(
-        "tests/test_projects/contract_test/out/debug/contract_test.bin",
-        &wallet_1,
-        TxParameters::default(),
-        StorageConfiguration::default(),
-    )
-    .await?;
+    setup_contract_test!(
+        contract_instance,
+        None,
+        "packages/fuels/tests/test_projects/contract_test"
+    );
+    // ANCHOR_END: contract_setup_macro_manual_wallet
 
-    // pay for call with wallet_1
-    let contract_instance = MyContract::new(id.to_string(), wallet_1.clone());
+    // pay for call with wallet
     let tx_params = TxParameters::new(Some(10), Some(10000), None);
     contract_instance
         .methods()
@@ -3192,8 +3184,8 @@ async fn test_connect_wallet() -> anyhow::Result<()> {
         .await?;
 
     // confirm that funds have been deducted
-    let wallet_1_balance = wallet_1.get_asset_balance(&Default::default()).await?;
-    assert!(DEFAULT_COIN_AMOUNT > wallet_1_balance);
+    let wallet_balance = wallet.get_asset_balance(&Default::default()).await?;
+    assert!(DEFAULT_COIN_AMOUNT > wallet_balance);
 
     // pay for call with wallet_2
     contract_instance
@@ -3204,10 +3196,10 @@ async fn test_connect_wallet() -> anyhow::Result<()> {
         .call()
         .await?;
 
-    // confirm there are no changes to wallet_1, wallet_2 has been charged
-    let wallet_1_balance_second_call = wallet_1.get_asset_balance(&Default::default()).await?;
+    // confirm there are no changes to wallet, wallet_2 has been charged
+    let wallet_balance_second_call = wallet.get_asset_balance(&Default::default()).await?;
     let wallet_2_balance = wallet_2.get_asset_balance(&Default::default()).await?;
-    assert_eq!(wallet_1_balance_second_call, wallet_1_balance);
+    assert_eq!(wallet_balance_second_call, wallet_balance);
     assert!(DEFAULT_COIN_AMOUNT > wallet_2_balance);
     Ok(())
 }
@@ -3365,11 +3357,6 @@ async fn testnet_hello_world() -> Result<(), Error> {
 
 #[tokio::test]
 async fn test_input_message() -> Result<(), Error> {
-    abigen!(
-        MyContract,
-        "packages/fuels/tests/test_projects/contract_test/out/debug/contract_test-abi.json"
-    );
-
     let compare_messages =
         |messages_from_provider: Vec<OtherMessage>, used_messages: Vec<Message>| -> bool {
             iter::zip(&used_messages, &messages_from_provider).all(|(a, b)| {
@@ -3397,21 +3384,17 @@ async fn test_input_message() -> Result<(), Error> {
     let (provider, _) = setup_test_provider(vec![], messages.clone(), None).await;
     wallet.set_provider(provider);
 
-    let contract_id = Contract::deploy(
-        "tests/test_projects/contract_test/out/debug/contract_test.bin",
-        &wallet,
-        TxParameters::default(),
-        StorageConfiguration::default(),
-    )
-    .await?;
-
-    let contract_instance_connected =
-        MyContract::new(contract_id.to_string(), wallet.clone()).methods();
+    setup_contract_test!(
+        contract_instance,
+        None,
+        "packages/fuels/tests/test_projects/contract_test"
+    );
 
     let messages_from_provider = wallet.get_messages().await?;
     assert!(compare_messages(messages_from_provider, messages));
 
-    let response = contract_instance_connected
+    let response = contract_instance
+        .methods()
         .initialize_counter(42) // Build the ABI call
         .call()
         .await?;

--- a/packages/fuels/tests/harness.rs
+++ b/packages/fuels/tests/harness.rs
@@ -59,9 +59,9 @@ async fn compile_bindings_from_contract_file() {
     let wallet = launch_provider_and_get_wallet().await;
 
     // `SimpleContract` is the name of the contract
-    let contract_instance = SimpleContractBuilder::new(null_contract_id(), wallet).build();
+    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
 
-    let call_handler = contract_instance.takes_ints_returns_bool(42);
+    let call_handler = contract_methods.takes_ints_returns_bool(42);
 
     let encoded = format!(
         "{}{}",
@@ -117,10 +117,10 @@ async fn compile_bindings_from_inline_contract() -> Result<(), Error> {
     );
 
     let wallet = launch_provider_and_get_wallet().await;
-    //`SimpleContract` is the name of the contract
-    let contract_instance = SimpleContractBuilder::new(null_contract_id(), wallet).build();
 
-    let call_handler = contract_instance.takes_ints_returns_bool(42_u32);
+    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
+
+    let call_handler = contract_methods.takes_ints_returns_bool(42_u32);
 
     let encoded = format!(
         "{}{}",
@@ -190,11 +190,10 @@ async fn compile_bindings_array_input() {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    // `SimpleContract` is the name of the contract
-    let contract_instance = SimpleContractBuilder::new(null_contract_id(), wallet).build();
+    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
 
     let input = [1, 2, 3];
-    let call_handler = contract_instance.takes_array(input);
+    let call_handler = contract_methods.takes_array(input);
 
     let encoded = format!(
         "{}{}",
@@ -265,11 +264,10 @@ async fn compile_bindings_bool_array_input() {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    // `SimpleContract` is the name of the contract
-    let contract_instance = SimpleContractBuilder::new(null_contract_id(), wallet).build();
+    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
 
     let input = [true, false, true];
-    let call_handler = contract_instance.takes_array(input);
+    let call_handler = contract_methods.takes_array(input);
 
     let encoded = format!(
         "{}{}",
@@ -328,10 +326,9 @@ async fn compile_bindings_byte_input() {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    // `SimpleContract` is the name of the contract
-    let contract_instance = SimpleContractBuilder::new(null_contract_id(), wallet).build();
+    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
 
-    let call_handler = contract_instance.takes_byte(Byte(10u8));
+    let call_handler = contract_methods.takes_byte(Byte(10u8));
 
     let encoded = format!(
         "{}{}",
@@ -387,11 +384,10 @@ async fn compile_bindings_string_input() {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    // `SimpleContract` is the name of the contract
-    let contract_instance = SimpleContractBuilder::new(null_contract_id(), wallet).build();
+    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
 
     // ANCHOR: contract_takes_string
-    let call_handler = contract_instance.takes_string(
+    let call_handler = contract_methods.takes_string(
         "This is a full sentence"
             .try_into()
             .expect("failed to convert string into SizedAsciiString"),
@@ -455,8 +451,7 @@ async fn compile_bindings_b256_input() {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    // `SimpleContract` is the name of the contract
-    let contract_instance = SimpleContractBuilder::new(null_contract_id(), wallet).build();
+    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
 
     let mut hasher = Sha256::new();
     hasher.update("test string".as_bytes());
@@ -464,7 +459,7 @@ async fn compile_bindings_b256_input() {
     // ANCHOR: 256_arg
     let arg: [u8; 32] = hasher.finalize().into();
 
-    let call_handler = contract_instance.takes_b256(Bits256(arg));
+    let call_handler = contract_methods.takes_b256(Bits256(arg));
     // ANCHOR_END: 256_arg
 
     let encoded = format!(
@@ -565,10 +560,9 @@ async fn compile_bindings_struct_input() {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    // `SimpleContract` is the name of the contract
-    let contract_instance = SimpleContractBuilder::new(null_contract_id(), wallet).build();
+    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
 
-    let call_handler = contract_instance.takes_struct(input);
+    let call_handler = contract_methods.takes_struct(input);
 
     let encoded = format!(
         "{}{}",
@@ -669,10 +663,9 @@ async fn compile_bindings_nested_struct_input() {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    // `SimpleContract` is the name of the contract
-    let contract_instance = SimpleContractBuilder::new(null_contract_id(), wallet).build();
+    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
 
-    let call_handler = contract_instance.takes_nested_struct(input);
+    let call_handler = contract_methods.takes_nested_struct(input);
 
     let encoded = format!(
         "{}{}",
@@ -753,10 +746,9 @@ async fn compile_bindings_enum_input() {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    // `SimpleContract` is the name of the contract
-    let contract_instance = SimpleContractBuilder::new(null_contract_id(), wallet).build();
+    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
 
-    let call_handler = contract_instance.takes_enum(variant);
+    let call_handler = contract_methods.takes_enum(variant);
 
     let encoded = format!(
         "{}{}",
@@ -847,10 +839,9 @@ async fn create_struct_from_decoded_tokens() -> Result<(), Error> {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    // `SimpleContract` is the name of the contract
-    let contract_instance = SimpleContractBuilder::new(null_contract_id(), wallet).build();
+    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
 
-    let call_handler = contract_instance.takes_struct(struct_from_tokens);
+    let call_handler = contract_methods.takes_struct(struct_from_tokens);
 
     let encoded = format!(
         "{}{}",
@@ -960,10 +951,9 @@ async fn create_nested_struct_from_decoded_tokens() -> Result<(), Error> {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    // `SimpleContract` is the name of the contract
-    let contract_instance = SimpleContractBuilder::new(null_contract_id(), wallet).build();
+    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();
 
-    let call_handler = contract_instance.takes_nested_struct(nested_struct_from_tokens);
+    let call_handler = contract_methods.takes_nested_struct(nested_struct_from_tokens);
 
     let encoded = format!(
         "{}{}",
@@ -984,11 +974,12 @@ async fn type_safe_output_values() -> Result<(), Error> {
     );
 
     // `response`'s type matches the return type of `is_event()`
-    let response = contract_instance.is_even(10).call().await?;
+    let contract_methods = contract_instance.methods();
+    let response = contract_methods.is_even(10).call().await?;
     assert!(response.value);
 
     // `response`'s type matches the return type of `return_my_string()`
-    let response = contract_instance
+    let response = contract_methods
         .return_my_string("fuel".try_into().unwrap())
         .call()
         .await?;
@@ -997,7 +988,7 @@ async fn type_safe_output_values() -> Result<(), Error> {
 
     let my_struct = MyStruct { foo: 10, bar: true };
 
-    let response = contract_instance.return_my_struct(my_struct).call().await?;
+    let response = contract_methods.return_my_struct(my_struct).call().await?;
 
     assert_eq!(response.value.foo, 10);
     assert!(response.value.bar);
@@ -1032,16 +1023,16 @@ async fn call_with_structs() -> Result<(), Error> {
     )
     .await?;
 
-    let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet).build();
+    let contract_methods = MyContract::new(contract_id.to_string(), wallet).methods();
 
-    let response = contract_instance
+    let response = contract_methods
         .initialize_counter(counter_config) // Build the ABI call
         .call() // Perform the network call
         .await?;
 
     assert_eq!(42, response.value);
 
-    let response = contract_instance.increment_counter(10).call().await?;
+    let response = contract_methods.increment_counter(10).call().await?;
 
     assert_eq!(52, response.value);
     Ok(())
@@ -1056,6 +1047,7 @@ async fn call_with_empty_return() -> Result<(), Error> {
     );
 
     let _response = contract_instance
+        .methods()
         .store_value(42) // Build the ABI call
         .call() // Perform the network call
         .await?;
@@ -1073,11 +1065,12 @@ async fn abigen_different_structs_same_arg_name() -> Result<(), Error> {
     let param_one = StructOne { foo: 42 };
     let param_two = StructTwo { bar: 42 };
 
-    let res_one = contract_instance.something(param_one).call().await?;
+    let contract_methods = contract_instance.methods();
+    let res_one = contract_methods.something(param_one).call().await?;
 
     assert_eq!(res_one.value, 43);
 
-    let res_two = contract_instance.something_else(param_two).call().await?;
+    let res_two = contract_methods.something_else(param_two).call().await?;
 
     assert_eq!(res_two.value, 41);
     Ok(())
@@ -1091,7 +1084,11 @@ async fn test_reverting_transaction() -> Result<(), Error> {
         "packages/fuels/tests/test_projects/revert_transaction_error"
     );
 
-    let response = contract_instance.make_transaction_fail(0).call().await;
+    let response = contract_instance
+        .methods()
+        .make_transaction_fail(0)
+        .call()
+        .await;
 
     assert!(matches!(response, Err(Error::RevertTransactionError(..))));
     Ok(())
@@ -1105,16 +1102,17 @@ async fn multiple_read_calls() -> Result<(), Error> {
         "packages/fuels/tests/test_projects/multiple_read_calls"
     );
 
-    contract_instance.store(42).call().await?;
+    let contract_methods = contract_instance.methods();
+    contract_methods.store(42).call().await?;
 
     // Use "simulate" because the methods don't actually run a transaction, but just a dry-run
     // We can notice here that, thanks to this, we don't generate a TransactionId collision,
     // even if the transactions are theoretically the same.
-    let stored = contract_instance.read(0).simulate().await?;
+    let stored = contract_methods.read(0).simulate().await?;
 
     assert_eq!(stored.value, 42);
 
-    let stored = contract_instance.read(0).simulate().await?;
+    let stored = contract_methods.read(0).simulate().await?;
 
     assert_eq!(stored.value, 42);
     Ok(())
@@ -1129,6 +1127,7 @@ async fn test_methods_typeless_argument() -> Result<(), Error> {
     );
 
     let response = contract_instance
+        .methods()
         .method_with_empty_argument()
         .call()
         .await?;
@@ -1144,7 +1143,8 @@ async fn test_large_return_data() -> Result<(), Error> {
         "packages/fuels/tests/test_projects/large_return_data"
     );
 
-    let res = contract_instance.get_id().call().await?;
+    let contract_methods = contract_instance.methods();
+    let res = contract_methods.get_id().call().await?;
 
     assert_eq!(
         res.value.0,
@@ -1155,23 +1155,23 @@ async fn test_large_return_data() -> Result<(), Error> {
     );
 
     // One word-sized string
-    let res = contract_instance.get_small_string().call().await?;
+    let res = contract_methods.get_small_string().call().await?;
     assert_eq!(res.value, "gggggggg");
 
     // Two word-sized string
-    let res = contract_instance.get_large_string().call().await?;
+    let res = contract_methods.get_large_string().call().await?;
     assert_eq!(res.value, "ggggggggg");
 
     // Large struct will be bigger than a `WORD`.
-    let res = contract_instance.get_large_struct().call().await?;
+    let res = contract_methods.get_large_struct().call().await?;
     assert_eq!(res.value.foo, 12);
     assert_eq!(res.value.bar, 42);
 
     // Array will be returned in `ReturnData`.
-    let res = contract_instance.get_large_array().call().await?;
+    let res = contract_methods.get_large_array().call().await?;
     assert_eq!(res.value, [1, 2]);
 
-    let res = contract_instance.get_contract_id().call().await?;
+    let res = contract_methods.get_contract_id().call().await?;
 
     // First `value` is from `CallResponse`.
     // Second `value` is from the `ContractId` type.
@@ -1214,7 +1214,7 @@ async fn test_provider_launch_and_connect() -> Result<(), Error> {
     .await?;
 
     let contract_instance_connected =
-        MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
+        MyContract::new(contract_id.to_string(), wallet.clone()).methods();
 
     let response = contract_instance_connected
         .initialize_counter(42) // Build the ABI call
@@ -1223,8 +1223,7 @@ async fn test_provider_launch_and_connect() -> Result<(), Error> {
     assert_eq!(42, response.value);
 
     wallet.set_provider(launched_provider);
-    let contract_instance_launched =
-        MyContractBuilder::new(contract_id.to_string(), wallet).build();
+    let contract_instance_launched = MyContract::new(contract_id.to_string(), wallet).methods();
 
     let response = contract_instance_launched
         .increment_counter(10)
@@ -1243,10 +1242,10 @@ async fn test_contract_calling_contract() -> Result<(), Error> {
         shared_wallet,
         "packages/fuels/tests/test_projects/foo_contract"
     );
-    let foo_contract_id = foo_contract_instance._get_contract_id();
+    let foo_contract_id = foo_contract_instance.get_contract_id();
 
     // Call the contract directly; it just flips the bool value that's passed.
-    let res = foo_contract_instance.foo(true).call().await?;
+    let res = foo_contract_instance.methods().foo(true).call().await?;
     assert!(!res.value);
 
     // Load and deploy the second compiled contract
@@ -1261,6 +1260,7 @@ async fn test_contract_calling_contract() -> Result<(), Error> {
     // ANCHOR: external_contract
     let bits = *foo_contract_id.hash();
     let res = foo_caller_contract_instance
+        .methods()
         .call_foo_contract(Bits256(bits), true)
         .set_contracts(&[foo_contract_id.clone()]) // Sets the external contract
         .call()
@@ -1280,7 +1280,7 @@ async fn test_contract_setup_macro_deploy_with_salt() -> Result<(), Error> {
         shared_wallet,
         "packages/fuels/tests/test_projects/foo_contract"
     );
-    let foo_contract_id = foo_contract_instance._get_contract_id();
+    let foo_contract_id = foo_contract_instance.get_contract_id();
 
     // The macros that want to use the `shared_wallet` have to set
     // the wallet name to `None`
@@ -1289,14 +1289,14 @@ async fn test_contract_setup_macro_deploy_with_salt() -> Result<(), Error> {
         None,
         "packages/fuels/tests/test_projects/foo_caller_contract"
     );
-    let foo_caller_contract_id = foo_caller_contract_instance._get_contract_id();
+    let foo_caller_contract_id = foo_caller_contract_instance.get_contract_id();
 
     setup_contract_test!(
         foo_caller_contract_instance2,
         None,
         "packages/fuels/tests/test_projects/foo_caller_contract"
     );
-    let foo_caller_contract_id2 = foo_caller_contract_instance2._get_contract_id();
+    let foo_caller_contract_id2 = foo_caller_contract_instance2.get_contract_id();
 
     // Because we deploy with salt, we can deploy the same contract multiple times
     assert_ne!(foo_caller_contract_id, foo_caller_contract_id2);
@@ -1304,6 +1304,7 @@ async fn test_contract_setup_macro_deploy_with_salt() -> Result<(), Error> {
     // The first contract can be called because they were deployed on the same provider
     let bits = *foo_contract_id.hash();
     let res = foo_caller_contract_instance
+        .methods()
         .call_foo_contract(Bits256(bits), true)
         .set_contracts(&[foo_contract_id.clone()]) // Sets the external contract
         .call()
@@ -1311,6 +1312,7 @@ async fn test_contract_setup_macro_deploy_with_salt() -> Result<(), Error> {
     assert!(!res.value);
 
     let res = foo_caller_contract_instance2
+        .methods()
         .call_foo_contract(Bits256(bits), true)
         .set_contracts(&[foo_contract_id.clone()]) // Sets the external contract
         .call()
@@ -1349,11 +1351,11 @@ async fn test_gas_errors() -> Result<(), Error> {
     )
     .await?;
 
-    let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet).build();
+    let contract_methods = MyContract::new(contract_id.to_string(), wallet).methods();
 
     // Test running out of gas. Gas price as `None` will be 0.
     let gas_limit = 100;
-    let contract_instace_call = contract_instance
+    let contract_instace_call = contract_methods
         .initialize_counter(42) // Build the ABI call
         .tx_params(TxParameters::new(None, Some(gas_limit), None));
 
@@ -1373,7 +1375,7 @@ async fn test_gas_errors() -> Result<(), Error> {
     assert!(response.to_string().starts_with(expected));
 
     // Test for insufficient base asset amount to pay for the transaction fee
-    let response = contract_instance
+    let response = contract_methods
         .initialize_counter(42) // Build the ABI call
         .tx_params(TxParameters::new(Some(100_000_000_000), None, None))
         .call()
@@ -1394,7 +1396,8 @@ async fn test_call_param_gas_errors() -> Result<(), Error> {
     );
 
     // Transaction gas_limit is sufficient, call gas_forwarded is too small
-    let response = contract_instance
+    let contract_methods = contract_instance.methods();
+    let response = contract_methods
         .initialize_counter(42)
         .tx_params(TxParameters::new(None, Some(1000), None))
         .call_params(CallParameters::new(None, None, Some(1)))
@@ -1406,7 +1409,7 @@ async fn test_call_param_gas_errors() -> Result<(), Error> {
     assert!(response.to_string().starts_with(expected));
 
     // Call params gas_forwarded exceeds transaction limit
-    let response = contract_instance
+    let response = contract_methods
         .initialize_counter(42)
         .tx_params(TxParameters::new(None, Some(1), None))
         .call_params(CallParameters::new(None, None, Some(1000)))
@@ -1426,17 +1429,18 @@ async fn test_amount_and_asset_forwarding() -> Result<(), Error> {
         wallet,
         "packages/fuels/tests/test_projects/token_ops"
     );
-    let contract_id = contract_instance._get_contract_id();
+    let contract_id = contract_instance.get_contract_id();
+    let contract_methods = contract_instance.methods();
 
-    let mut balance_response = contract_instance
+    let mut balance_response = contract_methods
         .get_balance(contract_id.into(), contract_id.into())
         .call()
         .await?;
     assert_eq!(balance_response.value, 0);
 
-    contract_instance.mint_coins(5_000_000).call().await?;
+    contract_methods.mint_coins(5_000_000).call().await?;
 
-    balance_response = contract_instance
+    balance_response = contract_methods
         .get_balance(contract_id.into(), contract_id.into())
         .call()
         .await?;
@@ -1447,7 +1451,7 @@ async fn test_amount_and_asset_forwarding() -> Result<(), Error> {
     // this is a big number for checking that amount can be a u64
     let call_params = CallParameters::new(Some(1_000_000), None, None);
 
-    let response = contract_instance
+    let response = contract_methods
         .get_msg_amount()
         .tx_params(tx_params)
         .call_params(call_params)
@@ -1469,7 +1473,7 @@ async fn test_amount_and_asset_forwarding() -> Result<(), Error> {
     let address = wallet.address();
 
     // withdraw some tokens to wallet
-    contract_instance
+    contract_methods
         .transfer_coins_to_output(1_000_000, contract_id.into(), address.into())
         .append_variable_outputs(1)
         .call()
@@ -1479,7 +1483,7 @@ async fn test_amount_and_asset_forwarding() -> Result<(), Error> {
     let call_params = CallParameters::new(Some(0), Some(asset_id), None);
     let tx_params = TxParameters::new(None, Some(1_000_000), None);
 
-    let response = contract_instance
+    let response = contract_methods
         .get_msg_amount()
         .tx_params(tx_params)
         .call_params(call_params)
@@ -1512,15 +1516,16 @@ async fn test_multiple_args() -> Result<(), Error> {
     );
 
     // Make sure we can call the contract with multiple arguments
-    let response = contract_instance.get(5, 6).call().await?;
+    let contract_methods = contract_instance.methods();
+    let response = contract_methods.get(5, 6).call().await?;
 
     assert_eq!(response.value, 5);
 
     let t = MyType { x: 5, y: 6 };
-    let response = contract_instance.get_alt(t.clone()).call().await?;
+    let response = contract_methods.get_alt(t.clone()).call().await?;
     assert_eq!(response.value, t);
 
-    let response = contract_instance.get_single(5).call().await?;
+    let response = contract_methods.get_single(5).call().await?;
     assert_eq!(response.value, 5);
     Ok(())
 }
@@ -1532,9 +1537,10 @@ async fn test_tuples() -> Result<(), Error> {
         wallet,
         "packages/fuels/tests/test_projects/tuples"
     );
+    let contract_methods = contract_instance.methods();
 
     {
-        let response = contract_instance.returns_tuple((1, 2)).call().await?;
+        let response = contract_methods.returns_tuple((1, 2)).call().await?;
 
         assert_eq!(response.value, (1, 2));
     }
@@ -1546,7 +1552,7 @@ async fn test_tuples() -> Result<(), Error> {
                 name: "Jane".try_into()?,
             },
         );
-        let response = contract_instance
+        let response = contract_methods
             .returns_struct_in_tuple(my_struct_tuple.clone())
             .call()
             .await?;
@@ -1557,7 +1563,7 @@ async fn test_tuples() -> Result<(), Error> {
         // Tuple with enum.
         let my_enum_tuple: (u64, State) = (42, State::A());
 
-        let response = contract_instance
+        let response = contract_methods
             .returns_enum_in_tuple(my_enum_tuple.clone())
             .call()
             .await?;
@@ -1568,7 +1574,7 @@ async fn test_tuples() -> Result<(), Error> {
         // Tuple with single element
         let my_enum_tuple = (123u64,);
 
-        let response = contract_instance
+        let response = contract_methods
             .single_element_tuple(my_enum_tuple)
             .call()
             .await?;
@@ -1580,7 +1586,7 @@ async fn test_tuples() -> Result<(), Error> {
         let id = *ContractId::zeroed();
         let my_b256_u8_tuple = (Bits256(id), 10);
 
-        let response = contract_instance
+        let response = contract_methods
             .tuple_with_b256(my_b256_u8_tuple)
             .call()
             .await?;
@@ -1600,7 +1606,12 @@ async fn test_array() -> Result<(), Error> {
     );
 
     assert_eq!(
-        contract_instance.get_array([42; 2]).call().await?.value,
+        contract_instance
+            .methods()
+            .get_array([42; 2])
+            .call()
+            .await?
+            .value,
         [42; 2]
     );
     Ok(())
@@ -1623,14 +1634,15 @@ async fn test_arrays_with_custom_types() -> Result<(), Error> {
         },
     ];
 
-    let response = contract_instance.array_of_structs(persons).call().await?;
+    let contract_methods = contract_instance.methods();
+    let response = contract_methods.array_of_structs(persons).call().await?;
 
     assert_eq!("John", response.value[0].name);
     assert_eq!("Jane", response.value[1].name);
 
     let states = [State::A(), State::B()];
 
-    let response = contract_instance
+    let response = contract_methods
         .array_of_enums(states.clone())
         .call()
         .await?;
@@ -1650,6 +1662,7 @@ async fn test_auth_msg_sender_from_sdk() -> Result<(), Error> {
 
     // Contract returns true if `msg_sender()` matches `wallet.address()`.
     let response = contract_instance
+        .methods()
         .check_msg_sender(wallet.address().into())
         .call()
         .await?;
@@ -1671,7 +1684,8 @@ async fn workflow_enum_inside_struct() -> Result<(), Error> {
         glass: 333,
     };
 
-    let response = contract_instance
+    let contract_methods = contract_instance.methods();
+    let response = contract_methods
         .return_enum_inside_struct(11)
         .call()
         .await?;
@@ -1683,7 +1697,7 @@ async fn workflow_enum_inside_struct() -> Result<(), Error> {
         glass: 555,
     };
 
-    let response = contract_instance
+    let response = contract_methods
         .take_enum_inside_struct(enum_inside_struct)
         .call()
         .await?;
@@ -1708,13 +1722,14 @@ async fn test_logd_receipts() -> Result<(), Error> {
     value[13] = 0xBB;
     value[14] = 0xCC;
 
-    let response = contract_instance
+    let contract_methods = contract_instance.methods();
+    let response = contract_methods
         .use_logd_opcode(Bits256(value), 3, 6)
         .call()
         .await?;
     assert_eq!(response.logs, vec!["ffeedd", "ffeedd000000"]);
 
-    let response = contract_instance
+    let response = contract_methods
         .use_logd_opcode(Bits256(value), 14, 15)
         .call()
         .await?;
@@ -1726,7 +1741,7 @@ async fn test_logd_receipts() -> Result<(), Error> {
         ]
     );
 
-    let response = contract_instance.dont_use_logd().call().await?;
+    let response = contract_methods.dont_use_logd().call().await?;
     assert!(response.logs.is_empty());
     Ok(())
 }
@@ -1809,11 +1824,12 @@ async fn native_types_support() -> Result<(), Box<dyn std::error::Error>> {
         address: Address::zeroed(),
     };
 
-    let response = contract_instance.wrapped_address(user).call().await?;
+    let contract_methods = contract_instance.methods();
+    let response = contract_methods.wrapped_address(user).call().await?;
 
     assert_eq!(response.value.address, Address::zeroed());
 
-    let response = contract_instance
+    let response = contract_methods
         .unwrapped_address(Address::zeroed())
         .call()
         .await?;
@@ -1833,7 +1849,7 @@ async fn test_transaction_script_workflow() -> Result<(), Error> {
         "packages/fuels/tests/test_projects/contract_test"
     );
 
-    let call_handler = contract_instance.initialize_counter(42);
+    let call_handler = contract_instance.methods().initialize_counter(42);
 
     let script = call_handler.get_call_execution_script().await?;
     assert!(script.tx.is_script());
@@ -1862,10 +1878,12 @@ async fn enum_coding_w_variable_width_variants() -> Result<(), Error> {
         arg_3: 7777,
         arg_4: 8888,
     };
-    let actual = contract_instance.get_big_bundle().call().await?.value;
+
+    let contract_methods = contract_instance.methods();
+    let actual = contract_methods.get_big_bundle().call().await?.value;
     assert_eq!(actual, expected);
 
-    let fuelvm_judgement = contract_instance
+    let fuelvm_judgement = contract_methods
         .check_big_bundle_integrity(expected)
         .call()
         .await?
@@ -1892,10 +1910,12 @@ async fn enum_coding_w_unit_enums() -> Result<(), Error> {
         arg_1: UnitEnum::var2(),
         arg_2: u64::MAX,
     };
-    let actual = contract_instance.get_unit_bundle().call().await?.value;
+
+    let contract_methods = contract_instance.methods();
+    let actual = contract_methods.get_unit_bundle().call().await?.value;
     assert_eq!(actual, expected);
 
-    let fuelvm_judgement = contract_instance
+    let fuelvm_judgement = contract_methods
         .check_unit_bundle_integrity(expected)
         .call()
         .await?
@@ -1917,10 +1937,11 @@ async fn enum_as_input() -> Result<(), Error> {
     );
 
     let expected = StandardEnum::Two(12345);
-    let actual = contract_instance.get_standard_enum().call().await?.value;
+    let contract_methods = contract_instance.methods();
+    let actual = contract_methods.get_standard_enum().call().await?.value;
     assert_eq!(expected, actual);
 
-    let fuelvm_judgement = contract_instance
+    let fuelvm_judgement = contract_methods
         .check_standard_enum_integrity(expected)
         .call()
         .await?
@@ -1931,10 +1952,10 @@ async fn enum_as_input() -> Result<(), Error> {
     );
 
     let expected = UnitEnum::Two();
-    let actual = contract_instance.get_unit_enum().call().await?.value;
+    let actual = contract_methods.get_unit_enum().call().await?.value;
     assert_eq!(actual, expected);
 
-    let fuelvm_judgement = contract_instance
+    let fuelvm_judgement = contract_methods
         .check_unit_enum_integrity(expected)
         .call()
         .await?
@@ -1958,10 +1979,11 @@ async fn nested_structs() -> Result<(), Error> {
         some_struct: SomeStruct { par_1: 12345 },
     };
 
-    let actual = contract_instance.get_struct().call().await?.value;
+    let contract_methods = contract_instance.methods();
+    let actual = contract_methods.get_struct().call().await?.value;
     assert_eq!(actual, expected);
 
-    let fuelvm_judgement = contract_instance
+    let fuelvm_judgement = contract_methods
         .check_struct_integrity(expected)
         .call()
         .await?
@@ -1985,7 +2007,7 @@ async fn nested_structs() -> Result<(), Error> {
         amount_of_gas_to_forward: 5,
     };
 
-    let actual = contract_instance
+    let actual = contract_methods
         .nested_struct_with_reserved_keyword_substring(call_data.clone())
         .call()
         .await?
@@ -2003,8 +2025,9 @@ async fn test_multi_call() -> Result<(), Error> {
         "packages/fuels/tests/test_projects/contract_test"
     );
 
-    let call_handler_1 = contract_instance.initialize_counter(42);
-    let call_handler_2 = contract_instance.get_array([42; 2]);
+    let contract_methods = contract_instance.methods();
+    let call_handler_1 = contract_methods.initialize_counter(42);
+    let call_handler_2 = contract_methods.get_array([42; 2]);
 
     let mut multi_call_handler = MultiContractCallHandler::new(wallet.clone());
 
@@ -2027,8 +2050,9 @@ async fn test_multi_call_script_workflow() -> Result<(), Error> {
         "packages/fuels/tests/test_projects/contract_test"
     );
 
-    let call_handler_1 = contract_instance.initialize_counter(42);
-    let call_handler_2 = contract_instance.get_array([42; 2]);
+    let contract_methods = contract_instance.methods();
+    let call_handler_1 = contract_methods.initialize_counter(42);
+    let call_handler_2 = contract_methods.get_array([42; 2]);
 
     let mut multi_call_handler = MultiContractCallHandler::new(wallet.clone());
 
@@ -2075,9 +2099,9 @@ async fn test_storage_initialization() -> Result<(), Error> {
     .await?;
     // ANCHOR_END: manual_storage
 
-    let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
+    let contract_methods = MyContract::new(contract_id.to_string(), wallet.clone()).methods();
 
-    let result = contract_instance
+    let result = contract_methods
         .get_value_b256(Bits256(key.into()))
         .call()
         .await?
@@ -2154,7 +2178,8 @@ async fn type_inside_enum() -> Result<(), Error> {
 
     // String inside enum
     let enum_string = SomeEnum::SomeStr("asdf".try_into()?);
-    let response = contract_instance
+    let contract_methods = contract_instance.methods();
+    let response = contract_methods
         .str_inside_enum(enum_string.clone())
         .call()
         .await?;
@@ -2162,21 +2187,21 @@ async fn type_inside_enum() -> Result<(), Error> {
 
     // Array inside enum
     let enum_array = SomeEnum::SomeArr([1, 2, 3, 4, 5, 6, 7]);
-    let response = contract_instance
+    let response = contract_methods
         .arr_inside_enum(enum_array.clone())
         .call()
         .await?;
     assert_eq!(response.value, enum_array);
 
     // Struct inside enum
-    let response = contract_instance
+    let response = contract_methods
         .return_struct_inside_enum(11)
         .call()
         .await?;
     let expected = Shaker::Cosmopolitan(Recipe { ice: 22, sugar: 99 });
     assert_eq!(response.value, expected);
     let struct_inside_enum = Shaker::Cosmopolitan(Recipe { ice: 22, sugar: 66 });
-    let response = contract_instance
+    let response = contract_methods
         .take_struct_inside_enum(struct_inside_enum)
         .call()
         .await?;
@@ -2184,10 +2209,10 @@ async fn type_inside_enum() -> Result<(), Error> {
 
     // Enum inside enum
     let expected_enum = EnumLevel3::El2(EnumLevel2::El1(EnumLevel1::Num(42)));
-    let response = contract_instance.get_nested_enum().call().await?;
+    let response = contract_methods.get_nested_enum().call().await?;
     assert_eq!(response.value, expected_enum);
 
-    let response = contract_instance
+    let response = contract_methods
         .check_nested_enum_integrity(expected_enum)
         .call()
         .await?;
@@ -2226,16 +2251,16 @@ async fn test_init_storage_automatically() -> Result<(), Error> {
         Bytes32::from_str("f383b0ce51358be57daa3b725fe44acdb2d880604e367199080b4379c41bb6ed")
             .unwrap();
 
-    let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
+    let contract_methods = MyContract::new(contract_id.to_string(), wallet.clone()).methods();
 
-    let value = contract_instance
+    let value = contract_methods
         .get_value_b256(Bits256(*key1))
         .call()
         .await?
         .value;
     assert_eq!(value.0, [1u8; 32]);
 
-    let value = contract_instance
+    let value = contract_methods
         .get_value_u64(Bits256(*key2))
         .call()
         .await?
@@ -2276,7 +2301,9 @@ async fn contract_method_call_respects_maturity() -> Result<(), Error> {
     );
 
     let call_w_maturity = |call_maturity| {
-        let mut prepared_call = contract_instance.calling_this_will_produce_a_block();
+        let mut prepared_call = contract_instance
+            .methods()
+            .calling_this_will_produce_a_block();
         prepared_call.tx_parameters.maturity = call_maturity;
         prepared_call.call()
     };
@@ -2358,7 +2385,7 @@ async fn can_handle_function_called_new() -> anyhow::Result<()> {
         "packages/fuels/tests/test_projects/collision_in_fn_names"
     );
 
-    let response = contract_instance.new().call().await?.value;
+    let response = contract_instance.methods().new().call().await?.value;
 
     assert_eq!(response, 12345);
     Ok(())
@@ -2766,6 +2793,7 @@ async fn test_get_gas_used() -> Result<(), Error> {
     );
 
     let gas_used = contract_instance
+        .methods()
         .initialize_counter(42)
         .call()
         .await?
@@ -2783,8 +2811,8 @@ async fn test_wallet_getter() -> Result<(), Error> {
         "packages/fuels/tests/test_projects/contract_test"
     );
 
-    assert_eq!(contract_instance._get_wallet().address(), wallet.address());
-    //`_get_contract_id()` is tested in
+    assert_eq!(contract_instance.get_wallet().address(), wallet.address());
+    //`get_contract_id()` is tested in
     // async fn test_contract_calling_contract() -> Result<(), Error> {
     Ok(())
 }
@@ -2828,21 +2856,22 @@ async fn str_in_array() -> Result<(), Error> {
     );
 
     let input = ["foo", "bar", "baz"].map(|str| str.try_into().unwrap());
-    let response = contract_instance
+    let contract_methods = contract_instance.methods();
+    let response = contract_methods
         .take_array_string_shuffle(input.clone())
         .call()
         .await?;
 
     assert_eq!(response.value, ["baz", "foo", "bar"]);
 
-    let response = contract_instance
+    let response = contract_methods
         .take_array_string_return_single(input.clone())
         .call()
         .await?;
 
     assert_eq!(response.value, ["foo"]);
 
-    let response = contract_instance
+    let response = contract_methods
         .take_array_string_return_single_element(input)
         .call()
         .await?;
@@ -2896,8 +2925,10 @@ async fn strings_must_have_correct_length() {
     );
 
     let wallet = launch_provider_and_get_wallet().await;
-    let contract_instance = SimpleContractBuilder::new(null_contract_id(), wallet).build();
-    let _ = contract_instance.takes_string("fuell".try_into().unwrap());
+    let contract_instance = SimpleContract::new(null_contract_id(), wallet);
+    let _ = contract_instance
+        .methods()
+        .takes_string("fuell".try_into().unwrap());
 }
 
 #[tokio::test]
@@ -2945,8 +2976,10 @@ async fn strings_must_have_all_ascii_chars() {
     );
 
     let wallet = launch_provider_and_get_wallet().await;
-    let contract_instance = SimpleContractBuilder::new(null_contract_id(), wallet).build();
-    let _ = contract_instance.takes_string("fueŁ".try_into().unwrap());
+    let contract_instance = SimpleContract::new(null_contract_id(), wallet);
+    let _ = contract_instance
+        .methods()
+        .takes_string("fueŁ".try_into().unwrap());
 }
 
 #[tokio::test]
@@ -3029,8 +3062,10 @@ async fn strings_must_have_correct_length_custom_types() {
     );
 
     let wallet = launch_provider_and_get_wallet().await;
-    let contract_instance = SimpleContractBuilder::new(null_contract_id(), wallet).build();
-    let _ = contract_instance.takes_enum(MyEnum::bar("fuell".try_into().unwrap()));
+    let contract_instance = SimpleContract::new(null_contract_id(), wallet);
+    let _ = contract_instance
+        .methods()
+        .takes_enum(MyEnum::bar("fuell".try_into().unwrap()));
 }
 
 #[tokio::test]
@@ -3121,8 +3156,8 @@ async fn strings_must_have_all_ascii_chars_custom_types() {
     };
 
     let wallet = launch_provider_and_get_wallet().await;
-    let contract_instance = SimpleContractBuilder::new(null_contract_id(), wallet).build();
-    let _ = contract_instance.takes_nested_struct(input);
+    let contract_instance = SimpleContract::new(null_contract_id(), wallet);
+    let _ = contract_instance.methods().takes_nested_struct(input);
 }
 
 #[tokio::test]
@@ -3147,9 +3182,10 @@ async fn test_connect_wallet() -> anyhow::Result<()> {
     .await?;
 
     // pay for call with wallet_1
-    let contract_instance = MyContractBuilder::new(id.to_string(), wallet_1.clone()).build();
+    let contract_instance = MyContract::new(id.to_string(), wallet_1.clone());
     let tx_params = TxParameters::new(Some(10), Some(10000), None);
     contract_instance
+        .methods()
         .initialize_counter(42)
         .tx_params(tx_params)
         .call()
@@ -3161,7 +3197,8 @@ async fn test_connect_wallet() -> anyhow::Result<()> {
 
     // pay for call with wallet_2
     contract_instance
-        ._with_wallet(wallet_2.clone())?
+        .with_wallet(wallet_2.clone())?
+        .methods()
         .initialize_counter(42)
         .tx_params(tx_params)
         .call()
@@ -3193,6 +3230,7 @@ async fn contract_call_fee_estimation() -> Result<(), Error> {
     let expected_total_fee = 359;
 
     let estimated_transaction_cost = contract_instance
+        .methods()
         .initialize_counter(42) // Build the ABI call
         .tx_params(TxParameters::new(Some(gas_price), Some(gas_limit), None))
         .estimate_transaction_cost(Some(tolerance)) // Perform the network call
@@ -3221,13 +3259,14 @@ async fn contract_call_has_same_estimated_and_used_gas() -> Result<(), Error> {
     );
 
     let tolerance = 0.0;
-    let estimated_gas_used = contract_instance
+    let contract_methods = contract_instance.methods();
+    let estimated_gas_used = contract_methods
         .initialize_counter(42) // Build the ABI call
         .estimate_transaction_cost(Some(tolerance)) // Perform the network call
         .await?
         .gas_used;
 
-    let gas_used = contract_instance
+    let gas_used = contract_methods
         .initialize_counter(42) // Build the ABI call
         .call() // Perform the network call
         .await?
@@ -3245,8 +3284,9 @@ async fn mutl_call_has_same_estimated_and_used_gas() -> Result<(), Error> {
         "packages/fuels/tests/test_projects/contract_test"
     );
 
-    let call_handler_1 = contract_instance.initialize_counter(42);
-    let call_handler_2 = contract_instance.get_array([42; 2]);
+    let contract_methods = contract_instance.methods();
+    let call_handler_1 = contract_methods.initialize_counter(42);
+    let call_handler_2 = contract_methods.get_array([42; 2]);
 
     let mut multi_call_handler = MultiContractCallHandler::new(wallet.clone());
 
@@ -3303,9 +3343,9 @@ async fn testnet_hello_world() -> Result<(), Error> {
     )
     .await?;
 
-    let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
+    let contract_methods = MyContract::new(contract_id.to_string(), wallet.clone()).methods();
 
-    let response = contract_instance
+    let response = contract_methods
         .initialize_counter(42) // Build the ABI call
         .tx_params(params)
         .call() // Perform the network call
@@ -3313,7 +3353,7 @@ async fn testnet_hello_world() -> Result<(), Error> {
 
     assert_eq!(42, response.value);
 
-    let response = contract_instance
+    let response = contract_methods
         .increment_counter(10)
         .tx_params(params)
         .call()
@@ -3366,7 +3406,7 @@ async fn test_input_message() -> Result<(), Error> {
     .await?;
 
     let contract_instance_connected =
-        MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
+        MyContract::new(contract_id.to_string(), wallet.clone()).methods();
 
     let messages_from_provider = wallet.get_messages().await?;
     assert!(compare_messages(messages_from_provider, messages));
@@ -3388,6 +3428,7 @@ async fn generics_test() -> anyhow::Result<()> {
         wallet,
         "packages/fuels/tests/test_projects/generics"
     );
+    let contract_methods = contract_instance.methods();
 
     {
         // ANCHOR: generic
@@ -3396,7 +3437,7 @@ async fn generics_test() -> anyhow::Result<()> {
             single_generic_param: 123u64,
         };
 
-        let result = contract_instance
+        let result = contract_methods
             .struct_w_generic(arg1.clone())
             .call()
             .await?
@@ -3413,7 +3454,7 @@ async fn generics_test() -> anyhow::Result<()> {
             },
         };
 
-        let result = contract_instance
+        let result = contract_methods
             .struct_delegating_generic(arg1.clone())
             .call()
             .await?
@@ -3425,7 +3466,7 @@ async fn generics_test() -> anyhow::Result<()> {
         // struct that has the generic in an array
         let arg1 = StructWArrayGeneric { a: [1u32, 2u32] };
 
-        let result = contract_instance
+        let result = contract_methods
             .struct_w_generic_in_array(arg1.clone())
             .call()
             .await?
@@ -3437,7 +3478,7 @@ async fn generics_test() -> anyhow::Result<()> {
         // struct that has the generic in a tuple
         let arg1 = StructWTupleGeneric { a: (1, 2) };
 
-        let result = contract_instance
+        let result = contract_methods
             .struct_w_generic_in_tuple(arg1.clone())
             .call()
             .await?
@@ -3448,7 +3489,7 @@ async fn generics_test() -> anyhow::Result<()> {
     {
         // struct with generic in variant
         let arg1 = EnumWGeneric::b(10);
-        let result = contract_instance
+        let result = contract_methods
             .enum_w_generic(arg1.clone())
             .call()
             .await?
@@ -3477,7 +3518,7 @@ async fn generics_test() -> anyhow::Result<()> {
             ),
         };
 
-        let result = contract_instance
+        let result = contract_methods
             .complex_test(arg1.clone())
             .call()
             .await?
@@ -3499,6 +3540,7 @@ async fn test_gas_forwarded_defaults_to_tx_limit() -> Result<(), Error> {
 
     let gas_limit = 225883;
     let response = contract_instance
+        .methods()
         .initialize_counter(42)
         .tx_params(TxParameters::new(None, Some(gas_limit), None))
         .call()
@@ -3519,22 +3561,12 @@ async fn test_gas_forwarded_defaults_to_tx_limit() -> Result<(), Error> {
 
 #[tokio::test]
 async fn test_rust_option_can_be_decoded() -> Result<(), Box<dyn std::error::Error>> {
-    abigen!(
-        MyContract,
-        "packages/fuels/tests/test_projects/options/out/debug/options-abi.json"
+    setup_contract_test!(
+        contract_instance,
+        wallet,
+        "packages/fuels/tests/test_projects/options"
     );
-
-    let wallet = launch_provider_and_get_wallet().await;
-
-    let contract_id = Contract::deploy(
-        "tests/test_projects/options/out/debug/options.bin",
-        &wallet,
-        TxParameters::default(),
-        StorageConfiguration::default(),
-    )
-    .await?;
-
-    let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
+    let contract_methods = contract_instance.methods();
 
     let expected_address =
         Address::from_str("0xd58573593432a30a800f97ad32f877425c223a9e427ab557aab5d5bb89156db0")?;
@@ -3546,26 +3578,26 @@ async fn test_rust_option_can_be_decoded() -> Result<(), Box<dyn std::error::Err
     let e = TestEnum::EnumOption(Some(expected_address));
 
     let expected_some_address = Some(expected_address);
-    let response = contract_instance.get_some_address().call().await?;
+    let response = contract_methods.get_some_address().call().await?;
 
     assert_eq!(response.value, expected_some_address);
 
     let expected_some_u64 = Some(10);
-    let response = contract_instance.get_some_u64().call().await?;
+    let response = contract_methods.get_some_u64().call().await?;
 
     assert_eq!(response.value, expected_some_u64);
 
-    let response = contract_instance.get_some_struct().call().await?;
+    let response = contract_methods.get_some_struct().call().await?;
     assert_eq!(response.value, Some(s.clone()));
 
-    let response = contract_instance.get_some_enum().call().await?;
+    let response = contract_methods.get_some_enum().call().await?;
     assert_eq!(response.value, Some(e.clone()));
 
-    let response = contract_instance.get_some_tuple().call().await?;
+    let response = contract_methods.get_some_tuple().call().await?;
     assert_eq!(response.value, Some((s.clone(), e.clone())));
 
     let expected_none = None;
-    let response = contract_instance.get_none().call().await?;
+    let response = contract_methods.get_none().call().await?;
 
     assert_eq!(response.value, expected_none);
 
@@ -3574,20 +3606,12 @@ async fn test_rust_option_can_be_decoded() -> Result<(), Box<dyn std::error::Err
 
 #[tokio::test]
 async fn test_rust_option_can_be_encoded() -> Result<(), Box<dyn std::error::Error>> {
-    abigen!(
-        MyContract,
-        "packages/fuels/tests/test_projects/options/out/debug/options-abi.json"
+    setup_contract_test!(
+        contract_instance,
+        wallet,
+        "packages/fuels/tests/test_projects/options"
     );
-
-    let wallet = launch_provider_and_get_wallet().await;
-
-    let contract_id = Contract::deploy(
-        "tests/test_projects/options/out/debug/options.bin",
-        &wallet,
-        TxParameters::default(),
-        StorageConfiguration::default(),
-    )
-    .await?;
+    let contract_methods = contract_instance.methods();
 
     let expected_address =
         Address::from_str("0xd58573593432a30a800f97ad32f877425c223a9e427ab557aab5d5bb89156db0")?;
@@ -3598,9 +3622,8 @@ async fn test_rust_option_can_be_encoded() -> Result<(), Box<dyn std::error::Err
 
     let e = TestEnum::EnumOption(Some(expected_address));
 
-    let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
     let expected_u64 = Some(36);
-    let response = contract_instance
+    let response = contract_methods
         .input_primitive(expected_u64)
         .call()
         .await?;
@@ -3608,7 +3631,7 @@ async fn test_rust_option_can_be_encoded() -> Result<(), Box<dyn std::error::Err
     assert!(response.value);
 
     let expected_struct = Some(s);
-    let response = contract_instance
+    let response = contract_methods
         .input_struct(expected_struct)
         .call()
         .await?;
@@ -3616,12 +3639,12 @@ async fn test_rust_option_can_be_encoded() -> Result<(), Box<dyn std::error::Err
     assert!(response.value);
 
     let expected_enum = Some(e);
-    let response = contract_instance.input_enum(expected_enum).call().await?;
+    let response = contract_methods.input_enum(expected_enum).call().await?;
 
     assert!(response.value);
 
     let expected_none = None;
-    let response = contract_instance.input_none(expected_none).call().await?;
+    let response = contract_methods.input_none(expected_none).call().await?;
 
     assert!(response.value);
 
@@ -3630,22 +3653,12 @@ async fn test_rust_option_can_be_encoded() -> Result<(), Box<dyn std::error::Err
 
 #[tokio::test]
 async fn test_rust_result_can_be_decoded() -> Result<(), Box<dyn std::error::Error>> {
-    abigen!(
-        MyContract,
-        "packages/fuels/tests/test_projects/results/out/debug/results-abi.json"
+    setup_contract_test!(
+        contract_instance,
+        wallet,
+        "packages/fuels/tests/test_projects/results"
     );
-
-    let wallet = launch_provider_and_get_wallet().await;
-
-    let contract_id = Contract::deploy(
-        "tests/test_projects/results/out/debug/results.bin",
-        &wallet,
-        TxParameters::default(),
-        StorageConfiguration::default(),
-    )
-    .await?;
-
-    let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
+    let contract_methods = contract_instance.methods();
 
     let expected_address =
         Address::from_str("0xd58573593432a30a800f97ad32f877425c223a9e427ab557aab5d5bb89156db0")?;
@@ -3657,26 +3670,26 @@ async fn test_rust_result_can_be_decoded() -> Result<(), Box<dyn std::error::Err
     let e = TestEnum::EnumOption(Some(expected_address));
 
     let expected_ok_address = Ok(expected_address);
-    let response = contract_instance.get_ok_address().call().await?;
+    let response = contract_methods.get_ok_address().call().await?;
 
     assert_eq!(response.value, expected_ok_address);
 
     let expected_some_u64 = Ok(10);
-    let response = contract_instance.get_ok_u64().call().await?;
+    let response = contract_methods.get_ok_u64().call().await?;
 
     assert_eq!(response.value, expected_some_u64);
 
-    let response = contract_instance.get_ok_struct().call().await?;
+    let response = contract_methods.get_ok_struct().call().await?;
     assert_eq!(response.value, Ok(s.clone()));
 
-    let response = contract_instance.get_ok_enum().call().await?;
+    let response = contract_methods.get_ok_enum().call().await?;
     assert_eq!(response.value, Ok(e.clone()));
 
-    let response = contract_instance.get_ok_tuple().call().await?;
+    let response = contract_methods.get_ok_tuple().call().await?;
     assert_eq!(response.value, Ok((s, e)));
 
     let expected_error = Err(TestError::NoAddress("error".try_into().unwrap()));
-    let response = contract_instance.get_error().call().await?;
+    let response = contract_methods.get_error().call().await?;
 
     assert_eq!(response.value, expected_error);
 
@@ -3685,28 +3698,18 @@ async fn test_rust_result_can_be_decoded() -> Result<(), Box<dyn std::error::Err
 
 #[tokio::test]
 async fn test_rust_result_can_be_encoded() -> Result<(), Box<dyn std::error::Error>> {
-    abigen!(
-        MyContract,
-        "packages/fuels/tests/test_projects/results/out/debug/results-abi.json"
+    setup_contract_test!(
+        contract_instance,
+        wallet,
+        "packages/fuels/tests/test_projects/results"
     );
-
-    let wallet = launch_provider_and_get_wallet().await;
-
-    let contract_id = Contract::deploy(
-        "tests/test_projects/results/out/debug/results.bin",
-        &wallet,
-        TxParameters::default(),
-        StorageConfiguration::default(),
-    )
-    .await?;
-
-    let contract_instance = MyContractBuilder::new(contract_id.to_string(), wallet.clone()).build();
+    let contract_methods = contract_instance.methods();
 
     let expected_address =
         Address::from_str("0xd58573593432a30a800f97ad32f877425c223a9e427ab557aab5d5bb89156db0")?;
 
     let expected_ok_address = Ok(expected_address);
-    let response = contract_instance
+    let response = contract_methods
         .input_ok(expected_ok_address)
         .call()
         .await?;
@@ -3714,7 +3717,7 @@ async fn test_rust_result_can_be_encoded() -> Result<(), Box<dyn std::error::Err
     assert!(response.value);
 
     let expected_error = Err(TestError::NoAddress("error".try_into().unwrap()));
-    let response = contract_instance.input_error(expected_error).call().await?;
+    let response = contract_methods.input_error(expected_error).call().await?;
 
     assert!(response.value);
 


### PR DESCRIPTION
closes: https://github.com/FuelLabs/fuels-rs/issues/515

- removed the `Builder` pattern from abigen
- added a new struct that holds the contract methods which is built by the `contract instance`

Now the workflow looks like this:
```rust
    abigen!(
        SimpleContract,
        "packages/fuels/tests/takes_ints_returns_bool-abi.json",
    );

    let wallet = launch_provider_and_get_wallet().await;

    // `SimpleContract` is the name of the contract
    let contract_instance = SimpleContract::new(null_contract_id(), wallet);

    let call_handler = contract_instance.methods().takes_ints_returns_bool(42);
```
In the tests where we have multiple contract calls, I have saved the methods in a new variable and called the methods directly. For example:

```rust
    let contract_methods = SimpleContract::new(null_contract_id(), wallet).methods();

    let call_handler = contract_methods.takes_nested_struct(nested_struct_from_tokens);
```