### PR TITLE
fix: coins query no longer returns spent coins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ env:
   CARGO_TERM_COLOR: always
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
   RUSTFLAGS: "-D warnings"
-  FUEL_CORE_VERSION: 0.17.0
+  FUEL_CORE_VERSION: 0.17.4
   RUST_VERSION: 1.67.0
-  FORC_VERSION: 0.35.2
+  FORC_VERSION: 0.35.5
   FORC_PATCH_BRANCH: ""
   FORC_PATCH_REVISION: ""
 

--- a/docs/src/providers/querying.md
+++ b/docs/src/providers/querying.md
@@ -18,7 +18,7 @@ You might need to set up a test blockchain first. You can skip this step if you'
 
 ## Get all coins from an address
 
-This method returns all coins (of a given asset ID) from a wallet, including spent ones.
+This method returns all unspent coins (of a given asset ID) from a wallet.
 
 ```rust,ignore
 {{#include ../../../examples/providers/src/lib.rs:get_coins}}

--- a/packages/fuels-signers/src/lib.rs
+++ b/packages/fuels-signers/src/lib.rs
@@ -222,9 +222,9 @@ mod tests {
         let wallet_1_all_coins = wallet_1.get_coins(BASE_ASSET_ID).await?;
         let wallet_2_all_coins = wallet_2.get_coins(BASE_ASSET_ID).await?;
 
-        // wallet_1 has now only one spent coin and one not spent(the remaining not sent coins)
+        // wallet_1 has now only one spent coin
         assert_eq!(wallet_1_spendable_resources.len(), 1);
-        assert_eq!(wallet_1_all_coins.len(), 2);
+        assert_eq!(wallet_1_all_coins.len(), 1);
         // Check that wallet two now has a coin.
         assert_eq!(wallet_2_all_coins.len(), 1);
         assert_eq!(wallet_2_spendable_resources.len(), 1);

--- a/packages/fuels-signers/src/provider.rs
+++ b/packages/fuels-signers/src/provider.rs
@@ -322,8 +322,7 @@ impl Provider {
         Ok(receipts)
     }
 
-    /// Gets all coins owned by address `from`, with asset ID `asset_id`, *even spent ones*. This
-    /// returns actual coins (UTXOs).
+    /// Gets all unspent coins owned by address `from`, with asset ID `asset_id`.
     pub async fn get_coins(
         &self,
         from: &Bech32Address,

--- a/packages/fuels-signers/src/wallet.rs
+++ b/packages/fuels-signers/src/wallet.rs
@@ -181,9 +181,7 @@ impl Wallet {
         ]
     }
 
-    /// Gets all coins of asset `asset_id` owned by the wallet, *even spent ones* (this is useful
-    /// for some particular cases, but in general, you should use `get_spendable_coins`). This
-    /// returns actual coins (UTXOs).
+    /// Gets all unspent coins of asset `asset_id` owned by the wallet.
     pub async fn get_coins(&self, asset_id: AssetId) -> Result<Vec<Coin>> {
         Ok(self
             .get_provider()?


### PR DESCRIPTION
Since `0.17.4` `fuel-core` no longer returns spent coins via the `coins` query. Due to semver compatibility this broke the CI on `master`.

### Checklist
- [x] I have linked to any relevant issues.
- [x] I have updated the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
