### PR TITLE
feat!: Accept chain config as argument for node setup test helpers

### DIFF
--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -190,7 +190,8 @@ mod tests {
             "packages/fuels/tests/contracts/contract_test/out/debug/contract_test-abi.json"
         );
 
-        let wallets = launch_custom_provider_and_get_wallets(WalletsConfig::default(), None).await;
+        let wallets =
+            launch_custom_provider_and_get_wallets(WalletsConfig::default(), None, None).await;
 
         let contract_id_1 = Contract::deploy(
             "../../packages/fuels/tests/contracts/contract_test/out/debug/contract_test.bin",
@@ -569,7 +570,7 @@ mod tests {
         );
 
         let config = WalletsConfig::new(Some(2), Some(1), Some(DEFAULT_COIN_AMOUNT));
-        let mut wallets = launch_custom_provider_and_get_wallets(config, None).await;
+        let mut wallets = launch_custom_provider_and_get_wallets(config, None, None).await;
         let wallet_1 = wallets.pop().unwrap();
         let wallet_2 = wallets.pop().unwrap();
 

--- a/examples/cookbook/src/lib.rs
+++ b/examples/cookbook/src/lib.rs
@@ -30,7 +30,7 @@ mod tests {
             .into();
 
         let wallet_config = WalletsConfig::new_multiple_assets(1, asset_configs);
-        let wallets = launch_custom_provider_and_get_wallets(wallet_config, None).await;
+        let wallets = launch_custom_provider_and_get_wallets(wallet_config, None, None).await;
         let wallet = &wallets[0];
         // ANCHOR_END: liquidity_wallet
 
@@ -105,6 +105,7 @@ mod tests {
             coins,
             vec![],
             Some(node_config),
+            None,
             Some(consensus_parameters_config),
         )
         .await;
@@ -129,7 +130,7 @@ mod tests {
         let (coins, _) =
             setup_multiple_assets_coins(wallet_1.address(), NUM_ASSETS, NUM_COINS, AMOUNT);
 
-        let (provider, _) = setup_test_provider(coins, vec![], None).await;
+        let (provider, _) = setup_test_provider(coins, vec![], None, None).await;
 
         wallet_1.set_provider(provider.clone());
         wallet_2.set_provider(provider.clone());

--- a/examples/predicates/src/lib.rs
+++ b/examples/predicates/src/lib.rs
@@ -45,6 +45,7 @@ mod tests {
                 utxo_validation: true,
                 ..Config::local_node()
             }),
+            None,
         )
         .await;
 

--- a/examples/providers/src/lib.rs
+++ b/examples/providers/src/lib.rs
@@ -55,7 +55,7 @@ mod tests {
         );
         // ANCHOR_END: setup_single_asset
 
-        let (provider, _) = setup_test_provider(coins.clone(), vec![], None).await;
+        let (provider, _) = setup_test_provider(coins.clone(), vec![], None, None).await;
         // ANCHOR_END: setup_test_blockchain
 
         // ANCHOR: get_coins

--- a/examples/wallets/src/lib.rs
+++ b/examples/wallets/src/lib.rs
@@ -8,7 +8,7 @@ mod tests {
         use fuels::prelude::*;
 
         // Use the test helper to setup a test provider.
-        let (provider, _address) = setup_test_provider(vec![], vec![], None).await;
+        let (provider, _address) = setup_test_provider(vec![], vec![], None, None).await;
 
         // Create the wallet.
         let _wallet = WalletUnlocked::new_random(Some(provider));
@@ -23,7 +23,7 @@ mod tests {
         use std::str::FromStr;
 
         // Use the test helper to setup a test provider.
-        let (provider, _address) = setup_test_provider(vec![], vec![], None).await;
+        let (provider, _address) = setup_test_provider(vec![], vec![], None, None).await;
 
         // Setup the private key.
         let secret = SecretKey::from_str(
@@ -45,7 +45,7 @@ mod tests {
             "oblige salon price punch saddle immune slogan rare snap desert retire surprise";
 
         // Use the test helper to setup a test provider.
-        let (provider, _address) = setup_test_provider(vec![], vec![], None).await;
+        let (provider, _address) = setup_test_provider(vec![], vec![], None, None).await;
 
         // Create first account from mnemonic phrase.
         let _wallet = WalletUnlocked::new_from_mnemonic_phrase_with_path(
@@ -73,7 +73,7 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         // Use the test helper to setup a test provider.
-        let (provider, _address) = setup_test_provider(vec![], vec![], None).await;
+        let (provider, _address) = setup_test_provider(vec![], vec![], None, None).await;
 
         let password = "my_master_password";
 
@@ -99,7 +99,7 @@ mod tests {
             "oblige salon price punch saddle immune slogan rare snap desert retire surprise";
 
         // Use the test helper to setup a test provider.
-        let (provider, _address) = setup_test_provider(vec![], vec![], None).await;
+        let (provider, _address) = setup_test_provider(vec![], vec![], None, None).await;
 
         // Create first account from mnemonic phrase.
         let wallet = WalletUnlocked::new_from_mnemonic_phrase(phrase, Some(provider))?;
@@ -124,6 +124,7 @@ mod tests {
 
         let wallets = launch_custom_provider_and_get_wallets(
             WalletsConfig::new(num_wallets, coins_per_wallet, coin_amount),
+            None,
             None,
         )
         .await;
@@ -165,7 +166,7 @@ mod tests {
         };
 
         let wallet_config = WalletsConfig::new_multiple_assets(1, vec![random_asset, base_asset]);
-        let wallet = launch_custom_provider_and_get_wallets(wallet_config, None)
+        let wallet = launch_custom_provider_and_get_wallets(wallet_config, None, None)
             .await
             .pop()
             .unwrap();
@@ -215,7 +216,8 @@ mod tests {
         use fuels::prelude::*;
         // This helper will launch a local node and provide 10 test wallets linked to it.
         // The initial balance defaults to 1 coin per wallet with an amount of 1_000_000_000
-        let wallets = launch_custom_provider_and_get_wallets(WalletsConfig::default(), None).await;
+        let wallets =
+            launch_custom_provider_and_get_wallets(WalletsConfig::default(), None, None).await;
         // ANCHOR_END: multiple_wallets_helper
         // ANCHOR: setup_5_wallets
         let num_wallets = 5;
@@ -228,7 +230,7 @@ mod tests {
             Some(amount_per_coin),
         );
         // Launches a local node and provides test wallets as specified by the config
-        let wallets = launch_custom_provider_and_get_wallets(config, None).await;
+        let wallets = launch_custom_provider_and_get_wallets(config, None, None).await;
         // ANCHOR_END: setup_5_wallets
         Ok(())
     }
@@ -251,7 +253,7 @@ mod tests {
             amount_per_coin,
         );
         // ANCHOR_END: multiple_assets_coins
-        let (provider, _socket_addr) = setup_test_provider(coins.clone(), vec![], None).await;
+        let (provider, _socket_addr) = setup_test_provider(coins.clone(), vec![], None, None).await;
         wallet.set_provider(provider);
         // ANCHOR_END: multiple_assets_wallet
         Ok(())
@@ -292,13 +294,13 @@ mod tests {
         let assets = vec![asset_base, asset_1, asset_2];
 
         let coins = setup_custom_assets_coins(wallet.address(), &assets);
-        let (provider, _socket_addr) = setup_test_provider(coins, vec![], None).await;
+        let (provider, _socket_addr) = setup_test_provider(coins, vec![], None, None).await;
         wallet.set_provider(provider);
         // ANCHOR_END: custom_assets_wallet
         // ANCHOR: custom_assets_wallet_short
         let num_wallets = 1;
         let wallet_config = WalletsConfig::new_multiple_assets(num_wallets, assets);
-        let wallets = launch_custom_provider_and_get_wallets(wallet_config, None).await;
+        let wallets = launch_custom_provider_and_get_wallets(wallet_config, None, None).await;
         // ANCHOR_END: custom_assets_wallet_short
         Ok(())
     }

--- a/packages/fuels-signers/src/lib.rs
+++ b/packages/fuels-signers/src/lib.rs
@@ -158,7 +158,7 @@ mod tests {
         coins_1.extend(coins_2);
 
         // Setup a provider and node with both set of coins.
-        let (client, _) = setup_test_client(coins_1, vec![], None, None).await;
+        let (client, _) = setup_test_client(coins_1, vec![], None, None, None).await;
         let provider = Provider::new(client);
 
         wallet_1.set_provider(provider.clone());
@@ -235,7 +235,7 @@ mod tests {
 
         coins_1.extend(coins_2);
 
-        let (client, _) = setup_test_client(coins_1, vec![], None, None).await;
+        let (client, _) = setup_test_client(coins_1, vec![], None, None, None).await;
         let provider = Provider::new(client);
 
         wallet_1.set_provider(provider.clone());

--- a/packages/fuels-signers/src/provider.rs
+++ b/packages/fuels-signers/src/provider.rs
@@ -69,7 +69,7 @@ impl Provider {
     /// use fuels::prelude::*;
     /// async fn foo() -> Result<(), Box<dyn std::error::Error>> {
     ///   // Setup local test node
-    ///   let (provider, _) = setup_test_provider(vec![], vec![], None).await;
+    ///   let (provider, _) = setup_test_provider(vec![], vec![], None, None).await;
     ///   let tx = Script::default();
     ///
     ///   let receipts = provider.send_transaction(&tx).await?;

--- a/packages/fuels-signers/src/wallet.rs
+++ b/packages/fuels-signers/src/wallet.rs
@@ -59,7 +59,7 @@ pub struct Wallet {
 ///
 /// async fn foo() -> Result<(), Error> {
 ///   // Setup local test node
-///   let (provider, _) = setup_test_provider(vec![], vec![], None).await;
+///   let (provider, _) = setup_test_provider(vec![], vec![], None, None).await;
 ///
 ///   // Create a new local wallet with the newly generated key
 ///   let wallet = WalletUnlocked::new_random(Some(provider));
@@ -572,7 +572,7 @@ impl WalletUnlocked {
     ///   coins_1.extend(coins_2);
     ///
     ///   // Setup a provider and node with both set of coins
-    ///   let (provider, _) = setup_test_provider(coins_1, vec![], None).await;
+    ///   let (provider, _) = setup_test_provider(coins_1, vec![], None, None).await;
     ///
     ///   // Set provider for wallets
     ///   wallet_1.set_provider(provider.clone());

--- a/packages/fuels-signers/src/wallet.rs
+++ b/packages/fuels-signers/src/wallet.rs
@@ -1014,7 +1014,7 @@ mod tests {
     #[tokio::test]
     async fn add_fee_coins_empty_transaction() -> Result<(), Error> {
         let wallet_config = add_fee_coins_wallet_config(1);
-        let wallet = launch_custom_provider_and_get_wallets(wallet_config, None)
+        let wallet = launch_custom_provider_and_get_wallets(wallet_config, None, None)
             .await
             .pop()
             .unwrap();
@@ -1043,7 +1043,7 @@ mod tests {
     #[tokio::test]
     async fn add_fee_coins_to_transfer_with_base_asset() -> Result<(), Error> {
         let wallet_config = add_fee_coins_wallet_config(1);
-        let wallet = launch_custom_provider_and_get_wallets(wallet_config, None)
+        let wallet = launch_custom_provider_and_get_wallets(wallet_config, None, None)
             .await
             .pop()
             .unwrap();

--- a/packages/fuels-test-helpers/src/lib.rs
+++ b/packages/fuels-test-helpers/src/lib.rs
@@ -26,6 +26,7 @@ use fuel_core_interfaces::model::{DaBlockHeight, Message};
 #[cfg(not(feature = "fuel-core-lib"))]
 use portpicker::is_free;
 
+use fuel_chain_config::ChainConfig;
 use fuel_gql_client::fuel_tx::ConsensusParameters;
 use fuel_gql_client::{
     client::FuelClient,
@@ -210,6 +211,7 @@ pub async fn setup_test_client(
     coins: Vec<(UtxoId, Coin)>,
     messages: Vec<Message>,
     node_config: Option<Config>,
+    chain_config: Option<ChainConfig>,
     consensus_parameters_config: Option<ConsensusParameters>,
 ) -> (FuelClient, SocketAddr) {
     let config = node_config.unwrap_or_else(Config::local_node);
@@ -230,6 +232,7 @@ pub async fn setup_test_client(
             addr: bound_address,
             ..config
         },
+        chain_config,
         consensus_parameters_config,
     )
     .await;
@@ -378,7 +381,7 @@ mod tests {
             ..Config::local_node()
         };
 
-        let wallets = setup_test_client(coins, vec![], Some(config), None).await;
+        let wallets = setup_test_client(coins, vec![], Some(config), None, None).await;
 
         assert_eq!(wallets.1, socket);
         Ok(())
@@ -398,7 +401,7 @@ mod tests {
         );
 
         let (fuel_client, _) =
-            setup_test_client(coins, vec![], None, Some(consensus_parameters_config)).await;
+            setup_test_client(coins, vec![], None, None, Some(consensus_parameters_config)).await;
         let provider = Provider::new(fuel_client);
         wallet.set_provider(provider.clone());
 

--- a/packages/fuels-test-helpers/src/script.rs
+++ b/packages/fuels-test-helpers/src/script.rs
@@ -78,7 +78,7 @@ mod tests {
             DEFAULT_NUM_COINS,
             DEFAULT_COIN_AMOUNT,
         );
-        let (provider, _) = setup_test_provider(coins, vec![], None).await;
+        let (provider, _) = setup_test_provider(coins, vec![], None, None).await;
 
         let return_val =
             run_compiled_script(path_to_bin, TxParameters::default(), Some(provider)).await?;

--- a/packages/fuels/tests/contracts.rs
+++ b/packages/fuels/tests/contracts.rs
@@ -398,7 +398,7 @@ async fn test_connect_wallet() -> anyhow::Result<()> {
     // ANCHOR: contract_setup_macro_manual_wallet
     let config = WalletsConfig::new(Some(2), Some(1), Some(DEFAULT_COIN_AMOUNT));
 
-    let mut wallets = launch_custom_provider_and_get_wallets(config, None).await;
+    let mut wallets = launch_custom_provider_and_get_wallets(config, None, None).await;
     let wallet = wallets.pop().unwrap();
     let wallet_2 = wallets.pop().unwrap();
 
@@ -442,7 +442,7 @@ async fn test_connect_wallet() -> anyhow::Result<()> {
 async fn setup_output_variable_estimation_test(
 ) -> Result<(Vec<WalletUnlocked>, [Address; 3], AssetId, Bech32ContractId), Error> {
     let wallet_config = WalletsConfig::new(Some(3), None, None);
-    let wallets = launch_custom_provider_and_get_wallets(wallet_config, None).await;
+    let wallets = launch_custom_provider_and_get_wallets(wallet_config, None, None).await;
 
     let contract_id = Contract::deploy(
         "tests/contracts/token_ops/out/debug/token_ops.bin",
@@ -583,7 +583,7 @@ async fn test_contract_instance_get_balances() -> Result<(), Error> {
     let mut wallet = WalletUnlocked::new_random(None);
     let (coins, asset_ids) = setup_multiple_assets_coins(wallet.address(), 2, 4, 8);
     let random_asset_id = &asset_ids[1];
-    let (provider, _) = setup_test_provider(coins.clone(), vec![], None).await;
+    let (provider, _) = setup_test_provider(coins.clone(), vec![], None, None).await;
     wallet.set_provider(provider.clone());
 
     setup_contract_test!(

--- a/packages/fuels/tests/predicates.rs
+++ b/packages/fuels/tests/predicates.rs
@@ -15,6 +15,7 @@ async fn setup_predicate_test(
             utxo_validation: true,
             ..Config::local_node()
         }),
+        None,
     )
     .await;
 

--- a/packages/fuels/tests/providers.rs
+++ b/packages/fuels/tests/providers.rs
@@ -20,7 +20,7 @@ async fn test_provider_launch_and_connect() -> Result<(), Error> {
         DEFAULT_NUM_COINS,
         DEFAULT_COIN_AMOUNT,
     );
-    let (launched_provider, address) = setup_test_provider(coins, vec![], None).await;
+    let (launched_provider, address) = setup_test_provider(coins, vec![], None, None).await;
     let connected_provider = Provider::connect(address.to_string()).await?;
 
     wallet.set_provider(connected_provider);
@@ -112,7 +112,7 @@ async fn test_input_message() -> Result<(), Error> {
         vec![1, 2],
     );
 
-    let (provider, _) = setup_test_provider(coins, messages.clone(), None).await;
+    let (provider, _) = setup_test_provider(coins, messages.clone(), None, None).await;
     wallet.set_provider(provider);
 
     setup_contract_test!(
@@ -143,7 +143,7 @@ async fn can_increase_block_height() -> Result<(), Error> {
         ..Config::local_node()
     };
     let wallets =
-        launch_custom_provider_and_get_wallets(WalletsConfig::default(), Some(config)).await;
+        launch_custom_provider_and_get_wallets(WalletsConfig::default(), Some(config), None).await;
     let wallet = &wallets[0];
     let provider = wallet.get_provider()?;
 
@@ -168,7 +168,7 @@ async fn contract_deployment_respects_maturity() -> Result<(), Error> {
         ..Config::local_node()
     };
     let wallets =
-        launch_custom_provider_and_get_wallets(WalletsConfig::default(), Some(config)).await;
+        launch_custom_provider_and_get_wallets(WalletsConfig::default(), Some(config), None).await;
     let wallet = &wallets[0];
     let provider = wallet.get_provider()?;
 
@@ -324,7 +324,7 @@ async fn test_gas_errors() -> Result<(), Error> {
         amount_per_coin,
     );
 
-    let (provider, _) = setup_test_provider(coins.clone(), vec![], None).await;
+    let (provider, _) = setup_test_provider(coins.clone(), vec![], None, None).await;
     wallet.set_provider(provider);
 
     setup_contract_test!(

--- a/packages/fuels/tests/wallets.rs
+++ b/packages/fuels/tests/wallets.rs
@@ -13,7 +13,7 @@ async fn test_wallet_balance_api_multi_asset() -> Result<(), Error> {
         amount_per_coin,
     );
 
-    let (provider, _) = setup_test_provider(coins.clone(), vec![], None).await;
+    let (provider, _) = setup_test_provider(coins.clone(), vec![], None, None).await;
     wallet.set_provider(provider);
     let balances = wallet.get_balances().await?;
     assert_eq!(balances.len() as u64, number_of_assets);
@@ -44,7 +44,7 @@ async fn test_wallet_balance_api_single_asset() -> Result<(), Error> {
         amount_per_coin,
     );
 
-    let (provider, _) = setup_test_provider(coins.clone(), vec![], None).await;
+    let (provider, _) = setup_test_provider(coins.clone(), vec![], None, None).await;
     wallet.set_provider(provider);
 
     for (_utxo_id, coin) in coins {


### PR DESCRIPTION
###### Description of changes

Enables passing a `ChainConfig` parameter to all test helpers related to node setup. 