### PR TITLE
feat: add Identity as native type

### DIFF
--- a/packages/fuels-core/src/code_gen/abigen.rs
+++ b/packages/fuels-core/src/code_gen/abigen.rs
@@ -81,7 +81,7 @@ impl Abigen {
             (
                 quote! {
                     use alloc::{vec, vec::Vec};
-                    use fuels_core::{EnumSelector, Parameterize, Tokenizable, Token, try_from_bytes};
+                    use fuels_core::{EnumSelector, Parameterize, Tokenizable, Token, Identity, try_from_bytes};
                     use fuels_core::types::*;
                     use fuels_core::code_gen::function_selector::resolve_fn_selector;
                     use fuels_types::errors::Error as SDKError;
@@ -93,7 +93,8 @@ impl Abigen {
             (
                 quote! {
                     use fuels::contract::contract::{Contract, ContractCallHandler};
-                    use fuels::core::{EnumSelector, StringToken, Parameterize, Tokenizable, Token, try_from_bytes};
+                    use fuels::core::{EnumSelector, StringToken, Parameterize, Tokenizable, Token,
+                                      Identity, try_from_bytes};
                     use fuels::core::code_gen::function_selector::resolve_fn_selector;
                     use fuels::core::types::*;
                     use fuels::signers::WalletUnlocked;
@@ -215,6 +216,7 @@ impl Abigen {
     pub fn is_native_type(type_field: &str) -> bool {
         const CONTRACT_ID_NATIVE_TYPE: &str = "ContractId";
         const ADDRESS_NATIVE_TYPE: &str = "Address";
+        const IDENTITY_NATIVE_TYPE: &str = "Identity";
         const OPTION_NATIVE_TYPE: &str = "Option";
         const RESULT_NATIVE_TYPE: &str = "Result";
 
@@ -226,6 +228,7 @@ impl Abigen {
 
         split[1] == CONTRACT_ID_NATIVE_TYPE
             || split[1] == ADDRESS_NATIVE_TYPE
+            || split[1] == IDENTITY_NATIVE_TYPE
             || split[1] == OPTION_NATIVE_TYPE
             || split[1] == RESULT_NATIVE_TYPE
     }
@@ -237,7 +240,7 @@ impl Abigen {
         let mut seen_enum: Vec<&str> = vec![];
 
         for prop in &self.abi.types {
-            if !prop.is_enum_type() || prop.is_option() || prop.is_result() {
+            if !prop.is_enum_type() || prop.is_option() || prop.is_result() || prop.is_identity() {
                 continue;
             }
 

--- a/packages/fuels-core/src/lib.rs
+++ b/packages/fuels-core/src/lib.rs
@@ -28,6 +28,12 @@ pub type ByteArray = [u8; 8];
 pub type Selector = ByteArray;
 pub type EnumSelector = (u8, Token, EnumVariants);
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Identity {
+    Address(fuel_tx::Address),
+    ContractId(fuel_tx::ContractId),
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct StringToken {
     data: String,

--- a/packages/fuels-core/src/utils.rs
+++ b/packages/fuels-core/src/utils.rs
@@ -12,7 +12,7 @@ pub fn first_four_bytes_of_sha256_hash(string: &str) -> ByteArray {
     hasher.update(string_as_bytes);
     let result = hasher.finalize();
     let mut output = ByteArray::default();
-    (&mut output[4..]).copy_from_slice(&result[..4]);
+    output[4..].copy_from_slice(&result[..4]);
     output
 }
 

--- a/packages/fuels-types/src/lib.rs
+++ b/packages/fuels-types/src/lib.rs
@@ -79,4 +79,9 @@ impl TypeDeclaration {
         const RESULT_KEYWORD: &str = " Result";
         self.type_field.ends_with(RESULT_KEYWORD)
     }
+
+    pub fn is_identity(&self) -> bool {
+        const IDENTITY_KEYWORD: &str = " Identity";
+        self.type_field.ends_with(IDENTITY_KEYWORD)
+    }
 }

--- a/packages/fuels/src/lib.rs
+++ b/packages/fuels/src/lib.rs
@@ -63,10 +63,12 @@ pub mod prelude {
     //! ```
 
     pub use super::contract::contract::{Contract, MultiContractCallHandler};
+    pub use super::contract::predicate::Predicate;
     pub use super::core::constants::*;
     pub use super::core::parameters::*;
     pub use super::core::tx::{Address, AssetId, ContractId};
     pub use super::core::types::*;
+    pub use super::core::Identity;
     pub use super::core::{Token, Tokenizable};
     pub use super::fuel_node::*;
     pub use super::fuels_abigen::{abigen, setup_contract_test};

--- a/packages/fuels/tests/test_projects/identity/Forc.toml
+++ b/packages/fuels/tests/test_projects/identity/Forc.toml
@@ -1,0 +1,7 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "identity"
+
+[dependencies]

--- a/packages/fuels/tests/test_projects/identity/src/main.sw
+++ b/packages/fuels/tests/test_projects/identity/src/main.sw
@@ -1,0 +1,76 @@
+contract;
+
+use std::{
+    address::Address,
+    contract_id::ContractId,
+    identity::Identity,
+};
+
+struct TestStruct {
+    identity: Identity
+}
+
+enum TestEnum {
+    EnumIdentity: Identity
+}
+
+const ADDR = 0xd58573593432a30a800f97ad32f877425c223a9e427ab557aab5d5bb89156db0;
+
+abi MyContract {
+    fn get_identity_address() -> Identity;
+    fn get_identity_contract_id() -> Identity;
+    fn get_struct_with_identity() -> TestStruct;
+    fn get_enum_with_identity() -> TestEnum;
+    fn get_identity_tuple() -> (TestStruct, TestEnum);
+    fn input_identity(i: Identity) -> bool;
+    fn input_struct_with_identity(s: TestStruct) -> bool;
+    fn input_enum_with_identity(s: TestEnum) -> bool;
+}
+
+impl MyContract for Contract {
+    fn get_identity_address() -> Identity {
+        Identity::Address(~Address::from(ADDR))
+    }
+
+    fn get_identity_contract_id() -> Identity {
+        Identity::ContractId(~ContractId::from(ADDR))
+    }
+
+    fn get_struct_with_identity() -> TestStruct {
+        TestStruct{identity: Identity::Address(~Address::from(ADDR))}
+    }
+
+    fn get_enum_with_identity() -> TestEnum {
+        TestEnum::EnumIdentity(Identity::ContractId(~ContractId::from(ADDR)))
+    }
+
+    fn get_identity_tuple() -> (TestStruct, TestEnum) {
+        let s = TestStruct{identity: Identity::Address(~Address::from(ADDR))};
+        let e = TestEnum::EnumIdentity(Identity::ContractId(~ContractId::from(ADDR)));
+        (s,e)
+    }
+
+
+    fn input_identity(input: Identity) -> bool{
+        if let Identity::Address(a) = input {
+            return a == ~Address::from(ADDR);
+        }
+        false
+    }
+
+    fn input_struct_with_identity(input: TestStruct) -> bool {
+        if let Identity::Address(a) = input.identity {
+            return a == ~Address::from(ADDR);
+        }
+        false
+    }
+
+    fn input_enum_with_identity(input: TestEnum) -> bool {
+        if let TestEnum::EnumIdentity(identity) = input {
+            if let Identity::ContractId(c) = identity {
+                return c == ~ContractId::from(ADDR);
+            }
+        }
+        false
+    }
+}


### PR DESCRIPTION
Using `Identity` in two deployed contracts would result in naming collision as both contract would make their own `Identity` enum. 

This PR fixes that by treating `Identity` as a native type.

- Updated abigen to use native `Identity`
- Added test for different `Identity` use-cases