### PR TITLE
ci: update `forc` and `rustc` version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
   RUSTFLAGS: "-D warnings"
   FUEL_CORE_VERSION: 0.14.1
-  RUST_VERSION: 1.65.0
+  RUST_VERSION: 1.64.0
   FORC_VERSION: 0.31.1
   FORC_PATCH_BRANCH: ""
   FORC_PATCH_REVISION: ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ env:
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
   RUSTFLAGS: "-D warnings"
   FUEL_CORE_VERSION: 0.14.1
-  RUST_VERSION: 1.64.0
-  FORC_VERSION: 0.30.1
+  RUST_VERSION: 1.65.0
+  FORC_VERSION: 0.31.1
   FORC_PATCH_BRANCH: ""
   FORC_PATCH_REVISION: ""
 

--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -131,7 +131,7 @@ mod tests {
             .await?;
         // ANCHOR_END: contract_call_cost_estimation
 
-        assert_eq!(transaction_cost.gas_used, 7146);
+        assert_eq!(transaction_cost.gas_used, 9826);
 
         Ok(())
     }
@@ -547,7 +547,7 @@ mod tests {
             .await?;
         // ANCHOR_END: multi_call_cost_estimation
 
-        assert_eq!(transaction_cost.gas_used, 15176);
+        assert_eq!(transaction_cost.gas_used, 16181);
 
         Ok(())
     }


### PR DESCRIPTION
This PR updates the FORC_VERSION and RUST_VERSION constants in CI, and updates the expected test gas values accordingly.
