### PR TITLE
fix(check-docs): check whole file includes

### DIFF
--- a/scripts/check-docs/src/main.rs
+++ b/scripts/check-docs/src/main.rs
@@ -13,13 +13,16 @@ fn main() -> anyhow::Result<(), Error> {
     let (valid_anchors, anchor_errors) = filter_valid_anchors(starts, ends);
 
     let text_mentioning_include = search_for_patterns_in_project("{{#include")?;
-    let includes = parse_includes(text_mentioning_include)?;
+    let (includes, include_path_errors) = parse_includes(text_mentioning_include);
 
     let (include_errors, additional_warnings) = validate_includes(includes, valid_anchors);
 
-    report_warnings(&additional_warnings);
+    if !additional_warnings.is_empty() {
+        report_warnings(&additional_warnings);
+    }
 
-    if !anchor_errors.is_empty() || !include_errors.is_empty() {
+    if !anchor_errors.is_empty() || !include_errors.is_empty() || !include_path_errors.is_empty() {
+        report_errors("include paths", &include_path_errors);
         report_errors("anchors", &anchor_errors);
         report_errors("includes", &include_errors);
         bail!("Finished with errors");

--- a/scripts/check-docs/tests/test_data/test_include_data.md
+++ b/scripts/check-docs/tests/test_data/test_include_data.md
@@ -14,3 +14,18 @@
 ```rust,ignore
 {{#include ./test_anchor_data.rs:no_existing_anchor}}
 ```
+
+Include file with correct path
+```rust,ignore
+{{#include ./test_anchor_data.rs}}
+```
+
+Include file with wrong path
+```rust,ignore
+{{#include ./test_anchor_data2.rs}}
+```
+
+Another include file with wrong path
+```rust,ignore
+{{#include ./test_anchor_data3.rs}}
+```


### PR DESCRIPTION
closes: https://github.com/FuelLabs/fuels-rs/issues/638

Previously, the `regex` used to match `include` statements would skip includes that did not have an `anchor`. I have updated the regex and now the anchor is optional. Previously the program would stop if the `path` in the include statement is not correct, now we partition the result and show the path errors the same way as the other errors.