### PR TITLE
Methods without #[payable] cannot accept assets

### DIFF
--- a/docs/src/calling-contracts/call-params.md
+++ b/docs/src/calling-contracts/call-params.md
@@ -20,6 +20,14 @@ Then, in Rust, after setting up and deploying the above contract, you can config
 {{#include ../../../examples/contracts/src/lib.rs:call_parameters}}
 ```
 
+`call_params` returns a result to ensure you don't forward assets to a contract method that isn't payable. In the following example, we try to forward an amount of 100 of the base asset to `non_payable`. As its name suggests, `non_payable` isn't annotated with `#[payable]` in the contract code. Passing `CallParameters` with an amount other than 0 leads to an `InvalidCallParameters` error:
+
+```rust,ignore
+{{#include ../../../packages/fuels/tests/contracts.rs:non_payable_params}}
+```
+
+> **Note:** forwarding gas to a contract call is always possible, regardless of the contract method being non-payable.
+
 You can also use `CallParameters::default()` to use the default values:
 
 ```rust,ignore

--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -304,14 +304,14 @@ mod tests {
         let response = contract_methods
             .get_msg_amount() // Our contract method.
             .tx_params(tx_params) // Chain the tx params setting method.
-            .call_params(call_params) // Chain the call params setting method.
+            .call_params(call_params)? // Chain the call params setting method.
             .call() // Perform the contract call.
             .await?;
         // ANCHOR_END: call_parameters
         // ANCHOR: call_parameters_default
         let response = contract_methods
             .initialize_counter(42)
-            .call_params(CallParameters::default())
+            .call_params(CallParameters::default())?
             .call()
             .await?;
 
@@ -577,7 +577,7 @@ mod tests {
         let response = contract_methods
             .get_msg_amount() // Our contract method.
             .tx_params(tx_params) // Chain the tx params setting method.
-            .call_params(call_params) // Chain the call params setting method.
+            .call_params(call_params)? // Chain the call params setting method.
             .call() // Perform the contract call.
             .await?;
         // ANCHOR_END: call_params_gas

--- a/examples/cookbook/src/lib.rs
+++ b/examples/cookbook/src/lib.rs
@@ -53,7 +53,7 @@ mod tests {
         let call_params = CallParameters::new(Some(deposit_amount), Some(base_asset_id), None);
         contract_methods
             .deposit(wallet.address().into())
-            .call_params(call_params)
+            .call_params(call_params)?
             .append_variable_outputs(1)
             .call()
             .await?;
@@ -66,7 +66,7 @@ mod tests {
         let call_params = CallParameters::new(Some(lp_token_balance), Some(lp_asset_id), None);
         contract_methods
             .withdraw(wallet.address().into())
-            .call_params(call_params)
+            .call_params(call_params)?
             .append_variable_outputs(1)
             .call()
             .await?;

--- a/examples/rust_bindings/src/rust_bindings_formatted.rs
+++ b/examples/rust_bindings/src/rust_bindings_formatted.rs
@@ -62,6 +62,7 @@ pub mod abigen_bindings {
                     ),
                     &[Tokenizable::into_token(value)],
                     log_decoder,
+                    false,
                 )
                 .expect("method not found (this should never happen)")
             }
@@ -81,6 +82,7 @@ pub mod abigen_bindings {
                     ),
                     &[Tokenizable::into_token(value)],
                     log_decoder,
+                    false,
                 )
                 .expect("method not found (this should never happen)")
             }

--- a/packages/fuels-macros/src/abigen_macro/code_gen/abigen/bindings/contract.rs
+++ b/packages/fuels-macros/src/abigen_macro/code_gen/abigen/bindings/contract.rs
@@ -148,6 +148,7 @@ pub(crate) fn expand_fn(
 
     let fn_selector = generator.fn_selector();
     let arg_tokens = generator.tokenized_args();
+    let is_payable = abi_fun.is_payable();
     let body = quote! {
             let provider = self.wallet.get_provider().expect("Provider not set up");
             ::fuels::programs::contract::Contract::method_hash(
@@ -156,7 +157,8 @@ pub(crate) fn expand_fn(
                 &self.wallet,
                 #fn_selector,
                 &#arg_tokens,
-                self.log_decoder.clone()
+                self.log_decoder.clone(),
+                #is_payable
             )
             .expect("method not found (this should never happen)")
     };
@@ -350,7 +352,8 @@ mod tests {
                         ::fuels::core::traits::Tokenizable::into_token(s_1),
                         ::fuels::core::traits::Tokenizable::into_token(s_2)
                     ],
-                    self.log_decoder.clone()
+                    self.log_decoder.clone(),
+                    false
                 )
                 .expect("method not found (this should never happen)")
             }
@@ -410,7 +413,8 @@ mod tests {
                         &[<bool as ::fuels::core::traits::Parameterize>::param_type()]
                     ),
                     &[::fuels::core::traits::Tokenizable::into_token(bimbam)],
-                    self.log_decoder.clone()
+                    self.log_decoder.clone(),
+                    false
                 )
                 .expect("method not found (this should never happen)")
             }
@@ -526,7 +530,8 @@ mod tests {
                     &[::fuels::core::traits::Tokenizable::into_token(
                         the_only_allowed_input
                     )],
-                    self.log_decoder.clone()
+                    self.log_decoder.clone(),
+                    false
                 )
                 .expect("method not found (this should never happen)")
             }

--- a/packages/fuels-macros/src/abigen_macro/code_gen/abigen/bindings/function_generator.rs
+++ b/packages/fuels-macros/src/abigen_macro/code_gen/abigen/bindings/function_generator.rs
@@ -411,7 +411,7 @@ mod tests {
             }],
         }];
 
-        FullABIFunction::new("test_function".to_string(), fn_inputs, fn_output)
+        FullABIFunction::new("test_function".to_string(), fn_inputs, fn_output, None)
             .expect("Hand crafted function known to be correct")
     }
 }

--- a/packages/fuels-macros/src/abigen_macro/code_gen/abigen/bindings/utils.rs
+++ b/packages/fuels-macros/src/abigen_macro/code_gen/abigen/bindings/utils.rs
@@ -62,6 +62,7 @@ mod tests {
                 },
                 type_arguments: vec![],
             },
+            None,
         )
         .expect("hand-crafted, should not fail!")
     }

--- a/packages/fuels-programs/src/call_utils.rs
+++ b/packages/fuels-programs/src/call_utils.rs
@@ -308,6 +308,7 @@ mod test {
                 external_contracts: Default::default(),
                 output_param: ParamType::Unit,
                 message_outputs: None,
+                is_payable: false,
             }
         }
     }
@@ -361,6 +362,7 @@ mod test {
                 message_outputs: None,
                 external_contracts: vec![],
                 output_param: ParamType::Unit,
+                is_payable: false,
             })
             .collect();
 

--- a/packages/fuels-programs/src/contract.rs
+++ b/packages/fuels-programs/src/contract.rs
@@ -110,6 +110,7 @@ impl Contract {
         signature: Selector,
         args: &[Token],
         log_decoder: LogDecoder,
+        is_payable: bool,
     ) -> Result<ContractCallHandler<D>, Error> {
         let encoded_selector = signature;
 
@@ -129,6 +130,7 @@ impl Contract {
             message_outputs: None,
             external_contracts: vec![],
             output_param: D::param_type(),
+            is_payable,
         };
 
         Ok(ContractCallHandler {
@@ -360,6 +362,7 @@ pub struct ContractCall {
     pub message_outputs: Option<Vec<Output>>,
     pub external_contracts: Vec<Bech32ContractId>,
     pub output_param: ParamType,
+    pub is_payable: bool,
 }
 
 impl ContractCall {
@@ -560,6 +563,10 @@ where
         self
     }
 
+    pub fn is_payable(&self) -> bool {
+        self.contract_call.is_payable
+    }
+
     /// Sets the transaction parameters for a given transaction.
     /// Note that this is a builder method, i.e. use it as a chain:
 
@@ -579,9 +586,12 @@ where
     /// let params = CallParameters { amount: 1, asset_id: BASE_ASSET_ID };
     /// my_contract_instance.my_method(...).call_params(params).call()
     /// ```
-    pub fn call_params(mut self, params: CallParameters) -> Self {
+    pub fn call_params(mut self, params: CallParameters) -> Result<Self, Error> {
+        if !self.is_payable() && params.amount > 0 {
+            return Err(Error::InvalidCallParameters());
+        }
         self.contract_call.call_parameters = params;
-        self
+        Ok(self)
     }
 
     /// Appends `num` [`Output::Variable`]s to the transaction.

--- a/packages/fuels-types/src/errors.rs
+++ b/packages/fuels-types/src/errors.rs
@@ -56,6 +56,8 @@ pub enum Error {
     ValidationError(#[from] CheckError),
     #[error("Revert transaction error: {}, receipts: {:?}", .0, .1)]
     RevertTransactionError(String, Vec<Receipt>),
+    #[error("Tried to forward assets to a contract method that is not payable.")]
+    InvalidCallParameters(),
 }
 
 impl From<CodecError> for Error {

--- a/packages/fuels/tests/contracts.rs
+++ b/packages/fuels/tests/contracts.rs
@@ -1004,3 +1004,47 @@ async fn test_deploy_error_messages() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_payable_annotation() -> Result<(), Error> {
+    setup_contract_test!(
+        Wallets("wallet"),
+        Abigen(
+            name = "TestContract",
+            abi = "packages/fuels/tests/contracts/payable_annotation"
+        ),
+        Deploy(
+            name = "contract_instance",
+            contract = "TestContract",
+            wallet = "wallet"
+        ),
+    );
+
+    let contract_methods = contract_instance.methods();
+
+    let response = contract_methods
+        .payable()
+        .call_params(CallParameters::new(Some(100), None, Some(20000)))?
+        .call()
+        .await?;
+
+    assert_eq!(response.value, 42);
+
+    // ANCHOR: non_payable_params
+    let err = contract_methods
+        .non_payable()
+        .call_params(CallParameters::new(Some(100), None, None))
+        .expect_err("Should return call params error.");
+
+    assert!(matches!(err, Error::InvalidCallParameters()));
+    // ANCHOR_END: non_payable_params */
+    let response = contract_methods
+        .non_payable()
+        .call_params(CallParameters::new(None, None, Some(20000)))?
+        .call()
+        .await?;
+
+    assert_eq!(response.value, 42);
+
+    Ok(())
+}

--- a/packages/fuels/tests/contracts/contract_test/src/main.sw
+++ b/packages/fuels/tests/contracts/contract_test/src/main.sw
@@ -31,6 +31,7 @@ abi TestContract {
     fn array_of_structs(p: [Person; 2]) -> [Person; 2];
     fn array_of_enums(p: [State; 2]) -> [State; 2];
     fn get_array(p: [u64; 2]) -> [u64; 2];
+    #[payable]
     fn get_msg_amount() -> u64;
     fn new() -> u64;
 }
@@ -39,6 +40,7 @@ const COUNTER_KEY = 0x0000000000000000000000000000000000000000000000000000000000
 
 impl TestContract for Contract {
     // ANCHOR: msg_amount
+    #[payable]
     fn get_msg_amount() -> u64 {
         msg_amount()
     }

--- a/packages/fuels/tests/contracts/liquidity_pool/src/main.sw
+++ b/packages/fuels/tests/contracts/liquidity_pool/src/main.sw
@@ -13,13 +13,16 @@ use std::{
 };
 
 abi LiquidityPool {
+    #[payable]
     fn deposit(recipient: Address);
+    #[payable]
     fn withdraw(recipient: Address);
 }
 
 const BASE_TOKEN: b256 = 0x9ae5b658754e096e4d681c548daf46354495a437cc61492599e33fc64dcdc30c;
 
 impl LiquidityPool for Contract {
+    #[payable]
     fn deposit(recipient: Address) {
         assert(ContractId::from(BASE_TOKEN) == msg_asset_id());
         assert(0 < msg_amount());
@@ -31,6 +34,7 @@ impl LiquidityPool for Contract {
         mint_to_address(amount_to_mint, recipient);
     }
 
+    #[payable]
     fn withdraw(recipient: Address) {
         assert(contract_id() == msg_asset_id());
         assert(0 < msg_amount());

--- a/packages/fuels/tests/contracts/payable_annotation/Forc.toml
+++ b/packages/fuels/tests/contracts/payable_annotation/Forc.toml
@@ -1,0 +1,7 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "payable_annotation"
+
+[dependencies]

--- a/packages/fuels/tests/contracts/payable_annotation/src/main.sw
+++ b/packages/fuels/tests/contracts/payable_annotation/src/main.sw
@@ -1,0 +1,18 @@
+contract;
+
+abi TestContract {
+    #[payable]
+    fn payable() -> u64;
+    fn non_payable() -> u64;
+}
+
+impl TestContract for Contract {
+    #[payable]
+    fn payable() -> u64 {
+        42
+    }
+
+    fn non_payable() -> u64 {
+        42
+    }
+}

--- a/packages/fuels/tests/contracts/token_ops/src/main.sw
+++ b/packages/fuels/tests/contracts/token_ops/src/main.sw
@@ -9,6 +9,7 @@ abi TestFuelCoin {
     fn force_transfer_coins(coins: u64, asset_id: ContractId, target: ContractId);
     fn transfer_coins_to_output(coins: u64, asset_id: ContractId, recipient: Address);
     fn get_balance(target: ContractId, asset_id: ContractId) -> u64;
+    #[payable]
     fn get_msg_amount() -> u64;
     fn send_message(recipient: b256, coins: u64);
 }
@@ -42,6 +43,7 @@ impl TestFuelCoin for Contract {
         balance_of(target, asset_id)
     }
 
+    #[payable]
     fn get_msg_amount() -> u64 {
         msg_amount()
     }

--- a/packages/fuels/tests/providers.rs
+++ b/packages/fuels/tests/providers.rs
@@ -364,7 +364,7 @@ async fn test_amount_and_asset_forwarding() -> Result<(), Error> {
     let response = contract_methods
         .get_msg_amount()
         .tx_params(tx_params)
-        .call_params(call_params)
+        .call_params(call_params)?
         .call()
         .await?;
 
@@ -396,7 +396,7 @@ async fn test_amount_and_asset_forwarding() -> Result<(), Error> {
     let response = contract_methods
         .get_msg_amount()
         .tx_params(tx_params)
-        .call_params(call_params)
+        .call_params(call_params)?
         .call()
         .await?;
 
@@ -500,7 +500,7 @@ async fn test_call_param_gas_errors() -> Result<(), Error> {
     let response = contract_methods
         .initialize_counter(42)
         .tx_params(TxParameters::new(None, Some(3000), None))
-        .call_params(CallParameters::new(None, None, Some(1)))
+        .call_params(CallParameters::new(None, None, Some(1)))?
         .call()
         .await
         .expect_err("should error");
@@ -512,7 +512,7 @@ async fn test_call_param_gas_errors() -> Result<(), Error> {
     let response = contract_methods
         .initialize_counter(42)
         .tx_params(TxParameters::new(None, Some(1), None))
-        .call_params(CallParameters::new(None, None, Some(1000)))
+        .call_params(CallParameters::new(None, None, Some(1000)))?
         .call()
         .await
         .expect_err("should error");


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuels-rs/issues/742

.call_params() now returns a Result which either resolves to the ContractCallHandler instance or an InvalidCallParameters error. The latter happens when the user tries to set call parameters with an amount > 0 on a contract method that isn't payable.