### PR TITLE
Remove --no-verify flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,5 +238,4 @@ jobs:
         uses: katyo/publish-crates@v1
         with:
           publish-delay: 30000
-          no-verify: true
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
The `--no-verify` flag skips the sorting step of the github action we use to publish our crates. This might be causing some publishing issues right now. I'm removing it to experiment whether or not this fixes the publishing issue.