### PR TITLE
feat: create `Bits256` from hex string

### DIFF
--- a/docs/src/types/bits256.md
+++ b/docs/src/types/bits256.md
@@ -7,3 +7,7 @@ Here's an example:
 ```rust,ignore
 {{#include ../../../packages/fuels/tests/bindings.rs:256_arg}}
 ```
+
+If you have a hexadecimal value as a string and wish to convert it to `Bits256`, you may do so with `from_hex_str`:
+
+{{#include ../../../packages/fuels-core/src/types/bits_256.rs:from_hex_str}}

--- a/packages/fuels-core/src/types/bits_256.rs
+++ b/packages/fuels-core/src/types/bits_256.rs
@@ -48,6 +48,7 @@ impl Tokenizable for Bits256 {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::Tokenizable;

--- a/packages/fuels-core/src/types/bits_256.rs
+++ b/packages/fuels-core/src/types/bits_256.rs
@@ -82,16 +82,22 @@ mod tests {
     }
 
     #[test]
-    fn from_hex_str() {
+    fn from_hex_str() -> Result<(), Error> {
         // ANCHOR: from_hex_str
         let hex_str = "0101010101010101010101010101010101010101010101010101010101010101";
-        let bits256 = Bits256::from_hex_str(hex_str).unwrap();
+
+        let bits256 = Bits256::from_hex_str(hex_str)?;
+
         assert_eq!(bits256.0, [1u8; 32]);
 
         // With the `0x0` prefix
         let hex_str = "0x0101010101010101010101010101010101010101010101010101010101010101";
-        let bits256 = Bits256::from_hex_str(hex_str).unwrap();
+
+        let bits256 = Bits256::from_hex_str(hex_str)?;
+
         assert_eq!(bits256.0, [1u8; 32]);
         // ANCHOR_END: from_hex_str
+
+        Ok(())
     }
 }

--- a/packages/fuels-core/src/types/bits_256.rs
+++ b/packages/fuels-core/src/types/bits_256.rs
@@ -60,11 +60,15 @@ mod tests {
     }
 
     #[test]
-    fn test_from_token() {
+    fn test_from_token() -> Result<(), Error> {
         let data = [0u8; 32];
         let token = Token::B256(data);
-        let bits256 = Bits256::from_token(token).unwrap();
+
+        let bits256 = Bits256::from_token(token)?;
+
         assert_eq!(bits256.0, data);
+
+        Ok(())
     }
 
     #[test]

--- a/packages/fuels-core/src/types/bits_256.rs
+++ b/packages/fuels-core/src/types/bits_256.rs
@@ -19,7 +19,9 @@ impl Bits256 {
         };
 
         let mut bytes = [0u8; 32];
-        hex::decode_to_slice(hex, &mut bytes as &mut [u8]).expect("Decoding failed");
+        hex::decode_to_slice(hex, &mut bytes as &mut [u8]).map_err(|e| {
+            Error::InvalidData(format!("Could not convert hex str '{hex}' to Bits256! {e}"))
+        })?;
         Ok(Bits256(bytes))
     }
 }

--- a/packages/fuels-core/src/types/bits_256.rs
+++ b/packages/fuels-core/src/types/bits_256.rs
@@ -8,6 +8,22 @@ use fuels_types::param_types::ParamType;
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct Bits256(pub [u8; 32]);
 
+impl Bits256 {
+    /// Create a new `Bits256` from a string representation of a hex.
+    /// Accepts both `0x` prefixed and non-prefixed hex strings.
+    pub fn from_hex_str(hex: &str) -> Result<Self, Error> {
+        let hex = if let Some(stripped_hex) = hex.strip_prefix("0x") {
+            stripped_hex
+        } else {
+            hex
+        };
+
+        let mut bytes = [0u8; 32];
+        hex::decode_to_slice(hex, &mut bytes as &mut [u8]).expect("Decoding failed");
+        Ok(Bits256(bytes))
+    }
+}
+
 impl Parameterize for Bits256 {
     fn param_type() -> ParamType {
         ParamType::B256
@@ -29,5 +45,46 @@ impl Tokenizable for Bits256 {
 
     fn into_token(self) -> Token {
         Token::B256(self.0)
+    }
+}
+
+mod tests {
+    use super::*;
+    use crate::Tokenizable;
+    use fuels_types::param_types::ParamType;
+
+    #[test]
+    fn test_param_type() {
+        assert_eq!(Bits256::param_type(), ParamType::B256);
+    }
+
+    #[test]
+    fn test_from_token() {
+        let data = [0u8; 32];
+        let token = Token::B256(data);
+        let bits256 = Bits256::from_token(token).unwrap();
+        assert_eq!(bits256.0, data);
+    }
+
+    #[test]
+    fn test_into_token() {
+        let data = [0u8; 32];
+        let bits256 = Bits256(data);
+        let token = bits256.into_token();
+        assert_eq!(token, Token::B256(data));
+    }
+
+    #[test]
+    fn from_hex_str() {
+        // ANCHOR: from_hex_str
+        let hex_str = "0101010101010101010101010101010101010101010101010101010101010101";
+        let bits256 = Bits256::from_hex_str(hex_str).unwrap();
+        assert_eq!(bits256.0, [1u8; 32]);
+
+        // With the `0x0` prefix
+        let hex_str = "0x0101010101010101010101010101010101010101010101010101010101010101";
+        let bits256 = Bits256::from_hex_str(hex_str).unwrap();
+        assert_eq!(bits256.0, [1u8; 32]);
+        // ANCHOR_END: from_hex_str
     }
 }

--- a/packages/fuels-core/src/types/bits_256.rs
+++ b/packages/fuels-core/src/types/bits_256.rs
@@ -75,7 +75,9 @@ mod tests {
     fn test_into_token() {
         let data = [0u8; 32];
         let bits256 = Bits256(data);
+
         let token = bits256.into_token();
+
         assert_eq!(token, Token::B256(data));
     }
 


### PR DESCRIPTION
Small ergonomics improvement. 

Enables the user to do `let bits256 = Bits256::from_hex_str(hex_str)?;` to get a `Bits256` from their hex strings instead of having to do some more manual conversions.