### PR TITLE
fix: check docs in dir with name `scripts`

### DIFF
--- a/scripts/check-docs/src/lib.rs
+++ b/scripts/check-docs/src/lib.rs
@@ -181,11 +181,11 @@ pub fn extract_starts_and_ends(
 
 pub fn search_for_patterns_in_project(pattern: &str) -> anyhow::Result<String> {
     let grep_project = std::process::Command::new("grep")
+        .arg("-H") // print filename
+        .arg("-n") // print line-number
+        .arg("-r") // search recursively
         .arg("--binary-files=without-match")
-        .arg("--with-filename")
-        .arg("--dereference-recursive")
-        .arg("--line-number")
-        .arg("--exclude-dir=scripts")
+        .arg("--exclude-dir=check-docs")
         .arg(pattern)
         .arg(".")
         .output()


### PR DESCRIPTION
fixes: https://github.com/FuelLabs/fuels-rs/issues/640

Now the `gerp` exclude is only applied to `check-docs` folder. I have also updated the flags and now we should not have any issues on mac.