### PR TITLE
feat: support all revert signals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,9 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
         # selecting a toolchain either by action or manual `rustup` calls should happen
         # before the cache plugin, as it uses the current rustc version as its cache key
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-rust"
 
       - name: Set git config
         run: |

--- a/packages/fuels-core/src/constants.rs
+++ b/packages/fuels-core/src/constants.rs
@@ -15,8 +15,4 @@ pub const BASE_ASSET_ID: AssetId = AssetId::BASE;
 pub const BASE_MESSAGE_ID: MessageId = MessageId::zeroed();
 
 pub const DEFAULT_GAS_ESTIMATION_TOLERANCE: f64 = 0.2;
-pub const GAS_PRICE_FACTOR: u64 = 1_000_000_000;
 pub const MAX_GAS_PER_TX: u64 = 100_000_000;
-
-// Revert return value that indicates missing output variables
-pub const FAILED_TRANSFER_TO_ADDRESS_SIGNAL: u64 = 0xffff_ffff_ffff_0001;

--- a/packages/fuels-programs/src/constants.rs
+++ b/packages/fuels-programs/src/constants.rs
@@ -1,0 +1,14 @@
+/// Revert with this value for a failing call to `require`
+pub const FAILED_REQUIRE_SIGNAL: u64 = 0xffff_ffff_ffff_0000;
+
+/// Revert with this value for a failing call to `transfer_to_address`.
+pub const FAILED_TRANSFER_TO_ADDRESS_SIGNAL: u64 = 0xffff_ffff_ffff_0001;
+
+/// Revert with this value for a failing call to `send_message`.
+pub const FAILED_SEND_MESSAGE_SIGNAL: u64 = 0xffff_ffff_ffff_0002;
+
+/// Revert with this value for a failing call to `assert_eq`.
+pub const FAILED_ASSERT_EQ_SIGNAL: u64 = 0xffff_ffff_ffff_0003;
+
+/// Revert with this value for a failing call to `assert`.
+pub const FAILED_ASSERT_SIGNAL: u64 = 0xffff_ffff_ffff_0004;

