### PR TITLE
feat: Add `messagesTypes` to ProgramABI

### DIFF
--- a/packages/fuels-types/src/lib.rs
+++ b/packages/fuels-types/src/lib.rs
@@ -40,6 +40,7 @@ pub struct ProgramABI {
     pub types: Vec<TypeDeclaration>,
     pub functions: Vec<ABIFunction>,
     pub logged_types: Option<Vec<LoggedType>>,
+    pub messages_types: Option<Vec<MessageType>>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -74,6 +75,14 @@ pub struct TypeApplication {
 pub struct LoggedType {
     pub log_id: u64,
     #[serde(rename = "loggedType")]
+    pub application: TypeApplication,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageType {
+    pub message_id: u64,
+    #[serde(rename = "messageType")]
     pub application: TypeApplication,
 }
 


### PR DESCRIPTION
This is needed for https://github.com/FuelLabs/sway/issues/3409. Basically, we want to be able to decode the data sent via `smo`, just like logs, so messages need to store information in the JSON ABI.

Doesn't look like this impacts anything at the moment as everything compiles fine.

Spec change: https://github.com/FuelLabs/fuel-specs/pull/444
Compiler change: https://github.com/FuelLabs/sway/pull/3564 that needs this (currently using a local copy of `fuels-rs`)