### PR TITLE
fuel-core v0.14 tai64 timestamp support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
   RUSTFLAGS: "-D warnings"
-  FUEL_CORE_VERSION: 0.13.2
+  FUEL_CORE_VERSION: 0.14.0
   RUST_VERSION: 1.64.0
   FORC_VERSION: 0.30.0
 

--- a/packages/fuels-contract/Cargo.toml
+++ b/packages/fuels-contract/Cargo.toml
@@ -11,7 +11,7 @@ description = "Fuel Rust SDK contracts."
 [dependencies]
 anyhow = "1"
 bytes = { version = "1.0.1", features = ["serde"] }
-fuel-gql-client = { version = "0.13", default-features = false }
+fuel-gql-client = { version = "0.14", default-features = false }
 fuel-tx = "0.23"
 fuels-core = { version = "0.29.0", path = "../fuels-core" }
 fuels-signers = { version = "0.29.0", path = "../fuels-signers" }

--- a/packages/fuels-signers/Cargo.toml
+++ b/packages/fuels-signers/Cargo.toml
@@ -13,9 +13,9 @@ async-trait = { version = "0.1.50", default-features = false }
 bytes = { version = "1.1.0", features = ["serde"] }
 elliptic-curve = { version = "0.11.6", default-features = false }
 eth-keystore = { version = "0.3.0" }
-fuel-core = { version = "0.13", default-features = false, optional = true }
+fuel-core = { version = "0.14", default-features = false, optional = true }
 fuel-crypto = { version = "0.6", features = ["random"] }
-fuel-gql-client = { version = "0.13", default-features = false }
+fuel-gql-client = { version = "0.14", default-features = false }
 fuel-types = { version = "0.5", default-features = false, features = ["random"] }
 fuels-core = { version = "0.29.0", path = "../fuels-core" }
 fuels-types = { version = "0.29.0", path = "../fuels-types" }

--- a/packages/fuels-test-helpers/Cargo.toml
+++ b/packages/fuels-test-helpers/Cargo.toml
@@ -10,10 +10,10 @@ description = "Fuel Rust SDK test helpers."
 
 [dependencies]
 anyhow = { version = "1.0.58" }
-fuel-core = { version = "0.13", default-features = false, optional = true }
-fuel-chain-config = { version = "0.13", default-features = false }
-fuel-core-interfaces = { version = "0.13", default-features = false }
-fuel-gql-client = { version = "0.13", default-features = false }
+fuel-core = { version = "0.14", default-features = false, optional = true }
+fuel-chain-config = { version = "0.14", default-features = false }
+fuel-core-interfaces = { version = "0.14", default-features = false }
+fuel-gql-client = { version = "0.14", default-features = false }
 fuel-types = { version = "0.5", default-features = false, features = ["random"] }
 fuels-contract = { version = "0.29.0", path = "../fuels-contract" }
 fuels-core = { version = "0.29.0", path = "../fuels-core" }

--- a/packages/fuels/Cargo.toml
+++ b/packages/fuels/Cargo.toml
@@ -10,8 +10,8 @@ rust-version = "1.64.0"
 description = "Fuel Rust SDK."
 
 [dependencies]
-fuel-core = { version = "0.13", default-features = false, optional = true }
-fuel-gql-client = { version = "0.13", default-features = false }
+fuel-core = { version = "0.14", default-features = false, optional = true }
+fuel-gql-client = { version = "0.14", default-features = false }
 fuels-abigen-macro = { version = "0.29.0", path = "../fuels-abigen-macro" }
 fuels-contract = { version = "0.29.0", path = "../fuels-contract" }
 fuels-core = { version = "0.29.0", path = "../fuels-core" }
@@ -22,9 +22,9 @@ fuels-types = { version = "0.29.0", path = "../fuels-types" }
 [dev-dependencies]
 anyhow = "1.0.58"
 ctor = " 0.1"
-fuel-core = { version = "0.13", default-features = false }
-fuel-core-interfaces = { version = "0.13", default-features = false }
-fuel-gql-client = { version = "0.13", default-features = false }
+fuel-core = { version = "0.14", default-features = false }
+fuel-core-interfaces = { version = "0.14", default-features = false }
+fuel-gql-client = { version = "0.14", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 sha2 = "0.9.5"
 tokio = "1.15.0"


### PR DESCRIPTION
###### Description of changes

Update fuels-rs to the latest fuel-core v0.14. This release was necessary to unblock the bridging team as fuel-core was incorrectly using datetime strings instead of tai64 when representing time. No breaking changes to the VM or forc like fuel-core v0.13, so this is a very lightweight update.
