### PR TITLE
fix: remove predicates config flag

### DIFF
--- a/packages/fuels-test-helpers/src/lib.rs
+++ b/packages/fuels-test-helpers/src/lib.rs
@@ -362,7 +362,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_setup_test_client_custom_config() -> Result<(), rand::Error> {
-        let socket = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 5000);
+        let socket = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 4000);
 
         let wallet = WalletUnlocked::new_random(None);
 

--- a/packages/fuels-test-helpers/src/node.rs
+++ b/packages/fuels-test-helpers/src/node.rs
@@ -26,7 +26,6 @@ use tokio::process::Command;
 pub struct Config {
     pub addr: SocketAddr,
     pub utxo_validation: bool,
-    pub predicates: bool,
     pub manual_blocks_enabled: bool,
     pub vm_backtrace: bool,
     pub silent: bool,
@@ -37,7 +36,6 @@ impl Config {
         Self {
             addr: SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 0),
             utxo_validation: false,
-            predicates: false,
             manual_blocks_enabled: false,
             vm_backtrace: false,
             silent: true,
@@ -259,10 +257,6 @@ pub async fn new_fuel_node(
 
         if config.utxo_validation {
             args.push("--utxo-validation");
-        }
-
-        if config.predicates {
-            args.push("--predicates");
         }
 
         if config.manual_blocks_enabled {


### PR DESCRIPTION
###### Description of changes

Seems like `fuel-core` doesn't take the `--predicates` flag anymore. So we're removing it from the SDK as well.

