### PR TITLE
Some minor cosmetic updates to the SDK Sway tests

### DIFF
--- a/packages/fuels/tests/test_projects/auth_testing_abi/Forc.toml
+++ b/packages/fuels/tests/test_projects/auth_testing_abi/Forc.toml
@@ -5,4 +5,3 @@ license = "Apache-2.0"
 name = "auth_testing_abi"
 
 [dependencies]
-

--- a/packages/fuels/tests/test_projects/auth_testing_abi/src/main.sw
+++ b/packages/fuels/tests/test_projects/auth_testing_abi/src/main.sw
@@ -1,10 +1,5 @@
 library auth_testing_abi;
 
-use std::address::Address;
-use std::contract_id::ContractId;
-use std::chain::auth::*;
-use std::result::*;
-
 abi AuthTesting {
     fn is_caller_external() -> bool;
     fn check_msg_sender(expected_id: Address) -> bool;

--- a/packages/fuels/tests/test_projects/auth_testing_contract/Forc.toml
+++ b/packages/fuels/tests/test_projects/auth_testing_contract/Forc.toml
@@ -5,4 +5,4 @@ license = "Apache-2.0"
 name = "auth_testing_contract"
 
 [dependencies]
-auth_testing_abi = { path = "../auth_testing_abi"}
+auth_testing_abi = { path = "../auth_testing_abi" }

--- a/packages/fuels/tests/test_projects/auth_testing_contract/src/main.sw
+++ b/packages/fuels/tests/test_projects/auth_testing_contract/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::chain::auth::AuthError;
+use std::chain::auth::{AuthError, caller_is_external, msg_sender};
 use auth_testing_abi::*;
 
 impl AuthTesting for Contract {

--- a/packages/fuels/tests/test_projects/auth_testing_contract/src/main.sw
+++ b/packages/fuels/tests/test_projects/auth_testing_contract/src/main.sw
@@ -1,12 +1,7 @@
 contract;
 
-use std::address::Address;
-use std::chain::auth::*;
-use std::contract_id::ContractId;
+use std::chain::auth::AuthError;
 use auth_testing_abi::*;
-use std::result::*;
-use std::assert::assert;
-use std::identity::Identity;
 
 impl AuthTesting for Contract {
     fn is_caller_external() -> bool {

--- a/packages/fuels/tests/test_projects/call_empty_return/Forc.toml
+++ b/packages/fuels/tests/test_projects/call_empty_return/Forc.toml
@@ -1,8 +1,7 @@
 [project]
 authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
 license = "Apache-2.0"
 name = "call_empty_return"
-entry = "main.sw"
 
 [dependencies]
-

--- a/packages/fuels/tests/test_projects/call_empty_return/src/main.sw
+++ b/packages/fuels/tests/test_projects/call_empty_return/src/main.sw
@@ -1,18 +1,17 @@
 contract;
 
-use std::storage::store;
-use std::storage::get;
+use std::storage::{get, store};
 
 abi TestContract {
-  #[storage(write)]
-  fn store_value(val: u64);
+    #[storage(write)]
+    fn store_value(val: u64);
 }
 
 const COUNTER_KEY = 0x0000000000000000000000000000000000000000000000000000000000000000;
 
 impl TestContract for Contract {
-  #[storage(write)]
-  fn store_value(val: u64) {
-    store(COUNTER_KEY, val);
-  }
+    #[storage(write)]
+    fn store_value(val: u64) {
+        store(COUNTER_KEY, val);
+    }
 }

--- a/packages/fuels/tests/test_projects/complex_types_contract/Forc.toml
+++ b/packages/fuels/tests/test_projects/complex_types_contract/Forc.toml
@@ -1,8 +1,7 @@
 [project]
 authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
 license = "Apache-2.0"
 name = "complex_types_contract"
-entry = "main.sw"
 
 [dependencies]
-

--- a/packages/fuels/tests/test_projects/complex_types_contract/src/main.sw
+++ b/packages/fuels/tests/test_projects/complex_types_contract/src/main.sw
@@ -1,34 +1,33 @@
 contract;
 
-use std::storage::store;
-use std::storage::get;
+use std::storage::{get, store};
 
 struct CounterConfig {
-  dummy: bool,
-  initial_value: u64,
+    dummy: bool,
+    initial_value: u64,
 }
 
 abi TestContract {
-  #[storage(write)]
-  fn initialize_counter(config: CounterConfig) -> u64;
-  #[storage(read, write)]
-  fn increment_counter(amount: u64) -> u64;
+    #[storage(write)]
+    fn initialize_counter(config: CounterConfig) -> u64;
+    #[storage(read, write)]
+    fn increment_counter(amount: u64) -> u64;
 }
 
 const COUNTER_KEY = 0x0000000000000000000000000000000000000000000000000000000000000000;
 
 impl TestContract for Contract {
-  #[storage(write)]
-  fn initialize_counter(config: CounterConfig) -> u64 {
-    let value = config.initial_value;
-    store(COUNTER_KEY, value);
-    value
-  }
+    #[storage(write)]
+    fn initialize_counter(config: CounterConfig) -> u64 {
+        let value = config.initial_value;
+        store(COUNTER_KEY, value);
+        value
+    }
 
-  #[storage(read, write)]
-  fn increment_counter(amount: u64) -> u64 {
-    let value = get::<u64>(COUNTER_KEY) + amount;
-    store(COUNTER_KEY, value);
-    value
-  }
+    #[storage(read, write)]
+    fn increment_counter(amount: u64) -> u64 {
+        let value = get::<u64>(COUNTER_KEY) + amount;
+        store(COUNTER_KEY, value);
+        value
+    }
 }

--- a/packages/fuels/tests/test_projects/contract_output_test/Forc.toml
+++ b/packages/fuels/tests/test_projects/contract_output_test/Forc.toml
@@ -1,8 +1,8 @@
 [project]
 authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
 license = "Apache-2.0"
 name = "contract_output_test"
-entry = "main.sw"
 
 [dependencies]
 increment_abi = { path = "../library_test", package = "library_test" }

--- a/packages/fuels/tests/test_projects/contract_output_test/src/main.sw
+++ b/packages/fuels/tests/test_projects/contract_output_test/src/main.sw
@@ -1,35 +1,29 @@
 contract;
 
-use std::*;
-use core::*;
-
 struct MyStruct {
-  foo: u8,
-  bar: bool,
+    foo: u8,
+    bar: bool,
 }
 
 abi TestContract {
-  fn is_even(value: u64) -> bool;
-  fn return_my_string(value: str[4]) -> str[4];
-  fn return_my_struct(value: MyStruct) -> MyStruct;
-  
+    fn is_even(value: u64) -> bool;
+    fn return_my_string(value: str[4]) -> str[4];
+    fn return_my_struct(value: MyStruct) -> MyStruct;
 }
 
 impl TestContract for Contract {
-  fn is_even(value: u64) -> bool {
-    if (value / 2) * 2 == value {
-      true
-    } else {
-      false
+    fn is_even(value: u64) -> bool {
+        if (value / 2) * 2 == value {
+            true
+        } else {
+            false
+        }
     }
-  }
-  fn return_my_string(value: str[4]) -> str[4] {
-    value
-  }
+    fn return_my_string(value: str[4]) -> str[4] {
+        value
+    }
 
-
-  fn return_my_struct(value: MyStruct) -> MyStruct {
-    value
-  }
-  
+    fn return_my_struct(value: MyStruct) -> MyStruct {
+        value
+    }
 }

--- a/packages/fuels/tests/test_projects/contract_storage_test/src/main.sw
+++ b/packages/fuels/tests/test_projects/contract_storage_test/src/main.sw
@@ -15,13 +15,13 @@ abi MyContract {
 }
 
 impl MyContract for Contract {
-  #[storage(read)]
-  fn get_value_b256(key: b256) -> b256 {
-    get::<b256>(key)
-  }
+    #[storage(read)]
+    fn get_value_b256(key: b256) -> b256 {
+        get::<b256>(key)
+    }
 
-  #[storage(read)]
-  fn get_value_u64(key: b256) -> u64 {
-    get::<u64>(key)
-  }
+    #[storage(read)]
+    fn get_value_u64(key: b256) -> u64 {
+        get::<u64>(key)
+    }
 }

--- a/packages/fuels/tests/test_projects/contract_test/Forc.toml
+++ b/packages/fuels/tests/test_projects/contract_test/Forc.toml
@@ -1,9 +1,8 @@
 [project]
 authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
 license = "Apache-2.0"
 name = "contract_test"
-entry = "main.sw"
 
 [dependencies]
 increment_abi = { path = "../library_test", package = "library_test" }
-

--- a/packages/fuels/tests/test_projects/contract_test/src/main.sw
+++ b/packages/fuels/tests/test_projects/contract_test/src/main.sw
@@ -1,8 +1,6 @@
 contract;
 
-use std::*;
-use core::*;
-use std::storage::*;
+use std::storage::{get, store};
 use std::context::msg_amount;
 
 struct MyType {
@@ -44,7 +42,6 @@ impl TestContract for Contract {
         msg_amount()
     }
     // ANCHOR_END: msg_amount
-
     #[storage(write)]
     fn initialize_counter(value: u64) -> u64 {
         store(COUNTER_KEY, value);

--- a/packages/fuels/tests/test_projects/empty_arguments/src/main.sw
+++ b/packages/fuels/tests/test_projects/empty_arguments/src/main.sw
@@ -1,16 +1,15 @@
 contract;
 
-use std::storage::store;
-use std::storage::get;
+use std::storage::{get, store};
 
 abi TestContract {
-  fn method_with_empty_argument() -> u64;
+    fn method_with_empty_argument() -> u64;
 }
 
 const COUNTER_KEY = 0x0000000000000000000000000000000000000000000000000000000000000000;
 
 impl TestContract for Contract {
-  fn method_with_empty_argument() -> u64 {
-    63
-  }
+    fn method_with_empty_argument() -> u64 {
+        63
+    }
 }

--- a/packages/fuels/tests/test_projects/enum_encoding/src/main.sw
+++ b/packages/fuels/tests/test_projects/enum_encoding/src/main.sw
@@ -37,7 +37,10 @@ impl EnumTesting for Contract {
         let arg_3 = 7777;
         let arg_4 = 8888;
         BigBundle {
-            arg_1, arg_2, arg_3, arg_4
+            arg_1,
+            arg_2,
+            arg_3,
+            arg_4,
         }
     }
     fn check_big_bundle_integrity(arg: BigBundle) -> bool {
@@ -45,7 +48,7 @@ impl EnumTesting for Contract {
             EnumThatHasABigAndSmallVariant::Small(value) => {
                 value == 12345u32
             },
-            _ => false, 
+            _ => false,
         };
 
         arg_1_is_correct && arg.arg_2 == 6666 && arg.arg_3 == 7777 && arg.arg_4 == 8888
@@ -59,7 +62,8 @@ impl EnumTesting for Contract {
     }
     fn check_unit_bundle_integrity(arg: UnitBundle) -> bool {
         let arg_1_is_correct = match arg.arg_1 {
-            UnitEnum::var2(_) => true, _ => false, 
+            UnitEnum::var2(_) => true,
+            _ => false,
         };
 
         arg_1_is_correct && arg.arg_2 == 18_446_744_073_709_551_615u64

--- a/packages/fuels/tests/test_projects/enum_inside_struct/src/main.sw
+++ b/packages/fuels/tests/test_projects/enum_inside_struct/src/main.sw
@@ -1,12 +1,8 @@
 contract;
 
-use std::*;
-use core::*;
-use std::storage::*;
-
 enum Shaker {
-    Cosmopolitan:u64,
-    Mojito:u64,
+    Cosmopolitan: u64,
+    Mojito: u64,
 }
 
 struct Cocktail {
@@ -19,16 +15,15 @@ abi TestContract {
     fn take_enum_inside_struct(c: Cocktail) -> u64;
 }
 
-
 impl TestContract for Contract {
     fn return_enum_inside_struct(a: u64) -> Cocktail {
         let b = Cocktail {
             the_thing_you_mix_in: Shaker::Mojito(222),
-            glass: 333
+            glass: 333,
         };
         b
     }
-    fn take_enum_inside_struct(c: Cocktail) -> u64{
+    fn take_enum_inside_struct(c: Cocktail) -> u64 {
         6666
     }
 }

--- a/packages/fuels/tests/test_projects/foo_caller_contract/src/main.sw
+++ b/packages/fuels/tests/test_projects/foo_caller_contract/src/main.sw
@@ -2,7 +2,6 @@ contract;
 
 use foo::FooContract;
 use std::constants::ZERO_B256;
-use std::contract_id::ContractId;
 
 abi FooCaller {
     fn call_foo_contract(target: b256, value: bool) -> bool;
@@ -12,9 +11,10 @@ impl FooCaller for Contract {
     fn call_foo_contract(target: b256, value: bool) -> bool {
         let foo_contract = abi(FooContract, target);
         let response = foo_contract.foo {
-            gas: 10000, coins: 0, asset_id: ZERO_B256
-        }
-        (value);
+            gas: 10000,
+            coins: 0,
+            asset_id: ZERO_B256,
+        }(value);
 
         !response
     }

--- a/packages/fuels/tests/test_projects/foo_contract/src/main.sw
+++ b/packages/fuels/tests/test_projects/foo_contract/src/main.sw
@@ -4,6 +4,6 @@ use foo::FooContract;
 
 impl FooContract for Contract {
     fn foo(value: bool) -> bool {
-       !value
+        !value
     }
 }

--- a/packages/fuels/tests/test_projects/generics/src/main.sw
+++ b/packages/fuels/tests/test_projects/generics/src/main.sw
@@ -1,6 +1,5 @@
 contract;
 
-use std::assert::assert;
 use std::hash::sha256;
 
 struct SimpleGeneric<T> {
@@ -65,10 +64,7 @@ impl MyContract for Contract {
 
     fn struct_w_generic_in_array(arg1: StructWArrayGeneric<u32>) -> StructWArrayGeneric<u32> {
         let expected = StructWArrayGeneric {
-            a: [
-                1u32,
-                2u32,
-            ],
+            a: [1u32, 2u32, ],
         };
 
         assert(expected.a[0] == arg1.a[0]);
@@ -78,12 +74,7 @@ impl MyContract for Contract {
     }
 
     fn struct_w_generic_in_tuple(arg1: StructWTupleGeneric<u32>) -> StructWTupleGeneric<u32> {
-        let expected = StructWTupleGeneric {
-            a: (
-                1,
-                2,
-            ),
-        };
+        let expected = StructWTupleGeneric { a: (1, 2, ) };
         assert(expected.a.0 == arg1.a.0);
         assert(expected.a.1 == arg1.a.1);
 

--- a/packages/fuels/tests/test_projects/identity/src/main.sw
+++ b/packages/fuels/tests/test_projects/identity/src/main.sw
@@ -1,17 +1,11 @@
 contract;
 
-use std::{
-    address::Address,
-    contract_id::ContractId,
-    identity::Identity,
-};
-
 struct TestStruct {
-    identity: Identity
+    identity: Identity,
 }
 
 enum TestEnum {
-    EnumIdentity: Identity
+    EnumIdentity: Identity,
 }
 
 const ADDR = 0xd58573593432a30a800f97ad32f877425c223a9e427ab557aab5d5bb89156db0;
@@ -37,7 +31,9 @@ impl MyContract for Contract {
     }
 
     fn get_struct_with_identity() -> TestStruct {
-        TestStruct{identity: Identity::Address(~Address::from(ADDR))}
+        TestStruct {
+            identity: Identity::Address(~Address::from(ADDR)),
+        }
     }
 
     fn get_enum_with_identity() -> TestEnum {
@@ -45,13 +41,14 @@ impl MyContract for Contract {
     }
 
     fn get_identity_tuple() -> (TestStruct, TestEnum) {
-        let s = TestStruct{identity: Identity::Address(~Address::from(ADDR))};
+        let s = TestStruct {
+            identity: Identity::Address(~Address::from(ADDR)),
+        };
         let e = TestEnum::EnumIdentity(Identity::ContractId(~ContractId::from(ADDR)));
-        (s,e)
+        (s, e)
     }
 
-
-    fn input_identity(input: Identity) -> bool{
+    fn input_identity(input: Identity) -> bool {
         if let Identity::Address(a) = input {
             return a == ~Address::from(ADDR);
         }

--- a/packages/fuels/tests/test_projects/large_return_data/Forc.toml
+++ b/packages/fuels/tests/test_projects/large_return_data/Forc.toml
@@ -5,4 +5,3 @@ license = "Apache-2.0"
 name = "large_return_data"
 
 [dependencies]
-

--- a/packages/fuels/tests/test_projects/large_return_data/src/main.sw
+++ b/packages/fuels/tests/test_projects/large_return_data/src/main.sw
@@ -1,10 +1,5 @@
 contract;
 
-use std::*;
-use core::*;
-use std::storage::*;
-use std::contract_id::ContractId;
-
 pub struct SmallStruct {
     foo: u32,
 }
@@ -20,8 +15,7 @@ abi TestContract {
     fn get_large_string() -> str[9];
     fn get_large_struct() -> LargeStruct;
     fn get_small_struct() -> SmallStruct;
-    fn get_large_array() -> [u32;
-    2];
+    fn get_large_array() -> [u32; 2];
     fn get_contract_id() -> ContractId;
 }
 
@@ -41,9 +35,7 @@ impl TestContract for Contract {
     }
 
     fn get_small_struct() -> SmallStruct {
-        SmallStruct {
-            foo: 100,
-        }
+        SmallStruct { foo: 100 }
     }
 
     fn get_large_struct() -> LargeStruct {
@@ -53,10 +45,8 @@ impl TestContract for Contract {
         }
     }
 
-    fn get_large_array() -> [u32;
-    2] {
-        let x: [u32;
-        2] = [1, 2];
+    fn get_large_array() -> [u32; 2] {
+        let x: [u32; 2] = [1, 2];
         x
     }
 

--- a/packages/fuels/tests/test_projects/library_test/Forc.toml
+++ b/packages/fuels/tests/test_projects/library_test/Forc.toml
@@ -1,8 +1,7 @@
 [project]
 authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
 license = "Apache-2.0"
 name = "library_test"
-entry = "main.sw"
 
 [dependencies]
-

--- a/packages/fuels/tests/test_projects/library_test/src/main.sw
+++ b/packages/fuels/tests/test_projects/library_test/src/main.sw
@@ -1,6 +1,6 @@
 library increment_abi;
 
 abi Incrementor {
-  fn initialize(gas: u64, amt: u64, coin: b256, initial_value: u64) -> u64;
-  fn increment(gas: u64, amt: u64, coin: b256, initial_value: u64) -> u64;
+    fn initialize(gas: u64, amt: u64, coin: b256, initial_value: u64) -> u64;
+    fn increment(gas: u64, amt: u64, coin: b256, initial_value: u64) -> u64;
 }

--- a/packages/fuels/tests/test_projects/liquidity_pool/Forc.toml
+++ b/packages/fuels/tests/test_projects/liquidity_pool/Forc.toml
@@ -1,8 +1,7 @@
 [project]
 authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
 license = "Apache-2.0"
 name = "liquidity_pool"
-entry = "main.sw"
 
 [dependencies]
-

--- a/packages/fuels/tests/test_projects/liquidity_pool/src/main.sw
+++ b/packages/fuels/tests/test_projects/liquidity_pool/src/main.sw
@@ -1,12 +1,15 @@
 contract;
 
 use std::{
-    address::Address,
-    assert::assert,
-    context::call_frames::{contract_id, msg_asset_id},
+    context::call_frames::{
+        contract_id,
+        msg_asset_id,
+    },
     context::msg_amount,
-    contract_id::ContractId,
-    token::{mint_to_address, transfer_to_address}
+    token::{
+        mint_to_address,
+        transfer_to_address,
+    },
 };
 
 abi LiquidityPool {
@@ -29,8 +32,8 @@ impl LiquidityPool for Contract {
     }
 
     fn withdraw(recipient: Address) {
-       assert(contract_id() == msg_asset_id());
-       assert(0 < msg_amount());
+        assert(contract_id() == msg_asset_id());
+        assert(0 < msg_amount());
 
         // Amount to withdraw.
         let amount_to_transfer = msg_amount() / 2;

--- a/packages/fuels/tests/test_projects/logged_types/src/main.sw
+++ b/packages/fuels/tests/test_projects/logged_types/src/main.sw
@@ -1,9 +1,6 @@
 contract;
 
-use std::*;
-use core::*;
-use std::storage::*;
-use std::context::msg_amount;
+use std::logging::log;
 
 struct TestStruct {
     field_1: bool,
@@ -25,10 +22,10 @@ abi TestContract {
 
 impl TestContract for Contract {
     fn produce_logs_values() {
-        __log(64);
-        __log(32u32);
-        __log(16u16);
-        __log(8u8);
+        log(64);
+        log(32u32);
+        log(16u16);
+        log(8u8);
     }
 
     // ANCHOR: produce_logs
@@ -38,17 +35,16 @@ impl TestContract for Contract {
         let e: str[4] = "Fuel";
         let l: [u8; 3] = [1u8, 2u8, 3u8];
 
-        __log(f);
-        __log(u);
-        __log(e);
-        __log(l);
+        log(f);
+        log(u);
+        log(e);
+        log(l);
     }
     // ANCHOR_END: produce_logs
-
     fn produce_logs_custom_types() -> () {
         let f: u64 = 64;
         let u: b256 = 0xef86afa9696cf0dc6385e2c407a6e159a1103cefb7e2ae0636fb33d3cb2a9e4a;
-        
+
         let test_struct = TestStruct {
             field_1: true,
             field_2: u,
@@ -56,8 +52,8 @@ impl TestContract for Contract {
         };
         let test_enum = TestEnum::VariantTwo;
 
-        __log(test_struct);
-        __log(test_enum);
+        log(test_struct);
+        log(test_enum);
     }
 
     fn produce_multiple_logs() -> () {
@@ -72,15 +68,15 @@ impl TestContract for Contract {
         };
         let test_enum = TestEnum::VariantTwo;
 
-        __log(64);
-        __log(32u32);
-        __log(16u16);
-        __log(8u8);
-        __log(f);
-        __log(u);
-        __log(e);
-        __log(l);
-        __log(test_struct);
-        __log(test_enum);
+        log(64);
+        log(32u32);
+        log(16u16);
+        log(8u8);
+        log(f);
+        log(u);
+        log(e);
+        log(l);
+        log(test_struct);
+        log(test_enum);
     }
 }

--- a/packages/fuels/tests/test_projects/multiple_read_calls/Forc.toml
+++ b/packages/fuels/tests/test_projects/multiple_read_calls/Forc.toml
@@ -5,4 +5,3 @@ license = "Apache-2.0"
 name = "multiple_read_calls"
 
 [dependencies]
-

--- a/packages/fuels/tests/test_projects/multiple_read_calls/src/main.sw
+++ b/packages/fuels/tests/test_projects/multiple_read_calls/src/main.sw
@@ -1,7 +1,6 @@
 contract;
 
-use std::storage::store;
-use std::storage::get;
+use std::storage::{get, store};
 
 abi MyContract {
     #[storage(write)]

--- a/packages/fuels/tests/test_projects/native_types/Forc.toml
+++ b/packages/fuels/tests/test_projects/native_types/Forc.toml
@@ -1,7 +1,7 @@
 [project]
-name = "native_types"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
+name = "native_types"
 
 [dependencies]

--- a/packages/fuels/tests/test_projects/native_types/src/main.sw
+++ b/packages/fuels/tests/test_projects/native_types/src/main.sw
@@ -1,10 +1,8 @@
 contract;
 
-use std::address::Address;
-
 struct User {
     address: Address,
-    weight: u64
+    weight: u64,
 }
 
 abi MyContract {

--- a/packages/fuels/tests/test_projects/nested_structs/src/main.sw
+++ b/packages/fuels/tests/test_projects/nested_structs/src/main.sw
@@ -1,7 +1,5 @@
 contract;
 
-use std::contract_id::ContractId;
-
 pub struct SomeStruct {
     par1: u32,
 }

--- a/packages/fuels/tests/test_projects/options/src/main.sw
+++ b/packages/fuels/tests/test_projects/options/src/main.sw
@@ -1,16 +1,11 @@
 contract;
 
-use std::{
-    address::Address,
-    option::Option,
-};
-
 struct TestStruct {
-    option: Option<Address>
+    option: Option<Address>,
 }
 
 enum TestEnum {
-    EnumOption: Option<Address>
+    EnumOption: Option<Address>,
 }
 
 const ADDR = 0xd58573593432a30a800f97ad32f877425c223a9e427ab557aab5d5bb89156db0;
@@ -38,7 +33,9 @@ impl MyContract for Contract {
     }
 
     fn get_some_struct() -> Option<TestStruct> {
-        Option::Some(TestStruct{option: Option::Some(~Address::from(ADDR))})
+        Option::Some(TestStruct {
+            option: Option::Some(~Address::from(ADDR)),
+        })
     }
 
     fn get_some_enum() -> Option<TestEnum> {
@@ -46,16 +43,18 @@ impl MyContract for Contract {
     }
 
     fn get_some_tuple() -> Option<(TestStruct, TestEnum)> {
-        let s = TestStruct{option: Option::Some(~Address::from(ADDR))};
+        let s = TestStruct {
+            option: Option::Some(~Address::from(ADDR)),
+        };
         let e = TestEnum::EnumOption(Option::Some(~Address::from(ADDR)));
-        Option::Some((s,e))
+        Option::Some((s, e))
     }
 
     fn get_none() -> Option<Address> {
         Option::None
     }
 
-    fn input_primitive(input: Option<u64>) -> bool{
+    fn input_primitive(input: Option<u64>) -> bool {
         if let Option::Some(u) = input {
             return u == 36;
         }

--- a/packages/fuels/tests/test_projects/predicate_signatures/src/main.sw
+++ b/packages/fuels/tests/test_projects/predicate_signatures/src/main.sw
@@ -1,29 +1,25 @@
 predicate;
 
-use std::{
-    inputs::input_predicate_data,
-    ecr::ec_recover_address,
-    constants::ZERO_B256,
-    b512::B512,
-    result::*
-};
+use std::{b512::B512, constants::ZERO_B256, ecr::ec_recover_address, inputs::input_predicate_data};
 
-fn extract_pulic_key_and_match(signature: B512, expected_public_key: b256) -> u64{
-    if let Result::Ok(pub_key_sig) = ec_recover_address(signature, ZERO_B256) {
-        if pub_key_sig.value == expected_public_key{
-           return 1;
+fn extract_pulic_key_and_match(signature: B512, expected_public_key: b256) -> u64 {
+    if let Result::Ok(pub_key_sig) = ec_recover_address(signature, ZERO_B256)
+    {
+        if pub_key_sig.value == expected_public_key {
+            return 1;
         }
     }
-   0
+    0
 }
 
 fn main() -> bool {
-    let signatures: [B512;3] = input_predicate_data(0);
+    let signatures: [B512; 3] = input_predicate_data(0);
 
     let public_keys = [
         0xd58573593432a30a800f97ad32f877425c223a9e427ab557aab5d5bb89156db0,
         0x14df7c7e4e662db31fe2763b1734a3d680e7b743516319a49baaa22b2032a857,
-        0x3ff494fb136978c3125844625dad6baf6e87cdb1328c8a51f35bda5afe72425c];
+        0x3ff494fb136978c3125844625dad6baf6e87cdb1328c8a51f35bda5afe72425c,
+    ];
 
     let mut matched_keys = 0;
 

--- a/packages/fuels/tests/test_projects/predicate_struct/src/main.sw
+++ b/packages/fuels/tests/test_projects/predicate_struct/src/main.sw
@@ -1,11 +1,10 @@
 predicate;
 
-
 use std::inputs::input_predicate_data;
 
 struct Validation {
     has_account: bool,
-    total_complete: u64
+    total_complete: u64,
 }
 
 fn main() -> bool {

--- a/packages/fuels/tests/test_projects/results/src/main.sw
+++ b/packages/fuels/tests/test_projects/results/src/main.sw
@@ -1,17 +1,11 @@
 contract;
 
-use std::{
-    address::Address,
-    result::Result,
-    option::Option
-};
-
 struct TestStruct {
-    option: Option<Address>
+    option: Option<Address>,
 }
 
 enum TestEnum {
-    EnumOption: Option<Address>
+    EnumOption: Option<Address>,
 }
 
 pub enum TestError {
@@ -29,7 +23,6 @@ abi MyContract {
     fn get_error() -> Result<Address, TestError>;
     fn input_ok(ok_address: Result<Address, TestError>) -> bool;
     fn input_error(test_error: Result<Address, TestError>) -> bool;
-
 }
 
 impl MyContract for Contract {
@@ -42,7 +35,9 @@ impl MyContract for Contract {
     }
 
     fn get_ok_struct() -> Result<TestStruct, TestError> {
-        Result::Ok(TestStruct{option: Option::Some(~Address::from(ADDR))})
+        Result::Ok(TestStruct {
+            option: Option::Some(~Address::from(ADDR)),
+        })
     }
 
     fn get_ok_enum() -> Result<TestEnum, TestError> {
@@ -50,9 +45,11 @@ impl MyContract for Contract {
     }
 
     fn get_ok_tuple() -> Result<(TestStruct, TestEnum), TestError> {
-        let s = TestStruct{option: Option::Some(~Address::from(ADDR))};
+        let s = TestStruct {
+            option: Option::Some(~Address::from(ADDR)),
+        };
         let e = TestEnum::EnumOption(Option::Some(~Address::from(ADDR)));
-        Result::Ok((s,e))
+        Result::Ok((s, e))
     }
 
     fn get_error() -> Result<Address, TestError> {

--- a/packages/fuels/tests/test_projects/revert_transaction_error/Forc.toml
+++ b/packages/fuels/tests/test_projects/revert_transaction_error/Forc.toml
@@ -5,4 +5,3 @@ license = "Apache-2.0"
 name = "revert_transaction_error"
 
 [dependencies]
-

--- a/packages/fuels/tests/test_projects/revert_transaction_error/src/main.sw
+++ b/packages/fuels/tests/test_projects/revert_transaction_error/src/main.sw
@@ -1,7 +1,5 @@
 contract;
 
-use std::revert::revert;
-
 abi MyContract {
     fn make_transaction_fail(input: u64) -> u64;
 }

--- a/packages/fuels/tests/test_projects/token_ops/src/main.sw
+++ b/packages/fuels/tests/test_projects/token_ops/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::{address::Address, context::balance_of, context::msg_amount, contract_id::ContractId, token::*};
+use std::{context::balance_of, context::msg_amount, token::*};
 
 abi TestFuelCoin {
     fn mint_coins(mint_amount: u64);
@@ -29,7 +29,6 @@ impl TestFuelCoin for Contract {
         transfer_to_address(coins, asset_id, recipient);
     }
     // ANCHOR_END: variable_outputs
-
     fn get_balance(target: ContractId, asset_id: ContractId) -> u64 {
         balance_of(target, asset_id)
     }

--- a/packages/fuels/tests/test_projects/transaction_block_height/src/main.sw
+++ b/packages/fuels/tests/test_projects/transaction_block_height/src/main.sw
@@ -10,6 +10,5 @@ impl MyContract for Contract {
         std::block::height()
     }
 
-    fn calling_this_will_produce_a_block() {
-    }
+    fn calling_this_will_produce_a_block() {}
 }

--- a/packages/fuels/tests/test_projects/tuples/src/main.sw
+++ b/packages/fuels/tests/test_projects/tuples/src/main.sw
@@ -1,8 +1,6 @@
 contract;
 
-use std::assert::assert;
-use std::hash::sha256;
-use std::constants::ZERO_B256;
+use std::{constants::ZERO_B256, hash::sha256};
 
 struct Person {
     name: str[4],
@@ -33,12 +31,7 @@ impl MyContract for Contract {
     }
 
     fn returns_struct_in_tuple(input: (u64, Person)) -> (u64, Person) {
-        let expected = (
-            42,
-            Person {
-                name: "Jane",
-            },
-        );
+        let expected = (42, Person { name: "Jane" }, );
         assert(input.0 == expected.0);
         assert(sha256(input.1.name) == sha256(expected.1.name));
 
@@ -69,10 +62,7 @@ impl MyContract for Contract {
     }
 
     fn tuple_with_b256(p: (b256, u8)) -> (b256, u8) {
-        let expected = (
-            ZERO_B256,
-            10u8,
-        );
+        let expected = (ZERO_B256, 10u8, );
 
         assert(p.0 == expected.0);
         assert(p.1 == expected.1);

--- a/packages/fuels/tests/test_projects/two_structs/Forc.toml
+++ b/packages/fuels/tests/test_projects/two_structs/Forc.toml
@@ -1,8 +1,7 @@
 [project]
-name = "two_structs"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
+name = "two_structs"
 
 [dependencies]
-

--- a/packages/fuels/tests/test_projects/two_structs/src/main.sw
+++ b/packages/fuels/tests/test_projects/two_structs/src/main.sw
@@ -15,12 +15,11 @@ abi MyTest {
 
 impl MyTest for Contract {
     fn something(input: StructOne) -> u64 {
-        let v = input.foo; 
+        let v = input.foo;
         v + 1
-    }    
-
+    }
     fn something_else(input: StructTwo) -> u64 {
-        let v = input.bar; 
+        let v = input.bar;
         v - 1
-    }    
+    }
 }

--- a/packages/fuels/tests/test_projects/type_inside_enum/src/main.sw
+++ b/packages/fuels/tests/test_projects/type_inside_enum/src/main.sw
@@ -1,21 +1,17 @@
 contract;
 
-use std::*;
-use core::*;
-use std::storage::*;
-
 // String and array inside enum
 enum SomeEnum {
-	SomeStr: str[4],
-	SomeArr: [u64; 7]
+    SomeStr: str[4],
+    SomeArr: [u64; 7],
 }
 
 // Struct inside enum
 enum Shaker {
     Cosmopolitan: Recipe,
     Mojito: u32,
-
 }
+
 struct Recipe {
     ice: u8,
     sugar: u16,
@@ -57,13 +53,11 @@ impl MyContract for Contract {
     }
 
     fn return_struct_inside_enum(c: u64) -> Shaker {
-            let s = Shaker::Cosmopolitan(
-                Recipe{
-                    ice: 22,
-                    sugar: 99
-                }
-            );
-            s
+        let s = Shaker::Cosmopolitan(Recipe {
+            ice: 22,
+            sugar: 99,
+        });
+        s
     }
     fn take_struct_inside_enum(s: Shaker) -> u64 {
         8888
@@ -82,5 +76,4 @@ impl MyContract for Contract {
 
         arg_is_correct
     }
-
 }

--- a/packages/fuels/tests/test_projects/vectors/src/eq_impls.sw
+++ b/packages/fuels/tests/test_projects/vectors/src/eq_impls.sw
@@ -2,10 +2,8 @@ library eq_impls;
 
 dep data_structures;
 
-use std::vec::Vec;
 use data_structures::{SomeEnum, SomeStruct};
 use core::ops::Eq;
-use std::option::Option;
 
 impl Eq for (u32, u32) {
     fn eq(self, other: Self) -> bool {

--- a/packages/fuels/tests/test_projects/vectors/src/main.sw
+++ b/packages/fuels/tests/test_projects/vectors/src/main.sw
@@ -62,10 +62,7 @@ impl MyContract for Contract {
     }
 
     fn vec_in_array(arg: [Vec<u32>; 2]) {
-        let expected = [
-            vec_from([0, 1, 2]),
-            vec_from([0, 1, 2]),
-        ];
+        let expected = [vec_from([0, 1, 2]), vec_from([0, 1, 2]), ];
 
         assert(expected == arg);
     }
@@ -93,10 +90,7 @@ impl MyContract for Contract {
     }
 
     fn vec_in_tuple(arg: (Vec<u32>, Vec<u32>)) {
-        let expected = (
-            vec_from([0, 1, 2]),
-            vec_from([0, 1, 2]),
-        );
+        let expected = (vec_from([0, 1, 2]), vec_from([0, 1, 2]), );
 
         assert(arg == expected);
     }


### PR DESCRIPTION
This started because I noticed that `__log` is used in the `fuels-rs` book instead of `std::logging::log`, so I wanted to update that in the tests. Users should really not be using intrinsics directly (intrinsics always start with `__`) which is why we provide wrappers around them in the standard library.

Then I noticed that a whole bunch of things could be cosmetically improved such as:
* Removing unnecessary imports due to the standard library prelude.
* Running the new formatter.