### PR TITLE
docs: update node-beta-1 to node-beta-2

### DIFF
--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -3,7 +3,7 @@
 Rust SDK for Fuel. It can be used for a variety of things, including but not limited to:
 
 - Compiling, deploying, and testing [Sway](https://github.com/FuelLabs/sway) contracts;
-- Use the [Testnet](../providers/external-node.md) or run a local Fuel node;
+- Use the [Testnet](providers/external-node.md) or run a local Fuel node;
 - Crafting and signing transactions with hand-crafted scripts or contract calls;
 - Generating type-safe Rust bindings of contract ABI methods;
 - And more. `fuels-rs` is still in active development.

--- a/docs/src/providers/external-node.md
+++ b/docs/src/providers/external-node.md
@@ -10,7 +10,7 @@ In the code example, we connected a new provider to the Testnet node and created
 
 > **Note:** New wallets on the Testnet will not have any assets! They can be obtained by providing the wallet address to the faucet at
 >
->[faucet-beta-1.fuel.network](https://faucet-beta-1.fuel.network)
+>[faucet-beta-2.fuel.network](https://faucet-beta-2.fuel.network)
 >
 > Once the assets have been transferred to the wallet, you can reuse it in other tests by providing the private key!
 >

--- a/examples/providers/src/lib.rs
+++ b/examples/providers/src/lib.rs
@@ -11,7 +11,7 @@ mod tests {
         use fuels::{prelude::*, signers::fuel_crypto::SecretKey};
 
         // Create a provider pointing to the testnet.
-        let provider = Provider::connect("node-beta-1.fuel.network").await.unwrap();
+        let provider = Provider::connect("node-beta-2.fuel.network").await.unwrap();
 
         // Setup a private key
         let secret =

--- a/packages/fuels/tests/providers.rs
+++ b/packages/fuels/tests/providers.rs
@@ -567,7 +567,7 @@ async fn testnet_hello_world() -> Result<(), Error> {
     ));
 
     // Create a provider pointing to the testnet.
-    let provider = Provider::connect("node-beta-1.fuel.network").await.unwrap();
+    let provider = Provider::connect("node-beta-2.fuel.network").await.unwrap();
 
     // Setup the private key.
     let secret =


### PR DESCRIPTION
Update the `Connecting to the Testnet or an external node` section to refer to beta-2 instead of beta-1

closes #773