### PR TITLE
release: Bump versions to `0.33.0`

### DIFF
--- a/docs/src/providers/short-lived.md
+++ b/docs/src/providers/short-lived.md
@@ -27,5 +27,5 @@ let wallet = launch_provider_and_get_wallet().await;
 The `fuel-core-lib` is a feature defined in the `fuels` library, allowing us to run a `fuel-core` node without installing the `fuel-core` binary on the local machine. Using the `fuel-core-lib` feature flag entails downloading all the dependencies needed to run the fuel-core node.
 
 ```rust,ignore
-fuels = { version = "0.32.3", features = ["fuel-core-lib"] }
+fuels = { version = "0.33.0", features = ["fuel-core-lib"] }
 ```

--- a/examples/contracts/Cargo.toml
+++ b/examples/contracts/Cargo.toml
@@ -11,7 +11,7 @@ description = "Fuel Rust SDK contract examples."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fuels = { version = "0.32.3", path = "../../packages/fuels" }
+fuels = { version = "0.33.0", path = "../../packages/fuels" }
 rand = "0.8"
 tokio = { version = "1.10", features = ["full"] }
 

--- a/examples/cookbook/Cargo.toml
+++ b/examples/cookbook/Cargo.toml
@@ -10,6 +10,6 @@ repository = "https://github.com/FuelLabs/fuels-rs"
 description = "Fuel Rust SDK cookbook examples."
 
 [dependencies]
-fuels = { version = "0.32.3", path = "../../packages/fuels" }
+fuels = { version = "0.33.0", path = "../../packages/fuels" }
 rand = "0.8"
 tokio = { version = "1.10", features = ["full"] }

--- a/examples/debugging/Cargo.toml
+++ b/examples/debugging/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/FuelLabs/fuels-rs"
 description = "Fuel Rust SDK debugging examples."
 
 [dependencies]
-fuels = { version = "0.32.3", path = "../../packages/fuels" }
+fuels = { version = "0.33.0", path = "../../packages/fuels" }
 rand = "0.8.5"
 tokio = { version = "1.10", features = ["full"] }
 

--- a/examples/predicates/Cargo.toml
+++ b/examples/predicates/Cargo.toml
@@ -10,6 +10,6 @@ repository = "https://github.com/FuelLabs/fuels-rs"
 description = "Fuel Rust SDK cookbook examples."
 
 [dependencies]
-fuels = { version = "0.32.3", path = "../../packages/fuels" }
+fuels = { version = "0.33.0", path = "../../packages/fuels" }
 rand = "0.8"
 tokio = { version = "1.10", features = ["full"] }

--- a/examples/providers/Cargo.toml
+++ b/examples/providers/Cargo.toml
@@ -10,6 +10,6 @@ repository = "https://github.com/FuelLabs/fuels-rs"
 description = "Fuel Rust SDK provider examples."
 
 [dependencies]
-fuels = { version = "0.32.3", path = "../../packages/fuels" }
+fuels = { version = "0.33.0", path = "../../packages/fuels" }
 rand = "0.8.5"
 tokio = { version = "1.10", features = ["full"] }

--- a/examples/rust_bindings/Cargo.toml
+++ b/examples/rust_bindings/Cargo.toml
@@ -11,8 +11,8 @@ description = "Fuel Rust SDK examples for Rust-native bindings"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fuels = { version = "0.32.3", path = "../../packages/fuels" }
-fuels-abigen-macro = { version = "0.32.3", path = "../../packages/fuels-abigen-macro" }
+fuels = { version = "0.33.0", path = "../../packages/fuels" }
+fuels-abigen-macro = { version = "0.33.0", path = "../../packages/fuels-abigen-macro" }
 proc-macro2 = "1.0"
 rand = "0.8"
 tokio = { version = "1.10", features = ["full"] }

