### PR TITLE
fix: ci individual package testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,9 +122,9 @@ jobs:
           - command: clippy
             args: --all-targets --all-features
           - command: test
-            args: --all-targets --all-features
+            args: --all-targets --all-features --workspace
           - command: test
-            args: --all-targets
+            args: --all-targets --workspace
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/packages/fuels-signers/src/provider.rs
+++ b/packages/fuels-signers/src/provider.rs
@@ -91,12 +91,11 @@ impl Provider {
     /// ## Sending a transaction
     ///
     /// ```
-    /// use fuels::tx::Script;
     /// use fuels::prelude::*;
     /// async fn foo() -> std::result::Result<(), Box<dyn std::error::Error>> {
     ///   // Setup local test node
     ///   let (provider, _) = setup_test_provider(vec![], vec![], None, None).await;
-    ///   let tx = Script::default();
+    ///   let tx = ScriptTransaction::default();
     ///
     ///   let receipts = provider.send_transaction(&tx).await?;
     ///   dbg!(receipts);

--- a/packages/fuels-types/src/transaction.rs
+++ b/packages/fuels-types/src/transaction.rs
@@ -75,6 +75,12 @@ macro_rules! impl_tx_wrapper {
             }
         }
 
+        impl Default for $wrapper {
+            fn default() -> Self {
+                $wrapped::default().into()
+            }
+        }
+
         impl From<$wrapper> for $wrapped {
             fn from(tx: $wrapper) -> Self {
                 tx.tx


### PR DESCRIPTION
closes: #851

Passing `--workspace` will make cargo test each package individually. It is not exactly the same effect as going into the package and running `cargo test` due to workspace-wide feature unification happening before the test.

This is as close as we can get without bumping our CI times (probably) significantly by running `cargo test` for each package and then for the workspace as a whole. 

