### PR TITLE
Setting a temporarily no-verify to true so we can bypass the cyclic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,4 +241,5 @@ jobs:
         uses: katyo/publish-crates@v1
         with:
           publish-delay: 30000
+          no-verify: true
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Setting a temporarily no-verify to true so we can bypass the cyclic dependency detection. We need this to publish the `0.32` version, which failed at the publish stage.

We can properly address this later (asap) once `0.32` is out.