--- a/packages/fuels-programs/src/contract.rs
+++ b/packages/fuels-programs/src/contract.rs
@@ -16,7 +16,6 @@ use fuel_vm::fuel_asm::PanicReason;
 use fuels_core::{
     abi_decoder::ABIDecoder,
     abi_encoder::{ABIEncoder, UnresolvedBytes},
-    constants::FAILED_TRANSFER_TO_ADDRESS_SIGNAL,
     parameters::{CallParameters, StorageConfiguration, TxParameters},
 };
 use fuels_signers::{
@@ -33,8 +32,9 @@ use fuels_types::{
 
 use crate::{
     call_response::FuelCallResponse,
+    constants::FAILED_TRANSFER_TO_ADDRESS_SIGNAL,
     execution_script::ExecutableFuelCall,
-    logs::{decode_revert_error, LogDecoder},
+    logs::{map_revert_error, LogDecoder},
 };
 
 /// How many times to attempt to resolve missing tx dependencies.
@@ -682,7 +682,7 @@ where
     pub async fn call(self) -> Result<FuelCallResponse<D>> {
         Self::call_or_simulate(&self, false)
             .await
-            .map_err(|err| decode_revert_error(err, &self.log_decoder))
+            .map_err(|err| map_revert_error(err, &self.log_decoder))
     }
 
     /// Call a contract's method on the node, in a simulated manner, meaning the state of the
@@ -693,7 +693,7 @@ where
     pub async fn simulate(self) -> Result<FuelCallResponse<D>> {
         Self::call_or_simulate(&self, true)
             .await
-            .map_err(|err| decode_revert_error(err, &self.log_decoder))
+            .map_err(|err| map_revert_error(err, &self.log_decoder))
     }
 
     /// Simulates a call without needing to resolve the generic for the return type
@@ -827,7 +827,7 @@ impl MultiContractCallHandler {
     pub async fn call<D: Tokenizable + Debug>(&self) -> Result<FuelCallResponse<D>> {
         Self::call_or_simulate(self, false)
             .await
-            .map_err(|err| decode_revert_error(err, &self.log_decoder))
+            .map_err(|err| map_revert_error(err, &self.log_decoder))
     }
 
     /// Call contract methods on the node, in a simulated manner, meaning the state of the
@@ -838,7 +838,7 @@ impl MultiContractCallHandler {
     pub async fn simulate<D: Tokenizable + Debug>(&self) -> Result<FuelCallResponse<D>> {
         Self::call_or_simulate(self, true)
             .await
-            .map_err(|err| decode_revert_error(err, &self.log_decoder))
+            .map_err(|err| map_revert_error(err, &self.log_decoder))
     }
 
     async fn call_or_simulate<D: Tokenizable + Debug>(

--- a/packages/fuels-programs/src/lib.rs
+++ b/packages/fuels-programs/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod call_response;
 pub mod call_utils;
+pub mod constants;
 pub mod contract;
 pub mod execution_script;
 pub mod logs;

--- a/packages/fuels-programs/src/logs.rs
+++ b/packages/fuels-programs/src/logs.rs
@@ -12,8 +12,10 @@ use fuels_types::{
     traits::{Parameterize, Tokenizable},
 };
 
-const REQUIRE_ID: u64 = 0xffff_ffff_ffff_0000;
-const ASSERT_EQ_ID: u64 = 0xffff_ffff_ffff_0003;
+use crate::constants::{
+    FAILED_ASSERT_EQ_SIGNAL, FAILED_ASSERT_SIGNAL, FAILED_REQUIRE_SIGNAL,
+    FAILED_SEND_MESSAGE_SIGNAL, FAILED_TRANSFER_TO_ADDRESS_SIGNAL,
+};
 
 /// Holds a unique log ID
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
@@ -88,39 +90,37 @@ impl<'a, I: Iterator<Item = &'a Receipt>> ExtractLogIdData for I {
     }
 }
 
-/// Decodes the logged type from the receipt of a `RevertTransactionError` if available
-pub fn decode_revert_error(err: Error, log_decoder: &LogDecoder) -> Error {
+/// Map the provided `RevertTransactionError` based on the `revert_id`.
+/// If applicable, decode the logged types from the receipt.
+pub fn map_revert_error(mut err: Error, log_decoder: &LogDecoder) -> Error {
     if let Error::RevertTransactionError {
         revert_id,
-        receipts,
-        ..
-    } = &err
+        ref receipts,
+        ref mut reason,
+    } = err
     {
-        match *revert_id {
-            REQUIRE_ID => return decode_require_revert(log_decoder, receipts),
-            ASSERT_EQ_ID => return decode_assert_eq_revert(log_decoder, receipts),
+        match revert_id {
+            FAILED_REQUIRE_SIGNAL => *reason = decode_require_revert(log_decoder, receipts),
+            FAILED_ASSERT_EQ_SIGNAL => *reason = decode_assert_eq_revert(log_decoder, receipts),
+            FAILED_ASSERT_SIGNAL => *reason = "assertion failed.".into(),
+            FAILED_SEND_MESSAGE_SIGNAL => *reason = "failed to send message.".into(),
+            FAILED_TRANSFER_TO_ADDRESS_SIGNAL => *reason = "failed transfer to address.".into(),
             _ => {}
         }
     }
     err
 }
 
-fn decode_require_revert(log_decoder: &LogDecoder, receipts: &[Receipt]) -> Error {
-    let reason = log_decoder
+fn decode_require_revert(log_decoder: &LogDecoder, receipts: &[Receipt]) -> String {
+    log_decoder
         .get_logs(receipts)
         .ok()
         .and_then(|logs| logs.last().cloned())
-        .unwrap_or_else(|| "Failed to decode log from require revert".to_string());
-
-    Error::RevertTransactionError {
-        reason,
-        revert_id: REQUIRE_ID,
-        receipts: receipts.to_owned(),
-    }
+        .unwrap_or_else(|| "failed to decode log from require revert".to_string())
 }
 
-fn decode_assert_eq_revert(log_decoder: &LogDecoder, receipts: &[Receipt]) -> Error {
-    let reason = log_decoder
+fn decode_assert_eq_revert(log_decoder: &LogDecoder, receipts: &[Receipt]) -> String {
+    log_decoder
         .get_logs(receipts)
         .ok()
         .and_then(|logs| {
@@ -131,13 +131,7 @@ fn decode_assert_eq_revert(log_decoder: &LogDecoder, receipts: &[Receipt]) -> Er
             }
             None
         })
-        .unwrap_or_else(|| "Failed to decode logs from assert_eq revert".to_string());
-
-    Error::RevertTransactionError {
-        reason,
-        revert_id: ASSERT_EQ_ID,
-        receipts: receipts.to_owned(),
-    }
+        .unwrap_or_else(|| "failed to decode logs from assert_eq revert".to_string())
 }
 
 pub fn log_type_lookup(

--- a/packages/fuels-programs/src/script_calls.rs
+++ b/packages/fuels-programs/src/script_calls.rs
@@ -20,7 +20,7 @@ use crate::{
     call_utils::{generate_contract_inputs, generate_contract_outputs},
     contract::{get_decoded_output, SettableContract},
     execution_script::ExecutableFuelCall,
-    logs::{decode_revert_error, LogDecoder},
+    logs::{map_revert_error, LogDecoder},
 };
 
 #[derive(Debug)]
@@ -197,7 +197,7 @@ where
     pub async fn call(self) -> Result<FuelCallResponse<D>> {
         Self::call_or_simulate(&self, false)
             .await
-            .map_err(|err| decode_revert_error(err, &self.log_decoder))
+            .map_err(|err| map_revert_error(err, &self.log_decoder))
     }
 
     /// Call a script on the node, in a simulated manner, meaning the state of the
@@ -208,7 +208,7 @@ where
     pub async fn simulate(self) -> Result<FuelCallResponse<D>> {
         Self::call_or_simulate(&self, true)
             .await
-            .map_err(|err| decode_revert_error(err, &self.log_decoder))
+            .map_err(|err| map_revert_error(err, &self.log_decoder))
     }
 
     /// Create a [`FuelCallResponse`] from call receipts

--- a/packages/fuels/tests/contracts/asserts/Forc.toml
+++ b/packages/fuels/tests/contracts/asserts/Forc.toml
@@ -2,6 +2,6 @@
 authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
-name = "assert_eq"
+name = "asserts"
 
 [dependencies]

--- a/packages/fuels/tests/contracts/asserts/src/main.sw
+++ b/packages/fuels/tests/contracts/asserts/src/main.sw
@@ -41,12 +41,17 @@ impl Eq for TestEnum {
 }
 
 abi TestContract {
+    fn assert_primitive(a: u64, b: u64);
     fn assert_eq_primitive(a: u64, b: u64);
     fn assert_eq_struct(test_struct: TestStruct, test_struct2: TestStruct);
     fn assert_eq_enum(test_enum: TestEnum, test_enum2: TestEnum);
 }
 
 impl TestContract for Contract {
+    fn assert_primitive(a: u64, b: u64) {
+        assert(a == b);
+    }
+
     fn assert_eq_primitive(a: u64, b: u64) {
         assert_eq(a, b);
     }

--- a/packages/fuels/tests/scripts/script_asserts/Forc.toml
+++ b/packages/fuels/tests/scripts/script_asserts/Forc.toml
@@ -2,6 +2,6 @@
 authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
-name = "script_assert_eq"
+name = "script_asserts"
 
 [dependencies]

--- a/packages/fuels/tests/scripts/script_asserts/src/main.sw
+++ b/packages/fuels/tests/scripts/script_asserts/src/main.sw
@@ -41,13 +41,16 @@ impl Eq for TestEnum {
 }
 
 enum MatchEnum {
+    AssertPrimitive: (u64, u64),
     AssertEqPrimitive: (u64, u64),
     AssertEqStruct: (TestStruct, TestStruct),
     AssertEqEnum: (TestEnum, TestEnum),
 }
 
 fn main(match_enum: MatchEnum) {
-    if let MatchEnum::AssertEqPrimitive((a, b)) = match_enum {
+    if let MatchEnum::AssertPrimitive((a, b)) = match_enum {
+        assert(a == b);
+    } else if let MatchEnum::AssertEqPrimitive((a, b)) = match_enum {
         assert_eq(a, b);
     } else if let MatchEnum::AssertEqStruct((test_struct, test_struct2)) = match_enum
     {


### PR DESCRIPTION
closes: https://github.com/FuelLabs/fuels-rs/issues/812

This PR adds appropriate error messages to all `revert` transactions based on the IDs in  [error_signals.sw](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/error_signals.sw)