--- a/examples/types/Cargo.toml
+++ b/examples/types/Cargo.toml
@@ -11,6 +11,6 @@ description = "Fuel Rust SDK types examples."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fuels = { version = "0.32.3", path = "../../packages/fuels" }
+fuels = { version = "0.33.0", path = "../../packages/fuels" }
 rand = "0.8"
 tokio = { version = "1.10", features = ["full"] }

--- a/examples/wallets/Cargo.toml
+++ b/examples/wallets/Cargo.toml
@@ -10,6 +10,6 @@ repository = "https://github.com/FuelLabs/fuels-rs"
 description = "Fuel Rust SDK wallet examples."
 
 [dependencies]
-fuels = { version = "0.32.3", path = "../../packages/fuels" }
+fuels = { version = "0.33.0", path = "../../packages/fuels" }
 rand = "0.8.5"
 tokio = { version = "1.10", features = ["full"] }

--- a/packages/fuels-abigen-macro/Cargo.toml
+++ b/packages/fuels-abigen-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuels-abigen-macro"
-version = "0.32.3"
+version = "0.33.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -13,7 +13,7 @@ proc-macro = true
 
 [dependencies]
 Inflector = "0.11"
-fuels-core = { version = "0.32.3", path = "../fuels-core" }
+fuels-core = { version = "0.33.0", path = "../fuels-core" }
 proc-macro2 = "1.0"
 quote = "1.0"
 rand = "0.8"

--- a/packages/fuels-contract/Cargo.toml
+++ b/packages/fuels-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuels-contract"
-version = "0.32.3"
+version = "0.33.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -13,9 +13,9 @@ anyhow = "1"
 bytes = { version = "1.0.1", features = ["serde"] }
 fuel-gql-client = { version = "0.15", default-features = false }
 fuel-tx = "0.23"
-fuels-core = { version = "0.32.3", path = "../fuels-core" }
-fuels-signers = { version = "0.32.3", path = "../fuels-signers" }
-fuels-types = { version = "0.32.3", path = "../fuels-types" }
+fuels-core = { version = "0.33.0", path = "../fuels-core" }
+fuels-signers = { version = "0.33.0", path = "../fuels-signers" }
+fuels-types = { version = "0.33.0", path = "../fuels-types" }
 futures = "0.3.21"
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 itertools = "0.10.3"

--- a/packages/fuels-core/Cargo.toml
+++ b/packages/fuels-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuels-core"
-version = "0.32.3"
+version = "0.33.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -13,7 +13,7 @@ Inflector = "0.11"
 anyhow = "1"
 fuel-tx = "0.23"
 fuel-types = "0.5"
-fuels-types = { version = "0.32.3", path = "../fuels-types" }
+fuels-types = { version = "0.33.0", path = "../fuels-types" }
 hex = { version = "0.4.3", features = ["std"] }
 itertools = "0.10"
 proc-macro2 = "1.0"
@@ -30,4 +30,4 @@ syn = "1.0.12"
 thiserror = "1.0.30"
 
 [dev-dependencies]
-fuels-test-helpers = { version = "0.32.3", path = "../fuels-test-helpers" }
+fuels-test-helpers = { version = "0.33.0", path = "../fuels-test-helpers" }

--- a/packages/fuels-signers/Cargo.toml
+++ b/packages/fuels-signers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuels-signers"
-version = "0.32.3"
+version = "0.33.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -18,8 +18,8 @@ fuel-core = { version = "0.15", default-features = false, optional = true }
 fuel-crypto = { version = "0.6", features = ["random"] }
 fuel-gql-client = { version = "0.15", default-features = false }
 fuel-types = { version = "0.5", default-features = false, features = ["random"] }
-fuels-core = { version = "0.32.3", path = "../fuels-core" }
-fuels-types = { version = "0.32.3", path = "../fuels-types" }
+fuels-core = { version = "0.33.0", path = "../fuels-core" }
+fuels-types = { version = "0.33.0", path = "../fuels-types" }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 itertools = "0.10"
 rand = { version = "0.8.4", default-features = false }

