### PR TITLE
refactor: remove the `Byte` type

### DIFF
--- a/packages/fuels-code-gen/src/program_bindings/resolved_type.rs
+++ b/packages/fuels-code-gen/src/program_bindings/resolved_type.rs
@@ -77,7 +77,6 @@ pub(crate) fn resolve_type(
 
     [
         to_simple_type,
-        to_byte,
         to_bits256,
         to_generic,
         to_array,
@@ -195,22 +194,6 @@ fn to_simple_type(
             })
         }
         _ => None,
-    }
-}
-
-fn to_byte(
-    type_field: &str,
-    _: impl Fn() -> Vec<ResolvedType>,
-    _: impl Fn() -> Vec<ResolvedType>,
-    _: bool,
-) -> Option<ResolvedType> {
-    if type_field == "byte" {
-        Some(ResolvedType {
-            type_name: quote! {::fuels::types::Byte},
-            generic_params: vec![],
-        })
-    } else {
-        None
     }
 }
 
@@ -339,11 +322,6 @@ mod tests {
     #[test]
     fn test_resolve_bool() -> Result<()> {
         test_resolve_primitive_type("bool", "bool")
-    }
-
-    #[test]
-    fn test_resolve_byte() -> Result<()> {
-        test_resolve_primitive_type("byte", ":: fuels :: types :: Byte")
     }
 
     #[test]

--- a/packages/fuels-core/src/abi_decoder.rs
+++ b/packages/fuels-core/src/abi_decoder.rs
@@ -64,7 +64,6 @@ impl ABIDecoder {
             ParamType::U32 => Self::decode_u32(bytes),
             ParamType::U64 => Self::decode_u64(bytes),
             ParamType::Bool => Self::decode_bool(bytes),
-            ParamType::Byte => Self::decode_byte(bytes),
             ParamType::B256 => Self::decode_b256(bytes),
             ParamType::RawSlice => Self::decode_raw_slice(bytes),
             ParamType::String(length) => Self::decode_string(bytes, *length),
@@ -165,13 +164,6 @@ impl ABIDecoder {
         Ok(DecodeResult {
             token: Token::B256(*peek_fixed::<32>(bytes)?),
             bytes_read: 32,
-        })
-    }
-
-    fn decode_byte(bytes: &[u8]) -> Result<DecodeResult> {
-        Ok(DecodeResult {
-            token: Token::Byte(peek_u8(bytes)?),
-            bytes_read: 8,
         })
     }
 

--- a/packages/fuels-core/src/abi_encoder.rs
+++ b/packages/fuels-core/src/abi_encoder.rs
@@ -112,7 +112,6 @@ impl ABIEncoder {
             Token::U16(arg_u16) => vec![Self::encode_u16(*arg_u16)],
             Token::U32(arg_u32) => vec![Self::encode_u32(*arg_u32)],
             Token::U64(arg_u64) => vec![Self::encode_u64(*arg_u64)],
-            Token::Byte(arg_byte) => vec![Self::encode_byte(*arg_byte)],
             Token::Bool(arg_bool) => vec![Self::encode_bool(*arg_bool)],
             Token::B256(arg_bits256) => vec![Self::encode_b256(arg_bits256)],
             Token::Array(arg_array) => Self::encode_array(arg_array)?,
@@ -156,10 +155,6 @@ impl ABIEncoder {
 
     fn encode_bool(arg_bool: bool) -> Data {
         Data::Inline(pad_u8(u8::from(arg_bool)).to_vec())
-    }
-
-    fn encode_byte(arg_byte: u8) -> Data {
-        Data::Inline(pad_u8(arg_byte).to_vec())
     }
 
     fn encode_u64(arg_u64: u64) -> Data {
@@ -410,40 +405,6 @@ mod tests {
         ];
 
         let expected_function_selector = [0x0, 0x0, 0x0, 0x0, 0xf5, 0x40, 0x73, 0x2b];
-
-        let encoded_function_selector = first_four_bytes_of_sha256_hash(fn_signature);
-
-        let encoded = ABIEncoder::encode(&args)?.resolve(0);
-
-        println!("Encoded ABI for ({fn_signature}): {encoded:#0x?}");
-
-        assert_eq!(hex::encode(expected_encoded_abi), hex::encode(encoded));
-        assert_eq!(encoded_function_selector, expected_function_selector);
-        Ok(())
-    }
-
-    #[test]
-    fn encode_function_with_byte_type() -> Result<()> {
-        // let json_abi =
-        // r#"
-        // [
-        //     {
-        //         "type":"function",
-        //         "inputs": [{"name":"arg","type":"byte"}],
-        //         "name":"takes_one_byte",
-        //         "outputs": []
-        //     }
-        // ]
-        // "#;
-
-        let fn_signature = "takes_one_byte(byte)";
-        let arg = Token::Byte(u8::MAX);
-
-        let args: Vec<Token> = vec![arg];
-
-        let expected_encoded_abi = [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff];
-
-        let expected_function_selector = [0x0, 0x0, 0x0, 0x0, 0x2e, 0xe3, 0xce, 0x1f];
 
         let encoded_function_selector = first_four_bytes_of_sha256_hash(fn_signature);
 

--- a/packages/fuels-core/src/function_selector.rs
+++ b/packages/fuels-core/src/function_selector.rs
@@ -27,7 +27,6 @@ fn resolve_arg(arg: &ParamType) -> String {
         ParamType::U32 => "u32".to_owned(),
         ParamType::U64 => "u64".to_owned(),
         ParamType::Bool => "bool".to_owned(),
-        ParamType::Byte => "byte".to_owned(),
         ParamType::B256 => "b256".to_owned(),
         ParamType::Unit => "()".to_owned(),
         ParamType::String(len) => {
@@ -98,7 +97,6 @@ mod tests {
             (ParamType::U32, "u32"),
             (ParamType::U64, "u64"),
             (ParamType::Bool, "bool"),
-            (ParamType::Byte, "byte"),
             (ParamType::B256, "b256"),
             (ParamType::Unit, "()"),
             (ParamType::String(15), "str[15]"),

--- a/packages/fuels-core/src/traits/decodable_log.rs
+++ b/packages/fuels-core/src/traits/decodable_log.rs
@@ -36,7 +36,6 @@ fn paramtype_decode_log(param_type: &ParamType, token: &Token) -> Result<String>
         (ParamType::U32, Token::U32(val)) => val.to_string(),
         (ParamType::U64, Token::U64(val)) => val.to_string(),
         (ParamType::Bool, Token::Bool(val)) => val.to_string(),
-        (ParamType::Byte, Token::Byte(val)) => val.to_string(),
         (ParamType::B256, Token::B256(val)) => {
             format!("Bits256({val:?})")
         }

--- a/packages/fuels-programs/src/contract.rs
+++ b/packages/fuels-programs/src/contract.rs
@@ -161,7 +161,6 @@ impl Contract {
                         | Token::B256(_)
                         | Token::Tuple(_)
                         | Token::Array(_)
-                        | Token::Byte(_)
                         | Token::Vector(_)
                 )
             })

--- a/packages/fuels-types/src/core.rs
+++ b/packages/fuels-types/src/core.rs
@@ -10,12 +10,11 @@ use crate::{
 };
 
 mod bits;
-mod byte;
 mod native;
 mod raw_slice;
 mod sized_ascii_string;
 
-pub use crate::core::{bits::*, byte::*, native::*, raw_slice::RawSlice, sized_ascii_string::*};
+pub use crate::core::{bits::*, native::*, raw_slice::RawSlice, sized_ascii_string::*};
 
 pub type ByteArray = [u8; 8];
 pub type Selector = ByteArray;
@@ -77,7 +76,6 @@ pub enum Token {
     U32(u32),
     U64(u64),
     Bool(bool),
-    Byte(u8),
     B256([u8; 32]),
     Array(Vec<Token>),
     Vector(Vec<Token>),

--- a/packages/fuels-types/src/core/byte.rs
+++ b/packages/fuels-types/src/core/byte.rs
@@ -1,1 +1,0 @@
-pub struct Byte(pub u8);

--- a/packages/fuels-types/src/traits/parameterize.rs
+++ b/packages/fuels-types/src/traits/parameterize.rs
@@ -3,7 +3,7 @@ use std::iter::zip;
 use fuel_types::{Address, AssetId, ContractId};
 
 use crate::{
-    core::{Bits256, Byte, RawSlice, SizedAsciiString},
+    core::{Bits256, RawSlice, SizedAsciiString},
     enum_variants::EnumVariants,
     param_types::ParamType,
 };
@@ -23,12 +23,6 @@ impl Parameterize for Bits256 {
 impl Parameterize for RawSlice {
     fn param_type() -> ParamType {
         ParamType::RawSlice
-    }
-}
-
-impl Parameterize for Byte {
-    fn param_type() -> ParamType {
-        ParamType::Byte
     }
 }
 

--- a/packages/fuels-types/src/traits/tokenizable.rs
+++ b/packages/fuels-types/src/traits/tokenizable.rs
@@ -1,7 +1,7 @@
 use fuel_types::{Address, AssetId, ContractId};
 
 use crate::{
-    core::{Bits256, Byte, RawSlice, SizedAsciiString, StringToken, Token},
+    core::{Bits256, RawSlice, SizedAsciiString, StringToken, Token},
     errors::{error, Error, Result},
     param_types::ParamType,
     traits::Parameterize,
@@ -41,25 +41,6 @@ impl Tokenizable for Bits256 {
 
     fn into_token(self) -> Token {
         Token::B256(self.0)
-    }
-}
-
-impl Tokenizable for Byte {
-    fn from_token(token: Token) -> Result<Self>
-    where
-        Self: Sized,
-    {
-        match token {
-            Token::Byte(value) => Ok(Byte(value)),
-            _ => Err(error!(
-                InvalidData,
-                "Byte::from_token failed! Can only handle Token::Byte, got {token:?}"
-            )),
-        }
-    }
-
-    fn into_token(self) -> Token {
-        Token::Byte(self.0)
     }
 }
 

--- a/packages/fuels/tests/bindings.rs
+++ b/packages/fuels/tests/bindings.rs
@@ -3,7 +3,7 @@ use std::{slice, str::FromStr};
 use fuels::{
     core::abi_encoder::ABIEncoder,
     prelude::*,
-    types::{traits::Tokenizable, Bits256, Byte, EvmAddress},
+    types::{traits::Tokenizable, Bits256, EvmAddress},
 };
 use sha2::{Digest, Sha256};
 
@@ -252,65 +252,6 @@ async fn compile_bindings_bool_array_input() {
         "000000000c228226000000000000000100000000000000000000000000000001",
         encoded
     );
-}
-
-#[tokio::test]
-async fn compile_bindings_byte_input() {
-    // Generates the bindings from the an ABI definition inline.
-    // The generated bindings can be accessed through `SimpleContract`.
-    abigen!(Contract(
-        name = "SimpleContract",
-        abi = r#"
-        {
-            "types": [
-              {
-                "typeId": 0,
-                "type": "()",
-                "components": [],
-                "typeParameters": null
-              },
-              {
-                "typeId": 1,
-                "type": "byte",
-                "components": null,
-                "typeParameters": null
-              }
-            ],
-            "functions": [
-              {
-                "inputs": [
-                  {
-                    "name": "arg",
-                    "type": 1,
-                    "typeArguments": null
-                  }
-                ],
-                "name": "takes_byte",
-                "output": {
-                  "name": "",
-                  "type": 0,
-                  "typeArguments": null
-                }
-              }
-            ]
-          }
-        "#,
-    ));
-
-    let wallet = launch_provider_and_get_wallet().await;
-
-    let contract_instance = SimpleContract::new(null_contract_id(), wallet);
-
-    let call_handler = contract_instance.methods().takes_byte(Byte(10u8));
-
-    let encoded_args = call_handler.contract_call.encoded_args.resolve(0);
-    let encoded = format!(
-        "{}{}",
-        hex::encode(call_handler.contract_call.encoded_selector),
-        hex::encode(encoded_args)
-    );
-
-    assert_eq!("00000000a4bd3861000000000000000a", encoded);
 }
 
 #[tokio::test]


### PR DESCRIPTION
This PR closes #880 by removing the `Byte` type, whose support was dropped in Sway.
