### PR TITLE
Fix: change transfer_to_output to transfer_to_address

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   RUSTFLAGS: "-D warnings"
   FUEL_CORE_VERSION: 0.10.1
   RUST_VERSION: 1.61.0
-  FORC_VERSION: 0.24.5
+  FORC_VERSION: 0.25.0
 
 jobs:
   setup-test-projects:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   RUSTFLAGS: "-D warnings"
   FUEL_CORE_VERSION: 0.10.1
   RUST_VERSION: 1.61.0
-  FORC_VERSION: 0.25.0
+  FORC_VERSION: 0.25.2
 
 jobs:
   setup-test-projects:

--- a/docs/src/calling-contracts/variable-outputs.md
+++ b/docs/src/calling-contracts/variable-outputs.md
@@ -1,6 +1,6 @@
 # Variable outputs
 
-In some cases, you might want to send funds to the output of a transaction. Sway has a specific method for that: `transfer_to_output`(coins, asset_id, recipient)`. So, if you have a contract that does something like this:
+In some cases, you might want to send funds to the output of a transaction. Sway has a specific method for that: `transfer_to_address`(coins, asset_id, recipient)`. So, if you have a contract that does something like this:
 
 ```rust,ignore
 {{#include ../../../packages/fuels/tests/test_projects/token_ops/src/main.sw:variable_outputs}}
@@ -14,4 +14,4 @@ With the SDK, you can call `transfer_coins_to_output` by chaining `append_variab
 
 `append_variable_outputs` effectively appends a given amount of `Output::Variable`s to the transaction's list of outputs. This output type indicates that the output's amount and the owner may vary based on transaction execution.
 
-Note that the Sway `lib-std` function `mint_to_address` calls `transfer_to_output` under the hood, so you need to call `append_variable_outputs` in the Rust SDK tests like you would for `transfer_to_output`.
+Note that the Sway `lib-std` function `mint_to_address` calls `transfer_to_address` under the hood, so you need to call `append_variable_outputs` in the Rust SDK tests like you would for `transfer_to_address`.

--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -540,7 +540,7 @@ mod tests {
             .await?;
         // ANCHOR_END: multi_call_cost_estimation
 
-        assert_eq!(transaction_cost.gas_used, 1012);
+        assert_eq!(transaction_cost.gas_used, 1006);
 
         Ok(())
     }

--- a/packages/fuels/tests/test_projects/liquidity_pool/src/main.sw
+++ b/packages/fuels/tests/test_projects/liquidity_pool/src/main.sw
@@ -6,7 +6,7 @@ use std::{
     context::call_frames::{contract_id, msg_asset_id},
     context::msg_amount,
     contract_id::ContractId,
-    token::{mint_to_address, transfer_to_output}
+    token::{mint_to_address, transfer_to_address}
 };
 
 abi LiquidityPool {
@@ -36,6 +36,6 @@ impl LiquidityPool for Contract {
         let amount_to_transfer = msg_amount() / 2;
 
         // Transfer base token to recipient.
-        transfer_to_output(amount_to_transfer, ~ContractId::from(BASE_TOKEN), recipient);
+        transfer_to_address(amount_to_transfer, ~ContractId::from(BASE_TOKEN), recipient);
     }
 }

--- a/packages/fuels/tests/test_projects/token_ops/src/main.sw
+++ b/packages/fuels/tests/test_projects/token_ops/src/main.sw
@@ -26,7 +26,7 @@ impl TestFuelCoin for Contract {
 
     // ANCHOR: variable_outputs
     fn transfer_coins_to_output(coins: u64, asset_id: ContractId, recipient: Address) {
-        transfer_to_output(coins, asset_id, recipient);
+        transfer_to_address(coins, asset_id, recipient);
     }
     // ANCHOR_END: variable_outputs
 


### PR DESCRIPTION
`forc` `0.25` changed `transfer_to_output` (the Sway function) to `transfer_to_address`. This PR makes this change in our test contracts and documentation.