### PR TITLE
Update for `fuel-asm` refactor. Updates for fuel-core 0.17, fuel-vm 0.26.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
   RUSTFLAGS: "-D warnings"
-  FUEL_CORE_VERSION: 0.16.1
+  FUEL_CORE_VERSION: 0.17.0
   RUST_VERSION: 1.67.0
   FORC_VERSION: 0.34.0
   FORC_PATCH_BRANCH: "Voxelot/update-predicate-metadata-0.33.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,13 @@ fuels-programs = { version = "0.35.1", path = "./packages/fuels-programs" }
 fuels-signers = { version = "0.35.1", path = "./packages/fuels-signers" }
 fuels-test-helpers = { version = "0.35.1", path = "./packages/fuels-test-helpers" }
 fuels-types = { version = "0.35.1", path = "./packages/fuels-types" }
+
+[patch.crates-io]
+fuel-asm = { git = "https://github.com/fuellabs/fuel-vm", branch = "mitchmindtree/monorepo-fuel-asm-refactor" }
+fuel-crypto = { git = "https://github.com/fuellabs/fuel-vm", branch = "mitchmindtree/monorepo-fuel-asm-refactor" }
+fuel-tx = { git = "https://github.com/fuellabs/fuel-vm", branch = "mitchmindtree/monorepo-fuel-asm-refactor" }
+fuel-types = { git = "https://github.com/fuellabs/fuel-vm", branch = "mitchmindtree/monorepo-fuel-asm-refactor" }
+fuel-vm = { git = "https://github.com/fuellabs/fuel-vm", branch = "mitchmindtree/monorepo-fuel-asm-refactor" }
+fuel-core = { git = "https://github.com/fuellabs/fuel-core", branch = "fuel-asm-refactor" }
+fuel-core-chain-config = { git = "https://github.com/fuellabs/fuel-core", branch = "fuel-asm-refactor" }
+fuel-core-client = { git = "https://github.com/fuellabs/fuel-core", branch = "fuel-asm-refactor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,17 +38,17 @@ rust-version = "1.67.0"
 version = "0.35.1"
 
 [workspace.dependencies]
-fuel-asm = "0.25"
-fuel-crypto = "0.25"
-fuel-merkle = "0.25"
-fuel-storage = "0.25"
-fuel-tx = "0.25"
-fuel-types = "0.25"
-fuel-core = { version = "0.16", default-features = false }
-fuel-core-client = "0.16"
-fuel-core-chain-config = "0.16"
-fuel-core-types = "0.16"
-fuel-vm = "0.25"
+fuel-asm = "0.26"
+fuel-crypto = "0.26"
+fuel-merkle = "0.26"
+fuel-storage = "0.26"
+fuel-tx = "0.26"
+fuel-types = "0.26"
+fuel-core = { version = "0.17", default-features = false }
+fuel-core-client = "0.17"
+fuel-core-chain-config = "0.17"
+fuel-core-types = "0.17"
+fuel-vm = "0.26"
 fuels = { version = "0.35.1", path = "./packages/fuels" }
 fuels-code-gen = { version = "0.35.1", path = "./packages/fuels-code-gen" }
 fuels-core = { version = "0.35.1", path = "./packages/fuels-core" }
@@ -57,13 +57,3 @@ fuels-programs = { version = "0.35.1", path = "./packages/fuels-programs" }
 fuels-signers = { version = "0.35.1", path = "./packages/fuels-signers" }
 fuels-test-helpers = { version = "0.35.1", path = "./packages/fuels-test-helpers" }
 fuels-types = { version = "0.35.1", path = "./packages/fuels-types" }
-
-[patch.crates-io]
-fuel-asm = { git = "https://github.com/fuellabs/fuel-vm", branch = "mitchmindtree/monorepo-fuel-asm-refactor" }
-fuel-crypto = { git = "https://github.com/fuellabs/fuel-vm", branch = "mitchmindtree/monorepo-fuel-asm-refactor" }
-fuel-tx = { git = "https://github.com/fuellabs/fuel-vm", branch = "mitchmindtree/monorepo-fuel-asm-refactor" }
-fuel-types = { git = "https://github.com/fuellabs/fuel-vm", branch = "mitchmindtree/monorepo-fuel-asm-refactor" }
-fuel-vm = { git = "https://github.com/fuellabs/fuel-vm", branch = "mitchmindtree/monorepo-fuel-asm-refactor" }
-fuel-core = { git = "https://github.com/fuellabs/fuel-core", branch = "fuel-asm-refactor" }
-fuel-core-chain-config = { git = "https://github.com/fuellabs/fuel-core", branch = "fuel-asm-refactor" }
-fuel-core-client = { git = "https://github.com/fuellabs/fuel-core", branch = "fuel-asm-refactor" }

--- a/packages/fuels-core/src/offsets.rs
+++ b/packages/fuels-core/src/offsets.rs
@@ -1,6 +1,6 @@
 use fuel_tx::{field::Script, ConsensusParameters, InputRepr};
 use fuel_types::bytes::padded_len_usize;
-use fuel_vm::prelude::Opcode;
+use fuel_vm::prelude::Instruction;
 
 /// Gets the base offset for a script or a predicate. The offset depends on the `max_inputs`
 /// field of the `ConsensusParameters` and the static offset.
@@ -14,9 +14,9 @@ pub fn call_script_data_offset(
     consensus_parameters: &ConsensusParameters,
     calls_instructions_len: usize,
 ) -> usize {
-    // Opcode::LEN is a placeholder for the RET instruction which is added later for returning
+    // Instruction::SIZE is a placeholder for the RET instruction which is added later for returning
     // from the script. This doesn't happen in the predicate.
-    let opcode_len = Opcode::LEN;
+    let opcode_len = Instruction::SIZE;
 
     base_offset(consensus_parameters) + padded_len_usize(calls_instructions_len + opcode_len)
 }

--- a/packages/fuels-programs/src/call_utils.rs
+++ b/packages/fuels-programs/src/call_utils.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, iter, vec};
 
 use fuel_tx::{AssetId, Bytes32, ContractId, Input, Output, TxPointer, UtxoId};
 use fuel_types::{Immediate18, Word};
