### PR TITLE
fix: latest release cannot be used by cargo

### DIFF
--- a/packages/fuels-core/Cargo.toml
+++ b/packages/fuels-core/Cargo.toml
@@ -19,11 +19,8 @@ itertools = "0.10"
 sha2 = "0.9.5"
 
 [dev-dependencies]
-fuels-test-helpers = { workspace = true }
+fuels-test-helpers = { workspace = true, features = ["std"] }
 
 [features]
 default = ["std"]
-std = [
-    "fuels-test-helpers/std",
-    "fuels-types/std",
-]
+std = ["fuels-types/std"]

--- a/packages/fuels-programs/Cargo.toml
+++ b/packages/fuels-programs/Cargo.toml
@@ -33,13 +33,12 @@ thiserror = { version = "1.0.26", default-features = false }
 tokio = "1.12"
 
 [dev-dependencies]
-fuels-test-helpers = { path = "../fuels-test-helpers" }
+fuels-test-helpers = { workspace = true, features = ["std", "fuels-signers"] }
 
 [features]
 default = ["std"]
 std = [
     "fuels-core/std",
     "fuels-signers/std",
-    "fuels-test-helpers/std",
     "fuels-types/std",
 ]

--- a/packages/fuels-signers/Cargo.toml
+++ b/packages/fuels-signers/Cargo.toml
@@ -33,8 +33,8 @@ tokio = { version = "1.10.1", features = ["full"] }
 tai64 = { version = "4.0", features = ["serde"] }
 
 [dev-dependencies]
-fuels = { path = "../fuels" }
-fuels-test-helpers = { path = "../fuels-test-helpers", default-features = false }
+fuels = { workspace = true }
+fuels-test-helpers = { workspace = true, features = ["std"] }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 tempfile = "3.3.0"
 
@@ -42,7 +42,6 @@ tempfile = "3.3.0"
 default = ["std"]
 std = [
     "fuels-core/std",
-    "fuels-test-helpers/std",
     "fuels-types/std",
 ]
 test-helpers = ["fuel-core"]


### PR DESCRIPTION
If you run 
```bash
 CARGO_LOG=debug cargo update  
```
On a simple project that has `fuels = "0.37.0"` as a dep, among a bunch of other logs you'll see the following:
```
[2023-02-23T15:38:57Z INFO  cargo::sources::registry::index] failed to parse "fu/el/fuels-programs" registry package: feature `std` includes `fuels-test-helpers/std`, but `fuels-test-helpers` is not a dependency
[2023-02-23T15:38:57Z DEBUG cargo::core::registry] load/precise  registry `crates-io`
[2023-02-23T15:38:57Z DEBUG cargo::sources::registry::index] cache missing for "fu/el/fuels-signers" error: No such file or directory (os error 2)
[2023-02-23T15:38:57Z DEBUG cargo::sources::registry::index] slow path for "fu/el/fuels-signers"
[2023-02-23T15:38:57Z INFO  cargo::sources::registry::index] failed to parse "fu/el/fuels-signers" registry package: feature `std` includes `fuels-test-helpers/std`, but `fuels-test-helpers` is not a dependency
[2023-02-23T15:38:57Z DEBUG cargo::core::registry] load/precise  registry `crates-io`
```
`fuels-signers` and `fuels-programs` are the only ones being complained about and they're exactly the ones that don't have a matching version. 

It would seem that enabling features on `dev-dependencies` via a traditional feature is not something you should do.

It will pass on your local machine, it will pass our CI. 

You'll only find out when you release it and stop having the dev dependencies.

we should look into guarding against this if this ends up the reason behind the release issue.