### PR TITLE
docs(fuels-{contract,core}): minor updates

### DIFF
--- a/packages/fuels-contract/src/contract_calls_utils.rs
+++ b/packages/fuels-contract/src/contract_calls_utils.rs
@@ -16,7 +16,7 @@ use std::{iter, vec};
 use crate::contract::ContractCall;
 
 #[derive(Default)]
-/// Specifies offsets of Opcode::CALL parameters stored in the script
+/// Specifies offsets of [`Opcode::CALL`] parameters stored in the script
 /// data from which they can be loaded into registers
 pub(crate) struct CallOpcodeParamsOffset {
     pub asset_id_offset: usize,
@@ -63,12 +63,12 @@ pub(crate) fn get_instructions(
 }
 
 /// Returns script data, consisting of the following items in the given order:
-/// 1. Asset ID to be forwarded (AmountId::LEN)
-/// 2. Amount to be forwarded (1 * WORD_SIZE)
-/// 3. Gas to be forwarded (1 * WORD_SIZE)
-/// 4. Contract ID (ContractID::LEN);
-/// 5. Function selector (1 * WORD_SIZE);
-/// 6. Calldata offset (optional) (1 * WORD_SIZE)
+/// 1. Asset ID to be forwarded ([`AssetId::LEN`])
+/// 2. Amount to be forwarded `(1 * `[`WORD_SIZE`]`)`
+/// 3. Gas to be forwarded `(1 * `[`WORD_SIZE`]`)`
+/// 4. Contract ID ([`ContractId::LEN`]);
+/// 5. Function selector `(1 * `[`WORD_SIZE`]`)`
+/// 6. Calldata offset (optional) `(1 * `[`WORD_SIZE`]`)`
 /// 7. Encoded arguments (optional) (variable length)
 pub(crate) fn build_script_data_from_contract_calls(
     calls: &[ContractCall],
@@ -129,8 +129,8 @@ pub(crate) fn build_script_data_from_contract_calls(
 }
 
 /// Returns the VM instructions for calling a contract method
-/// We use the Opcode to call a contract: `CALL` pointing at the
-/// following registers;
+/// We use the [`Opcode`] to call a contract: [`CALL`](Opcode::CALL)
+/// pointing at the following registers:
 ///
 /// 0x10 Script data offset
 /// 0x11 Gas forwarded
@@ -154,8 +154,8 @@ fn get_single_call_instructions(offsets: &CallOpcodeParamsOffset) -> Vec<u8> {
     instructions.iter().copied().collect::<Vec<u8>>()
 }
 
-/// Returns the assets and contracts that will be consumed (inputs) and created (outputs)
-/// by the transaction
+/// Returns the assets and contracts that will be consumed ([`Input`]s)
+/// and created ([`Output`]s) by the transaction
 pub(crate) fn get_transaction_inputs_outputs(
     calls: &[ContractCall],
     wallet_address: &Bech32Address,

--- a/packages/fuels-contract/src/execution_script.rs
+++ b/packages/fuels-contract/src/execution_script.rs
@@ -19,7 +19,7 @@ use crate::contract_calls_utils::{
     get_instructions, get_transaction_inputs_outputs,
 };
 
-/// TransactionExecution provides methods to create and call/simulate a transaction that carries
+/// [`TransactionExecution`] provides methods to create and call/simulate a transaction that carries
 /// out contract method calls or script calls
 #[derive(Debug)]
 pub struct TransactionExecution {
@@ -31,7 +31,7 @@ impl TransactionExecution {
         Self { tx }
     }
 
-    /// Creates a TransactionExecution from contract calls. The internal Transaction is
+    /// Creates a [`TransactionExecution`] from contract calls. The internal [`Transaction`] is
     /// initialized with the actual script instructions, script data needed to perform the call and
     /// transaction inputs/outputs consisting of assets and contracts.
     pub async fn from_contract_calls(

--- a/packages/fuels-contract/src/script_calls.rs
+++ b/packages/fuels-contract/src/script_calls.rs
@@ -29,7 +29,9 @@ pub struct ScriptCallResponse<D> {
 }
 
 impl<D> ScriptCallResponse<D> {
-    /// Get the gas used from ScriptResult receipt
+    /// Get the gas used from [`ScriptResult`] receipt
+    ///
+    /// [`ScriptResult`]: Receipt::ScriptResult
     fn get_gas_used(receipts: &[Receipt]) -> u64 {
         receipts
             .iter()
@@ -112,8 +114,11 @@ where
 
     /// Sets the transaction parameters for a given transaction.
     /// Note that this is a builder method, i.e. use it as a chain:
+    ///
+    /// ```ignore
     /// let params = TxParameters { gas_price: 100, gas_limit: 1000000 };
-    /// `instance.main(...).tx_params(params).call()`.
+    /// instance.main(...).tx_params(params).call()
+    /// ```
     pub fn tx_params(mut self, params: TxParameters) -> Self {
         self.tx_parameters = params;
         self
@@ -129,12 +134,11 @@ where
         self
     }
 
-    /// Call a script on the node. If `simulate==true`, then the call is done in a
-    /// read-only manner, using a `dry-run`. Return a Result<ScriptCallResponse, Error>. The ScriptCallResponse
-    /// struct contains the main's value in its `value` field as an actual typed value `D` (if
-    /// your method returns `bool`, it will be a bool, works also for structs thanks to the
-    /// `script_abigen!()`). The other field of ScriptCallResponse, `receipts`, contains the receipts of the
-    /// transaction.
+    /// Call a script on the node. If `simulate == true`, then the call is done in a
+    /// read-only manner, using a `dry-run`. The [`ScriptCallResponse`] struct contains the `main`'s value
+    /// in its `value` field as an actual typed value `D` (if your method returns `bool`,
+    /// it will be a bool, works also for structs thanks to the `abigen!()`).
+    /// The other field of [`ScriptCallResponse`], `receipts`, contains the receipts of the transaction.
     #[tracing::instrument]
     async fn call_or_simulate(&self, simulate: bool) -> Result<ScriptCallResponse<D>, Error> {
         let mut tx = Transaction::script(
@@ -168,12 +172,14 @@ where
 
     /// Call a script on the node, in a simulated manner, meaning the state of the
     /// blockchain is *not* modified but simulated.
-    /// It is the same as the `call` method because the API is more user-friendly this way.
+    /// It is the same as the [`call`] method because the API is more user-friendly this way.
+    ///
+    /// [`call`]: Self::call
     pub async fn simulate(self) -> Result<ScriptCallResponse<D>, Error> {
         Self::call_or_simulate(&self, true).await
     }
 
-    /// Create a ScriptCallResponse from call receipts
+    /// Create a [`ScriptCallResponse`] from call receipts
     pub fn get_response(&self, mut receipts: Vec<Receipt>) -> Result<ScriptCallResponse<D>, Error> {
         let token = get_decoded_output(&mut receipts, None, &self.output_param)?;
         Ok(ScriptCallResponse::new(D::from_token(token)?, receipts))

--- a/packages/fuels-core/src/abi_encoder.rs
+++ b/packages/fuels-core/src/abi_encoder.rs
@@ -90,7 +90,7 @@ impl UnresolvedBytes {
 
 impl ABIEncoder {
     /// Encodes `Token`s in `args` following the ABI specs defined
-    /// https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md
+    /// [here](https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md)
     pub fn encode(args: &[Token]) -> Result<UnresolvedBytes, CodecError> {
         let data = Self::encode_tokens(args)?;
 

--- a/packages/fuels-core/src/code_gen/functions_gen.rs
+++ b/packages/fuels-core/src/code_gen/functions_gen.rs
@@ -13,14 +13,17 @@ use std::collections::HashMap;
 
 /// Functions used by the Abigen to expand functions defined in an ABI spec.
 
-/// Transforms a function defined in [`Function`] into a [`TokenStream`]
+/// Transforms a function defined in [`ABIFunction`] into a [`TokenStream`]
 /// that represents that same function signature as a Rust-native function
 /// declaration.
-/// The actual logic inside the function is the function `method_hash` under
-/// [`Contract`], which is responsible for encoding the function selector
-/// and the function parameters that will be used in the actual contract call.
 ///
-/// [`Contract`]: crate::contract::Contract
+/// The actual logic inside the function is the function `method_hash` under
+/// [`Contract`], which is responsible for encoding
+/// the function selector and the function parameters that will be used
+/// in the actual contract call.
+///
+/// [`Contract`]: fuels_contract::contract::Contract
+// TODO (oleksii/docs): linkify the above `Contract` link properly
 pub fn expand_function(
     function: &ABIFunction,
     types: &HashMap<usize, TypeDeclaration>,

--- a/packages/fuels-signers/src/wallet.rs
+++ b/packages/fuels-signers/src/wallet.rs
@@ -82,7 +82,6 @@ pub struct Wallet {
 ///   Ok(())
 /// }
 /// ```
-/// [`Signature`]: fuels_core::signature::Signature
 #[derive(Clone, Debug)]
 pub struct WalletUnlocked {
     wallet: Wallet,

--- a/packages/fuels-types/src/lib.rs
+++ b/packages/fuels-types/src/lib.rs
@@ -21,9 +21,8 @@ pub enum CustomType {
     Enum,
 }
 
-/// FuelVM ABI representation in JSON, originally specified here:
-///
-/// https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md
+/// FuelVM ABI representation in JSON, originally specified
+/// [here](https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md).
 ///
 /// This type may be used by compilers and related tooling to convert an ABI
 /// representation into native Rust structs and vice-versa.


### PR DESCRIPTION
###### Description of changes

> **Note** that this PR targets #620 (`iqdecay/feat-script-main-args`), as it is a byproduct of my review of #620.

- properly linkify some intra-doc links to Rust items 
- fix some improperly formatted links (e.g. bare URLs)

Tested with `cargo doc --document-private-items -p fuels-{contract,core}`.

<!-- Please mention:
- the issue(s) this PR closes
- any docs/collaterals that need to be updated (e.g. Sway book)
-->
