### PR TITLE
Add cname for gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -40,6 +40,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/book
           destination_dir: ${{ steps.branch_name.outputs.BRANCH_NAME }}
+          cname: rust.fuel.network
         if: startsWith(github.ref, 'refs/tags')
 
       - name: Create latest HTML redirect file


### PR DESCRIPTION
Makes rust docs navigable from `rust.fuel.network`