-use fuel_vm::{consts::REG_ONE, prelude::Opcode};
+use fuel_vm::fuel_asm::{op, RegId};
 use fuels_core::constants::BASE_ASSET_ID;
 use fuels_types::{bech32::Bech32Address, constants::WORD_SIZE, resource::Resource};
 use itertools::{chain, Itertools};
@@ -10,7 +10,7 @@ use itertools::{chain, Itertools};
 use crate::contract::ContractCall;
 
 #[derive(Default)]
-/// Specifies offsets of [`Opcode::CALL`] parameters stored in the script
+/// Specifies offsets of [`Instruction::CALL`] parameters stored in the script
 /// data from which they can be loaded into registers
 pub(crate) struct CallOpcodeParamsOffset {
     pub asset_id_offset: usize,
@@ -71,7 +71,7 @@ pub(crate) fn get_instructions(
         instructions.extend(get_single_call_instructions(call_offsets));
     }
 
-    instructions.extend(Opcode::RET(REG_ONE).to_bytes());
+    instructions.extend(op::ret(RegId::ONE).to_bytes());
 
     instructions
 }
@@ -154,18 +154,18 @@ pub(crate) fn build_script_data_from_contract_calls(
 /// Note that these are soft rules as we're picking this addresses simply because they
 /// non-reserved register.
 pub(crate) fn get_single_call_instructions(offsets: &CallOpcodeParamsOffset) -> Vec<u8> {
-    let instructions = vec![
-        Opcode::MOVI(0x10, offsets.call_data_offset as Immediate18),
-        Opcode::MOVI(0x11, offsets.gas_forwarded_offset as Immediate18),
-        Opcode::LW(0x11, 0x11, 0),
-        Opcode::MOVI(0x12, offsets.amount_offset as Immediate18),
-        Opcode::LW(0x12, 0x12, 0),
-        Opcode::MOVI(0x13, offsets.asset_id_offset as Immediate18),
-        Opcode::CALL(0x10, 0x12, 0x13, 0x11),
+    let instructions = [
+        op::movi(0x10, offsets.call_data_offset as Immediate18),
+        op::movi(0x11, offsets.gas_forwarded_offset as Immediate18),
+        op::lw(0x11, 0x11, 0),
+        op::movi(0x12, offsets.amount_offset as Immediate18),
+        op::lw(0x12, 0x12, 0),
+        op::movi(0x13, offsets.asset_id_offset as Immediate18),
+        op::call(0x10, 0x12, 0x13, 0x11),
     ];
 
     #[allow(clippy::iter_cloned_collect)]
-    instructions.iter().copied().collect::<Vec<u8>>()
+    instructions.into_iter().collect::<Vec<u8>>()
 }
 
 /// Returns the assets and contracts that will be consumed ([`Input`]s)

--- a/packages/fuels-programs/src/call_utils.rs
+++ b/packages/fuels-programs/src/call_utils.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashSet, iter, vec};
 
 use fuel_tx::{AssetId, Bytes32, ContractId, Input, Output, TxPointer, UtxoId};
-use fuel_types::{Immediate18, Word};
+use fuel_types::Word;
 use fuel_vm::fuel_asm::{op, RegId};
 use fuels_core::constants::BASE_ASSET_ID;
 use fuels_types::{bech32::Bech32Address, constants::WORD_SIZE, resource::Resource};
@@ -154,13 +154,29 @@ pub(crate) fn build_script_data_from_contract_calls(
 /// Note that these are soft rules as we're picking this addresses simply because they
 /// non-reserved register.
 pub(crate) fn get_single_call_instructions(offsets: &CallOpcodeParamsOffset) -> Vec<u8> {
+    let call_data_offset = offsets
+        .call_data_offset
+        .try_into()
+        .expect("call_data_offset out of range");
+    let gas_forwarded_offset = offsets
+        .gas_forwarded_offset
+        .try_into()
+        .expect("gas_forwarded_offset out of range");
+    let amount_offset = offsets
+        .amount_offset
+        .try_into()
+        .expect("amount_offset out of range");
+    let asset_id_offset = offsets
+        .asset_id_offset
+        .try_into()
+        .expect("asset_id_offset out of range");
     let instructions = [
-        op::movi(0x10, offsets.call_data_offset as Immediate18),
-        op::movi(0x11, offsets.gas_forwarded_offset as Immediate18),
+        op::movi(0x10, call_data_offset),
+        op::movi(0x11, gas_forwarded_offset),
         op::lw(0x11, 0x11, 0),
-        op::movi(0x12, offsets.amount_offset as Immediate18),
+        op::movi(0x12, amount_offset),
         op::lw(0x12, 0x12, 0),
-        op::movi(0x13, offsets.asset_id_offset as Immediate18),
+        op::movi(0x13, asset_id_offset),
         op::call(0x10, 0x12, 0x13, 0x11),
     ];
 

--- a/packages/fuels-signers/src/wallet.rs
+++ b/packages/fuels-signers/src/wallet.rs
@@ -11,8 +11,8 @@ use fuel_tx::{
 };
 use fuel_types::{bytes::WORD_SIZE, Address, MessageId};
 use fuel_vm::{
-    consts::REG_ONE,
-    prelude::{GTFArgs, Opcode},
+    fuel_asm::{op, RegId},
+    prelude::GTFArgs,
 };
 use fuels_core::{
     abi_encoder::UnresolvedBytes,
@@ -308,13 +308,13 @@ impl Wallet {
         //  - a pointer to the asset id
         // into the registers 0x10, 0x12, 0x13
         // and calls the TR instruction
-        let script = vec![
-            Opcode::gtf(0x10, 0x00, GTFArgs::ScriptData),
-            Opcode::ADDI(0x11, 0x10, ContractId::LEN as u16),
-            Opcode::LW(0x12, 0x11, 0),
-            Opcode::ADDI(0x13, 0x11, WORD_SIZE as u16),
-            Opcode::TR(0x10, 0x12, 0x13),
-            Opcode::RET(REG_ONE),
+        let script = [
+            op::gtf_args(0x10, 0x00, GTFArgs::ScriptData),
+            op::addi(0x11, 0x10, ContractId::LEN as u16),
+            op::lw(0x12, 0x11, 0),
+            op::addi(0x13, 0x11, WORD_SIZE as u16),
+            op::tr(0x10, 0x12, 0x13),
+            op::ret(RegId::ONE),
         ]
         .into_iter()
         .collect();
@@ -348,12 +348,12 @@ impl Wallet {
         //  - the amount
         // into the registers 0x10, 0x11
         // and calls the SMO instruction
-        let script = vec![
-            Opcode::gtf(0x10, 0x00, GTFArgs::ScriptData),
-            Opcode::ADDI(0x11, 0x10, Bytes32::LEN as u16),
-            Opcode::LW(0x11, 0x11, 0),
-            Opcode::SMO(0x10, 0x00, 0x00, 0x11),
-            Opcode::RET(REG_ONE),
+        let script = [
+            op::gtf_args(0x10, 0x00, GTFArgs::ScriptData),
+            op::addi(0x11, 0x10, Bytes32::LEN as u16),
+            op::lw(0x11, 0x11, 0),
+            op::smo(0x10, 0x00, 0x00, 0x11),
+            op::ret(RegId::ONE),
         ]
         .into_iter()
         .collect();

--- a/packages/fuels-test-helpers/src/lib.rs
+++ b/packages/fuels-test-helpers/src/lib.rs
@@ -19,7 +19,7 @@ use fuels_core::constants::BASE_ASSET_ID;
 use fuels_signers::fuel_crypto::{fuel_types::AssetId, rand};
 use fuels_types::{
     coin::{Coin, CoinStatus},
-    message::Message,
+    message::{Message, MessageStatus},
     param_types::ParamType,
 };
 #[cfg(not(feature = "fuel-core-lib"))]
@@ -136,7 +136,7 @@ pub fn setup_single_message(
         amount,
         data,
         da_height: 0,
-        fuel_block_spend: None,
+        status: MessageStatus::Unspent,
     }]
 }
 

--- a/packages/fuels-types/src/message.rs
+++ b/packages/fuels-types/src/message.rs
@@ -1,5 +1,7 @@
 use fuel_core_chain_config::MessageConfig;
-use fuel_core_client::client::schema::message::Message as ClientMessage;
+use fuel_core_client::client::schema::message::{
+    Message as ClientMessage, MessageStatus as ClientMessageStatus,
+};
 use fuel_tx::{Input, MessageId};
 
 use crate::bech32::Bech32Address;
@@ -12,7 +14,13 @@ pub struct Message {
     pub nonce: u64,
     pub data: Vec<u8>,
     pub da_height: u64,
-    pub fuel_block_spend: Option<u64>,
+    pub status: MessageStatus,
+}
+
+#[derive(Debug, Clone)]
+pub enum MessageStatus {
+    Unspent,
+    Spent,
 }
 
 impl Message {
@@ -36,7 +44,16 @@ impl From<ClientMessage> for Message {
             nonce: message.nonce.0,
             data: message.data.0 .0,
             da_height: message.da_height.0,
-            fuel_block_spend: message.fuel_block_spend.map(|bs| bs.0),
+            status: MessageStatus::from(message.status),
+        }
+    }
+}
+
+impl From<ClientMessageStatus> for MessageStatus {
+    fn from(status: ClientMessageStatus) -> Self {
+        match status {
+            ClientMessageStatus::Unspent => MessageStatus::Unspent,
+            ClientMessageStatus::Spent => MessageStatus::Spent,
         }
     }
 }


### PR DESCRIPTION
This updates all crates for the `fuel-asm` refactor introduced here: FuelLabs/fuel-vm#283. You can learn more about the change at this PR. The aim is to propagate this last API-breaking update through fuels-rs and sway before beta-3.

The associated fuel-core PR can be found here: FuelLabs/fuel-core#973.

Once the refactor lands upstream and the [patch] table is removed in this PR, this unblocks the associated sway update PR here: FuelLabs/sway#4004.