### PR TITLE
chore: update `deploy_with_parameters` in docs

### DIFF
--- a/docs/src/api/contracts.md
+++ b/docs/src/api/contracts.md
@@ -1,1 +1,0 @@
-# Contracts

--- a/docs/src/api/providers.md
+++ b/docs/src/api/providers.md
@@ -1,1 +1,0 @@
-# Providers

--- a/docs/src/api/wallets.md
+++ b/docs/src/api/wallets.md
@@ -1,1 +1,0 @@
-# Wallets

--- a/docs/src/getting-started/contracts.md
+++ b/docs/src/getting-started/contracts.md
@@ -13,7 +13,7 @@ Below is how you can deploy your contracts using the SDK. For more details about
 There are two intended ways to deploy a contract
 
 - `deploy`
-- `deploy_with_salt`
+- `deploy_with_parameters`
 
 If you are only interested in a single instance of your contract, then use `deploy`
 
@@ -27,7 +27,7 @@ You can then use the contract methods very simply:
 {{#include ../../../examples/contracts/src/lib.rs:use_deployed_contract}}
 ```
 
-Alternatively, if you want multiple instances of the same contract then use `deploy_with_salt`
+Alternatively, if you want multiple instances of the same contract then use `deploy_with_parameters` and set the salt parameter.
 
 ```rust,ignore
 {{#include ../../../examples/contracts/src/lib.rs:deploy_with_parameters}}

--- a/docs/src/workspaces/fuels-abi-cli.md
+++ b/docs/src/workspaces/fuels-abi-cli.md
@@ -1,1 +1,0 @@
-# fuels-abi-cli

--- a/docs/src/workspaces/fuels-abigen-macro.md
+++ b/docs/src/workspaces/fuels-abigen-macro.md
@@ -1,1 +1,0 @@
-# fuels-abigen-macro

--- a/docs/src/workspaces/index.md
+++ b/docs/src/workspaces/index.md
@@ -1,1 +1,0 @@
-# fuels-rs Rust Workspaces


### PR DESCRIPTION
This PR replaces `deploy_with_salt` with `deploy_with_parameters` in the docs. This was done by @MujkicA already in PR: https://github.com/FuelLabs/fuels-rs/pull/441 but is was probably missed when we did the big book update. 

In addition, I removed unused `.md` files from the docs.