### PR TITLE
Test logging generics

### DIFF
--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -540,7 +540,7 @@ mod tests {
             .await?;
         // ANCHOR_END: multi_call_cost_estimation
 
-        assert_eq!(transaction_cost.gas_used, 1012);
+        assert_eq!(transaction_cost.gas_used, 1006);
 
         Ok(())
     }

--- a/packages/fuels/tests/harness.rs
+++ b/packages/fuels/tests/harness.rs
@@ -3786,6 +3786,53 @@ async fn test_parse_logs_custom_types() -> Result<(), Error> {
 }
 
 #[tokio::test]
+async fn test_parse_logs_generic_types() -> Result<(), Error> {
+    setup_contract_test!(
+        contract_instance,
+        wallet,
+        "packages/fuels/tests/test_projects/logged_types"
+    );
+
+    let contract_methods = contract_instance.methods();
+    let response = contract_methods.produce_logs_generic_types().call().await?;
+
+    let log_struct =
+        contract_instance.logs_with_type::<StructWithGeneric<[_; 3]>>(&response.receipts)?;
+    let log_enum =
+        contract_instance.logs_with_type::<EnumWithGeneric<[_; 3]>>(&response.receipts)?;
+    let log_struct_nested = contract_instance
+        .logs_with_type::<StructWithNestedGeneric<StructWithGeneric<[_; 3]>>>(&response.receipts)?;
+    let log_struct_deeply_nested = contract_instance.logs_with_type::<StructDeeplyNestedGeneric<
+        StructWithNestedGeneric<StructWithGeneric<[_; 3]>>,
+    >>(&response.receipts)?;
+
+    let l = [1u8, 2u8, 3u8];
+    let expected_struct = StructWithGeneric {
+        field_1: l,
+        field_2: 64,
+    };
+    let expected_enum = EnumWithGeneric::VariantOne(l);
+    let expected_nested_struct = StructWithNestedGeneric {
+        field_1: expected_struct.clone(),
+        field_2: 64,
+    };
+    let expected_deeply_nested_struct = StructDeeplyNestedGeneric {
+        field_1: expected_nested_struct.clone(),
+        field_2: 64,
+    };
+
+    assert_eq!(log_struct, vec![expected_struct]);
+    assert_eq!(log_enum, vec![expected_enum]);
+    assert_eq!(log_struct_nested, vec![expected_nested_struct]);
+    assert_eq!(
+        log_struct_deeply_nested,
+        vec![expected_deeply_nested_struct]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_fetch_logs() -> Result<(), Error> {
     setup_contract_test!(
         contract_instance,

--- a/packages/fuels/tests/harness.rs
+++ b/packages/fuels/tests/harness.rs
@@ -3856,6 +3856,10 @@ async fn test_fetch_logs() -> Result<(), Error> {
         field_3: 64,
     };
     let expected_enum = TestEnum::VariantTwo();
+    let expected_generic_struct = StructWithGeneric {
+        field_1: expected_struct.clone(),
+        field_2: 64,
+    };
     let expected_logs: Vec<String> = vec![
         format!("{:#?}", 64u64),
         format!("{:#?}", 32u32),
@@ -3867,6 +3871,7 @@ async fn test_fetch_logs() -> Result<(), Error> {
         format!("{:#?}", [1, 2, 3]),
         format!("{:#?}", expected_struct),
         format!("{:#?}", expected_enum),
+        format!("{:#?}", expected_generic_struct),
     ];
 
     assert_eq!(logs, expected_logs);

--- a/packages/fuels/tests/test_projects/logged_types/src/main.sw
+++ b/packages/fuels/tests/test_projects/logged_types/src/main.sw
@@ -115,6 +115,10 @@ impl TestContract for Contract {
             field_3: f,
         };
         let test_enum = TestEnum::VariantTwo;
+        let test_generic_struct = StructWithGeneric {
+            field_1: test_struct,
+            field_2: 64,
+        };
 
         __log(64);
         __log(32u32);
@@ -126,5 +130,6 @@ impl TestContract for Contract {
         __log(l);
         __log(test_struct);
         __log(test_enum);
+        __log(test_generic_struct);
     }
 }

--- a/packages/fuels/tests/test_projects/logged_types/src/main.sw
+++ b/packages/fuels/tests/test_projects/logged_types/src/main.sw
@@ -16,10 +16,31 @@ enum TestEnum {
     VariantTwo: (),
 }
 
+struct StructWithGeneric<D> {
+    field_1: D,
+    field_2: u64,
+}
+
+enum EnumWithGeneric<D> {
+    VariantOne: (D),
+    VariantTwo: (),
+}
+
+struct StructWithNestedGeneric<D> {
+    field_1: D,
+    field_2: u64,
+}
+
+struct StructDeeplyNestedGeneric<D> {
+    field_1: D,
+    field_2: u64,
+}
+
 abi TestContract {
     fn produce_logs_values() -> ();
     fn produce_logs_variables() -> ();
     fn produce_logs_custom_types() -> ();
+    fn produce_logs_generic_types() -> ();
     fn produce_multiple_logs() -> ();
 }
 
@@ -58,6 +79,29 @@ impl TestContract for Contract {
 
         __log(test_struct);
         __log(test_enum);
+    }
+
+    fn produce_logs_generic_types() -> () {
+        let l: [u8; 3] = [1u8, 2u8, 3u8];
+
+        let test_struct = StructWithGeneric {
+            field_1: l,
+            field_2: 64,
+        };
+        let test_enum = EnumWithGeneric::VariantOne(l);
+        let test_struct_nested = StructWithNestedGeneric {
+            field_1: test_struct,
+            field_2: 64,
+        };
+        let test_deeply_nested_generic = StructDeeplyNestedGeneric {
+            field_1: test_struct_nested,
+            field_2: 64
+        };
+
+        __log(test_struct);
+        __log(test_enum);
+        __log(test_struct_nested);
+        __log(test_deeply_nested_generic);
     }
 
     fn produce_multiple_logs() -> () {

--- a/packages/fuels/tests/test_projects/logged_types/src/main.sw
+++ b/packages/fuels/tests/test_projects/logged_types/src/main.sw
@@ -94,10 +94,10 @@ impl TestContract for Contract {
             field_2: 64
         };
 
-        __log(test_struct);
-        __log(test_enum);
-        __log(test_struct_nested);
-        __log(test_deeply_nested_generic);
+        log(test_struct);
+        log(test_enum);
+        log(test_struct_nested);
+        log(test_deeply_nested_generic);
     }
 
     fn produce_multiple_logs() -> () {
@@ -116,16 +116,16 @@ impl TestContract for Contract {
             field_2: 64,
         };
 
-        __log(64);
-        __log(32u32);
-        __log(16u16);
-        __log(8u8);
-        __log(f);
-        __log(u);
-        __log(e);
-        __log(l);
-        __log(test_struct);
-        __log(test_enum);
-        __log(test_generic_struct);
+        log(64);
+        log(32u32);
+        log(16u16);
+        log(8u8);
+        log(f);
+        log(u);
+        log(e);
+        log(l);
+        log(test_struct);
+        log(test_enum);
+        log(test_generic_struct);
     }
 }


### PR DESCRIPTION
Closes #603

Logging types with generics seems to work just fine, no further changes to the implementation were needed.

This PR just adds a new test case that calls `logs_with_type` on  generics with up to 3 levels of nesting.  It also extends the `fetch_logs` test with a generic type. 