### PR TITLE
fix: clear environment before running fuel-core binary

### DIFF
--- a/packages/fuels-test-helpers/src/node.rs
+++ b/packages/fuels-test-helpers/src/node.rs
@@ -33,7 +33,6 @@ pub struct Config {
     pub manual_blocks_enabled: bool,
     pub vm_backtrace: bool,
     pub silent: bool,
-    pub poa_interval_millis: u64,
 }
 
 impl Config {
@@ -44,7 +43,6 @@ impl Config {
             manual_blocks_enabled: false,
             vm_backtrace: false,
             silent: true,
-            poa_interval_millis: 2500,
         }
     }
 }
@@ -217,7 +215,6 @@ pub async fn new_fuel_node(
         let temp_config_file = write_temp_config_file(config_json);
 
         let port = &config.addr.port().to_string();
-        let poa_str = format!("{}ms", config.poa_interval_millis);
         let mut args = vec![
             "run", // `fuel-core` is now run with `fuel-core run`
             "--ip",
@@ -226,8 +223,6 @@ pub async fn new_fuel_node(
             port,
             "--db-type",
             "in-memory",
-            "--poa-interval-period",
-            poa_str.as_str(),
             "--chain",
             temp_config_file.path().to_str().unwrap(),
         ];
@@ -265,7 +260,7 @@ pub async fn new_fuel_node(
         if config.silent {
             command.stdout(Stdio::null()).stderr(Stdio::null());
         }
-        let running_node = command.args(args).kill_on_drop(true).output();
+        let running_node = command.args(args).kill_on_drop(true).env_clear().output();
 
         let client = FuelClient::from(config.addr);
         server_health_check(&client).await;

--- a/packages/fuels/tests/providers.rs
+++ b/packages/fuels/tests/providers.rs
@@ -194,7 +194,6 @@ async fn test_input_message_pays_fee() -> Result<()> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn can_increase_block_height() -> Result<()> {
     // ANCHOR: use_produce_blocks_to_increase_block_height
     let config = Config {
@@ -216,7 +215,6 @@ async fn can_increase_block_height() -> Result<()> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn can_set_custom_block_time() -> Result<()> {
     use chrono::{TimeZone, Utc};
 
@@ -255,7 +253,6 @@ async fn can_set_custom_block_time() -> Result<()> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn contract_deployment_respects_maturity() -> Result<()> {
     abigen!(Contract(name="MyContract", abi="packages/fuels/tests/contracts/transaction_block_height/out/debug/transaction_block_height-abi.json"));
 


### PR DESCRIPTION
closes: #842 

Fuel-core probably uses HOME for the database path, so clearing all environment variables would cause problems for that use case. 

But since we use the in memory database, everything works even without the environment. 