### PR TITLE
ci: update `forc` version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   RUSTFLAGS: "-D warnings"
   FUEL_CORE_VERSION: 0.10.1
   RUST_VERSION: 1.61.0
-  FORC_VERSION: 0.25.2
+  FORC_VERSION: 0.26.0
 
 jobs:
   setup-test-projects:

--- a/scripts/build-test-projects/src/lib.rs
+++ b/scripts/build-test-projects/src/lib.rs
@@ -24,7 +24,7 @@ pub fn discover_projects(path: &Path) -> Vec<PathBuf> {
 pub fn build_recursively(path: &Path) -> impl Iterator<Item = BuildResult> {
     discover_projects(path).into_iter().map(|path| {
         let output = std::process::Command::new("forc")
-            .args(["build", "--generate-logged-types", "--path"])
+            .args(["build", "--path"])
             .arg(&path)
             .output()
             .expect("failed to run `forc build` for example project");


### PR DESCRIPTION
Release `0.26` of `forc` removed the need for the `--generate-logged-types` flag on `forc build` commands.