--- a/packages/fuels-test-helpers/Cargo.toml
+++ b/packages/fuels-test-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuels-test-helpers"
-version = "0.32.3"
+version = "0.33.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -15,10 +15,10 @@ fuel-chain-config = { version = "0.15", default-features = false }
 fuel-core-interfaces = { version = "0.15", default-features = false }
 fuel-gql-client = { version = "0.15", default-features = false }
 fuel-types = { version = "0.5", default-features = false, features = ["random"] }
-fuels-contract = { version = "0.32.3", path = "../fuels-contract" }
-fuels-core = { version = "0.32.3", path = "../fuels-core" }
-fuels-signers = { version = "0.32.3", path = "../fuels-signers", optional = true }
-fuels-types = { version = "0.32.3", path = "../fuels-types" }
+fuels-contract = { version = "0.33.0", path = "../fuels-contract" }
+fuels-core = { version = "0.33.0", path = "../fuels-core" }
+fuels-signers = { version = "0.33.0", path = "../fuels-signers", optional = true }
+fuels-types = { version = "0.33.0", path = "../fuels-types" }
 
 hex = { version = "0.4.3", default-features = false, features = ["std", "serde"] }
 portpicker = { version = "0.1.1" }

--- a/packages/fuels-types/Cargo.toml
+++ b/packages/fuels-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuels-types"
-version = "0.32.3"
+version = "0.33.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/packages/fuels/Cargo.toml
+++ b/packages/fuels/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuels"
-version = "0.32.3"
+version = "0.33.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -12,12 +12,12 @@ description = "Fuel Rust SDK."
 [dependencies]
 fuel-core = { version = "0.15", default-features = false, optional = true }
 fuel-gql-client = { version = "0.15", default-features = false }
-fuels-abigen-macro = { version = "0.32.3", path = "../fuels-abigen-macro" }
-fuels-contract = { version = "0.32.3", path = "../fuels-contract" }
-fuels-core = { version = "0.32.3", path = "../fuels-core" }
-fuels-signers = { version = "0.32.3", path = "../fuels-signers" }
-fuels-test-helpers = { version = "0.32.3", path = "../fuels-test-helpers" }
-fuels-types = { version = "0.32.3", path = "../fuels-types" }
+fuels-abigen-macro = { version = "0.33.0", path = "../fuels-abigen-macro" }
+fuels-contract = { version = "0.33.0", path = "../fuels-contract" }
+fuels-core = { version = "0.33.0", path = "../fuels-core" }
+fuels-signers = { version = "0.33.0", path = "../fuels-signers" }
+fuels-test-helpers = { version = "0.33.0", path = "../fuels-test-helpers" }
+fuels-types = { version = "0.33.0", path = "../fuels-types" }
 
 [dev-dependencies]
 anyhow = "1.0.58"

--- a/tools/fuels-abi-cli/Cargo.toml
+++ b/tools/fuels-abi-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuels-abi-cli"
-version = "0.32.3"
+version = "0.33.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -10,9 +10,9 @@ description = "Fuel Rust SDK CLI tool to parse ABI."
 
 [dependencies]
 anyhow = "1"
-fuels-contract = { version = "0.32.3", path = "../../packages/fuels-contract" }
-fuels-core = { version = "0.32.3", path = "../../packages/fuels-core" }
-fuels-types = { version = "0.32.3", path = "../../packages/fuels-types" }
+fuels-contract = { version = "0.33.0", path = "../../packages/fuels-contract" }
+fuels-core = { version = "0.33.0", path = "../../packages/fuels-core" }
+fuels-types = { version = "0.33.0", path = "../../packages/fuels-types" }
 hex = "0.4"
 itertools = "0.10"
 structopt = "0.3"


### PR DESCRIPTION
The functions attributes feature for JSON ABI breaks compatibility with 0.32 for the Sway compiler because of the changes in `fuels-types`, so the `fuels-rs` version should be corrected from 0.32.3 to 0.33.0.

This changes is following this comment https://github.com/FuelLabs/fuels-rs/pull/749#issuecomment-1354594423 by @mohammadfawaz.