### PR TITLE
Update to fuel-core v0.15.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
   RUSTFLAGS: "-D warnings"
-  FUEL_CORE_VERSION: 0.15.0
+  FUEL_CORE_VERSION: 0.15.1
   RUST_VERSION: 1.64.0
   FORC_VERSION: 0.31.1
   FORC_PATCH_BRANCH: ""

--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -131,7 +131,7 @@ mod tests {
             .await?;
         // ANCHOR_END: contract_call_cost_estimation
 
-        assert_eq!(transaction_cost.gas_used, 7146);
+        assert_eq!(transaction_cost.gas_used, 9826);
 
         Ok(())
     }
@@ -547,7 +547,7 @@ mod tests {
             .await?;
         // ANCHOR_END: multi_call_cost_estimation
 
-        assert_eq!(transaction_cost.gas_used, 15176);
+        assert_eq!(transaction_cost.gas_used, 16181);
 
         Ok(())
     }

--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -131,7 +131,7 @@ mod tests {
             .await?;
         // ANCHOR_END: contract_call_cost_estimation
 
-        assert_eq!(transaction_cost.gas_used, 9826);
+        assert_eq!(transaction_cost.gas_used, 7146);
 
         Ok(())
     }
@@ -547,7 +547,7 @@ mod tests {
             .await?;
         // ANCHOR_END: multi_call_cost_estimation
 
-        assert_eq!(transaction_cost.gas_used, 16181);
+        assert_eq!(transaction_cost.gas_used, 15176);
 
         Ok(())
     }


### PR DESCRIPTION
###### Description of changes

Update to latest fuel-core v0.15.1 - fixes CI

In local testing I thought there was a problem with estimated gas costs, but it seems using the latest fuel-core binary was all that was needed to resolve the CI issues.