### PR TITLE
chore: remove unused anchors

### DIFF
--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -182,7 +182,6 @@ mod tests {
 
     #[tokio::test]
     async fn deploy_with_multiple_wallets() -> Result<(), Error> {
-        // ANCHOR: deploy_with_multiple_wallets
         use fuels::prelude::*;
 
         abigen!(
@@ -232,7 +231,6 @@ mod tests {
             .await?;
 
         assert_eq!(42, response.value);
-        // ANCHOR_END: deploy_with_multiple_wallets
         Ok(())
     }
 
@@ -254,10 +252,8 @@ mod tests {
         )
         .await?;
         println!("Contract deployed @ {contract_id}");
-        // ANCHOR: instantiate_contract
         // ANCHOR: tx_parameters
         let contract_methods = MyContract::new(contract_id.clone(), wallet.clone()).methods();
-        // ANCHOR_END: instantiate_contract
 
         // In order: gas_price, gas_limit, and maturity
         let my_tx_params = TxParameters::new(None, Some(1_000_000), None);
@@ -372,10 +368,7 @@ mod tests {
         .await?;
         let contract_methods = TestContract::new(contract_id, wallet).methods();
 
-        // ANCHOR: good_practice
         let response = contract_methods.increment_counter(162).call().await?;
-        // ANCHOR_END: good_practice
-        // ANCHOR: contract_receipts
         let response = contract_methods.increment_counter(162).call().await;
         match response {
             // The transaction is valid and executes to completion
@@ -398,7 +391,6 @@ mod tests {
             }
             Err(_) => {}
         }
-        // ANCHOR_END: contract_receipts
         // ANCHOR: deployed_contracts
         // Replace with your contract ABI.json path
         abigen!(

--- a/examples/cookbook/src/lib.rs
+++ b/examples/cookbook/src/lib.rs
@@ -116,7 +116,6 @@ mod tests {
 
     #[tokio::test]
     async fn transfer_multiple() -> Result<(), Error> {
-        // ANCHOR: transfer_multiple
         use fuels::prelude::*;
         use std::str::FromStr;
 
@@ -170,7 +169,6 @@ mod tests {
         }
         // ANCHOR_END: transfer_multiple_transaction
 
-        // ANCHOR_END: transfer_multiple
         Ok(())
     }
 }

--- a/packages/fuels/tests/bindings.rs
+++ b/packages/fuels/tests/bindings.rs
@@ -37,7 +37,6 @@ async fn compile_bindings_from_contract_file() {
 
 #[tokio::test]
 async fn compile_bindings_from_inline_contract() -> Result<(), Error> {
-    // ANCHOR: bindings_from_inline_contracts
     // Generates the bindings from the an ABI definition inline.
     // The generated bindings can be accessed through `SimpleContract`.
     abigen!(
@@ -93,7 +92,6 @@ async fn compile_bindings_from_inline_contract() -> Result<(), Error> {
     );
 
     assert_eq!("000000009593586c000000000000002a", encoded);
-    // ANCHOR_END: bindings_from_inline_contracts
     Ok(())
 }
 

--- a/packages/fuels/tests/contracts/msg_amount/src/main.sw
+++ b/packages/fuels/tests/contracts/msg_amount/src/main.sw
@@ -2,7 +2,6 @@ contract;
 
 use std::context::msg_amount;
 
-// ANCHOR: msg_amount_contract
 abi FuelTest {
     fn get_msg_amount() -> u64;
 }
@@ -12,4 +11,3 @@ impl FuelTest for Contract {
         msg_amount()
     }
 }
-// ANCHOR_END: msg_amount_contract

--- a/packages/fuels/tests/storage.rs
+++ b/packages/fuels/tests/storage.rs
@@ -11,14 +11,11 @@ async fn test_storage_initialization() -> Result<(), Error> {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    // ANCHOR: storage_slot_create
     let key = Bytes32::from([1u8; 32]);
     let value = Bytes32::from([2u8; 32]);
     let storage_slot = StorageSlot::new(key, value);
     let storage_vec = vec![storage_slot.clone()];
-    // ANCHOR_END: storage_slot_create
 
-    // ANCHOR: manual_storage
     let contract_id = Contract::deploy_with_parameters(
         "tests/storage/contract_storage_test/out/debug/contract_storage_test.bin",
         &wallet,
@@ -27,7 +24,6 @@ async fn test_storage_initialization() -> Result<(), Error> {
         Salt::from([0; 32]),
     )
     .await?;
-    // ANCHOR_END: manual_storage
 
     let contract_instance = MyContract::new(contract_id, wallet.clone());
 
@@ -51,7 +47,6 @@ async fn test_init_storage_automatically() -> Result<(), Error> {
 
     let wallet = launch_provider_and_get_wallet().await;
 
-    // ANCHOR: automatic_storage
     let contract_id = Contract::deploy_with_parameters(
         "tests/storage/contract_storage_test/out/debug/contract_storage_test.bin",
         &wallet,
@@ -61,7 +56,6 @@ async fn test_init_storage_automatically() -> Result<(), Error> {
         Salt::default(),
     )
         .await?;
-    // ANCHOR_END: automatic_storage
 
     let key1 =
         Bytes32::from_str("de9090cb50e71c2588c773487d1da7066d0c719849a7e58dc8b6397a25c567c0")

--- a/scripts/check-docs/src/lib.rs
+++ b/scripts/check-docs/src/lib.rs
@@ -4,16 +4,20 @@ use regex::Regex;
 use std::path::{Path, PathBuf};
 
 pub fn report_errors(error_type: &str, errors: &[Error]) {
-    eprintln!("\n\nInvalid {error_type} detected!");
-    for error in errors {
-        eprintln!("\n{error}")
+    if !errors.is_empty() {
+        eprintln!("\nInvalid {error_type} detected!\n");
+        for error in errors {
+            eprintln!("{error}\n")
+        }
     }
 }
 
 pub fn report_warnings(warnings: &[Error]) {
-    eprintln!("\n\nWarnings detected!");
-    for warning in warnings {
-        eprintln!("\n{warning}")
+    if !warnings.is_empty() {
+        eprintln!("\nWarnings detected!\n");
+        for warning in warnings {
+            eprintln!("{warning}\n")
+        }
     }
 }
 
@@ -73,7 +77,10 @@ pub fn parse_includes(text_w_includes: String) -> (Vec<Include>, Vec<Error>) {
                 let the_path = include_file.parent().unwrap().join(anchor_file);
 
                 let anchor_file = the_path.canonicalize().map_err(|err| {
-                    anyhow!("{the_path:?} when canonicalized gives error {err:?}")
+                    anyhow!(
+                        "{the_path:?} when canonicalized gives error {err:?}\ninclude_file: {:?}",
+                        include_file
+                    )
                 })?;
 
                 Ok(Include {

--- a/scripts/check-docs/src/main.rs
+++ b/scripts/check-docs/src/main.rs
@@ -1,9 +1,8 @@
-use crate::lib::{
+use anyhow::{bail, Error};
+use check_docs::{
     extract_starts_and_ends, filter_valid_anchors, parse_includes, report_errors, report_warnings,
     search_for_patterns_in_project, validate_includes,
 };
-use anyhow::{bail, Error};
-pub mod lib;
 
 fn main() -> anyhow::Result<(), Error> {
     let text_w_anchors = search_for_patterns_in_project("ANCHOR")?;
@@ -17,15 +16,15 @@ fn main() -> anyhow::Result<(), Error> {
 
     let (include_errors, additional_warnings) = validate_includes(includes, valid_anchors);
 
-    if !additional_warnings.is_empty() {
-        report_warnings(&additional_warnings);
-    }
+    report_warnings(&additional_warnings);
+
+    report_errors("include paths", &include_path_errors);
+    report_errors("anchors", &anchor_errors);
+    report_errors("includes", &include_errors);
 
     if !anchor_errors.is_empty() || !include_errors.is_empty() || !include_path_errors.is_empty() {
-        report_errors("include paths", &include_path_errors);
-        report_errors("anchors", &anchor_errors);
-        report_errors("includes", &include_errors);
         bail!("Finished with errors");
     }
+
     Ok(())
 }


### PR DESCRIPTION
The `check-docs` is warning that we have 10 unused anchors in our docs. They are:

```shell
line_no: 185, name: "deploy_with_multiple_wallets",   file: "/examples/contracts/src/lib.rs"
line_no: 257, name: "instantiate_contract",           file: "/examples/contracts/src/lib.rs"
line_no: 375, name: "good_practice",                  file: "/examples/contracts/src/lib.rs"
line_no: 378, name: "contract_receipts",              file: "/examples/contracts/src/lib.rs"
line_no: 119, name: "transfer_multiple",              file: "/examples/cookbook/src/lib.rs"
line_no: 5,   name: "msg_amount_contract",            file: "/packages/fuels/tests/contracts/msg_amount/src/main.sw"
line_no: 14,  name: "storage_slot_create",            file: "/packages/fuels/tests/storage.rs"
line_no: 21,  name: "manual_storage",                 file: "/packages/fuels/tests/storage.rs"
line_no: 54,  name: "automatic_storage",              file: "/packages/fuels/tests/storage.rs"
line_no: 40,  name: "bindings_from_inline_contracts", file: "/packages/fuels/tests/bindings.rs"
```
I have would like to remove them but it seems that some could stay. Can we use this PR to agree on what needs to stay and I will open additional issues to update our documentation.

I have also made some small updates to the script to improve error outputs.