### PR TITLE
fix: support empty structs

### DIFF
--- a/packages/fuels-core/src/code_gen/custom_types/enum_gen.rs
+++ b/packages/fuels-core/src/code_gen/custom_types/enum_gen.rs
@@ -21,6 +21,12 @@ pub fn expand_custom_enum(
     let enum_ident = ident(&custom_type_name(&type_decl.type_field)?);
 
     let components = extract_components(type_decl, types, false)?;
+    if components.is_empty() {
+        return Err(Error::InvalidData(
+            "Enum must have at least one component!".into(),
+        ));
+    }
+
     let generics = extract_generic_parameters(type_decl, types)?;
 
     let enum_def = enum_decl(&enum_ident, &components, &generics);

--- a/packages/fuels-core/src/code_gen/custom_types/utils.rs
+++ b/packages/fuels-core/src/code_gen/custom_types/utils.rs
@@ -1,6 +1,5 @@
 use crate::code_gen::resolved_type::{resolve_type, ResolvedType};
 use crate::utils::{ident, safe_ident};
-use anyhow::anyhow;
 use fuels_types::errors::Error;
 use fuels_types::utils::extract_generic_name;
 use fuels_types::{TypeApplication, TypeDeclaration};
@@ -22,7 +21,7 @@ impl Component {
         component: &TypeApplication,
         types: &HashMap<usize, TypeDeclaration>,
         snake_case: bool,
-    ) -> anyhow::Result<Component> {
+    ) -> Result<Component, Error> {
         let field_name = if snake_case {
             component.name.to_snake_case()
         } else {
@@ -82,16 +81,11 @@ pub(crate) fn extract_components(
     type_decl: &TypeDeclaration,
     types: &HashMap<usize, TypeDeclaration>,
     snake_case: bool,
-) -> anyhow::Result<Vec<Component>> {
-    let components = match &type_decl.components {
-        Some(components) if !components.is_empty() => Ok(components),
-        _ => Err(anyhow!(
-            "Custom type {} must have at least one component!",
-            type_decl.type_field
-        )),
-    }?;
-
-    components
+) -> Result<Vec<Component>, Error> {
+    type_decl
+        .components
+        .as_ref()
+        .unwrap_or(&vec![])
         .iter()
         .map(|component| Component::new(component, types, snake_case))
         .collect()

--- a/packages/fuels-core/src/code_gen/functions_gen.rs
+++ b/packages/fuels-core/src/code_gen/functions_gen.rs
@@ -87,7 +87,7 @@ fn function_arguments(
     fun.inputs
         .iter()
         .map(|input| Component::new(input, types, true))
-        .collect::<Result<Vec<_>, anyhow::Error>>()
+        .collect::<Result<Vec<_>, Error>>()
         .map_err(|e| Error::InvalidType(e.to_string()))
 }
 

--- a/packages/fuels/tests/types.rs
+++ b/packages/fuels/tests/types.rs
@@ -187,6 +187,32 @@ async fn nested_structs() -> Result<(), Error> {
 }
 
 #[tokio::test]
+async fn calls_with_empty_struct() -> Result<(), Error> {
+    setup_contract_test!(
+        contract_instance,
+        wallet,
+        "packages/fuels/tests/types/complex_types_contract"
+    );
+    let contract_methods = contract_instance.methods();
+
+    {
+        let response = contract_methods.get_empty_struct().call().await?;
+
+        assert_eq!(response.value, EmptyStruct {});
+    }
+    {
+        let response = contract_methods
+            .input_empty_struct(EmptyStruct {})
+            .call()
+            .await?;
+
+        assert!(response.value);
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn can_use_try_into_to_construct_struct_from_bytes() -> Result<(), Error> {
     abigen!(
         MyContract,

--- a/packages/fuels/tests/types/complex_types_contract/src/main.sw
+++ b/packages/fuels/tests/types/complex_types_contract/src/main.sw
@@ -2,6 +2,8 @@ contract;
 
 use std::storage::{get, store};
 
+struct EmptyStruct {}
+
 struct CounterConfig {
     dummy: bool,
     initial_value: u64,
@@ -12,6 +14,8 @@ abi TestContract {
     fn initialize_counter(config: CounterConfig) -> u64;
     #[storage(read, write)]
     fn increment_counter(amount: u64) -> u64;
+    fn get_empty_struct() -> EmptyStruct;
+    fn input_empty_struct(es: EmptyStruct) -> bool;
 }
 
 const COUNTER_KEY = 0x0000000000000000000000000000000000000000000000000000000000000000;
@@ -29,5 +33,16 @@ impl TestContract for Contract {
         let value = get::<u64>(COUNTER_KEY) + amount;
         store(COUNTER_KEY, value);
         value
+    }
+
+    fn get_empty_struct() -> EmptyStruct {
+        EmptyStruct {}
+    }
+
+    fn input_empty_struct(es: EmptyStruct) -> bool {
+        if let EmptyStruct {} = es {
+            return true;
+        }
+        false
     }
 }


### PR DESCRIPTION
Structs can now be empty.

- Updated `code_gen` unit tests
- Added integration test