### PR TITLE
refactor!: `fuels` wasm-offending packages/reexports hidden behind `std` flag

### DIFF
--- a/packages/fuels-code-gen/src/program_bindings/abigen.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen.rs
@@ -54,12 +54,6 @@ impl Abigen {
     }
     fn wasm_paths_hotfix(code: &TokenStream) -> TokenStream {
         [
-            (r#"::\s*fuels\s*::\s*core"#, "::fuels_core"),
-            (r#"::\s*fuels\s*::\s*macros"#, "::fuels_macros"),
-            (r#"::\s*fuels\s*::\s*programs"#, "::fuels_programs"),
-            (r#"::\s*fuels\s*::\s*accounts"#, "::fuels_accounts"),
-            (r#"::\s*fuels\s*::\s*tx"#, "::fuel_tx"),
-            (r#"::\s*fuels\s*::\s*types"#, "::fuels_types"),
             (r#"::\s*std\s*::\s*string"#, "::alloc::string"),
             (r#"::\s*std\s*::\s*format"#, "::alloc::format"),
             (r#"::\s*std\s*::\s*vec"#, "::alloc::vec"),

--- a/packages/fuels-code-gen/src/program_bindings/custom_types.rs
+++ b/packages/fuels-code-gen/src/program_bindings/custom_types.rs
@@ -181,8 +181,6 @@ mod tests {
                 ::fuels::macros::Tokenizable,
                 ::fuels::macros::TryFrom
             )]
-            #[FuelsTypesPath("::fuels::types")]
-            #[FuelsCorePath("::fuels::core")]
             pub enum MatchaTea<> {
                 LongIsland(u64),
                 MoscowMule(bool)
@@ -267,8 +265,6 @@ mod tests {
                 ::fuels::macros::Tokenizable,
                 ::fuels::macros::TryFrom
             )]
-            #[FuelsTypesPath("::fuels::types")]
-            #[FuelsCorePath("::fuels::core")]
             pub enum Amsterdam<> {
                 Infrastructure(self::Building),
                 Service(u32)
@@ -331,8 +327,6 @@ mod tests {
                 ::fuels::macros::Tokenizable,
                 ::fuels::macros::TryFrom
             )]
-            #[FuelsTypesPath("::fuels::types")]
-            #[FuelsCorePath("::fuels::core")]
             pub enum SomeEnum < > {
                 SomeArr([u64; 7usize])
             }
@@ -407,8 +401,6 @@ mod tests {
                 ::fuels::macros::Tokenizable,
                 ::fuels::macros::TryFrom
             )]
-            #[FuelsTypesPath("::fuels::types")]
-            #[FuelsCorePath("::fuels::core")]
             pub enum EnumLevel3<> {
                 El2(self::EnumLevel2)
             }
@@ -484,8 +476,6 @@ mod tests {
                 ::fuels::macros::Tokenizable,
                 ::fuels::macros::TryFrom
             )]
-            #[FuelsTypesPath("::fuels::types")]
-            #[FuelsCorePath("::fuels::core")]
             pub struct Cocktail < > {
                 pub long_island: bool,
                 pub cosmopolitan: u64,
@@ -521,8 +511,6 @@ mod tests {
                 ::fuels::macros::Tokenizable,
                 ::fuels::macros::TryFrom
             )]
-            #[FuelsTypesPath("::fuels::types")]
-            #[FuelsCorePath("::fuels::core")]
             pub struct SomeEmptyStruct < > {}
         };
 
@@ -586,8 +574,6 @@ mod tests {
                 ::fuels::macros::Tokenizable,
                 ::fuels::macros::TryFrom
             )]
-            #[FuelsTypesPath("::fuels::types")]
-            #[FuelsCorePath("::fuels::core")]
             pub struct Cocktail < > {
                 pub long_island: self::Shaker,
                 pub mojito: u32
@@ -691,8 +677,6 @@ mod tests {
                 ::fuels::macros::Tokenizable,
                 ::fuels::macros::TryFrom
             )]
-            #[FuelsTypesPath("::fuels::types")]
-            #[FuelsCorePath("::fuels::core")]
             pub struct MyStruct1 < > {
                 pub x: u64,
                 pub y: ::fuels::types::Bits256
@@ -716,8 +700,6 @@ mod tests {
                 ::fuels::macros::Tokenizable,
                 ::fuels::macros::TryFrom
             )]
-            #[FuelsTypesPath("::fuels::types")]
-            #[FuelsCorePath("::fuels::core")]
             pub struct MyStruct2 < > {
                 pub x: bool,
                 pub y: self::MyStruct1

--- a/packages/fuels-code-gen/src/program_bindings/custom_types/enums.rs
+++ b/packages/fuels-code-gen/src/program_bindings/custom_types/enums.rs
@@ -67,8 +67,6 @@ fn enum_decl(
             ::fuels::macros::Tokenizable,
             ::fuels::macros::TryFrom
         )]
-        #[FuelsTypesPath("::fuels::types")]
-        #[FuelsCorePath("::fuels::core")]
         #maybe_disable_std
         pub enum #enum_ident <#(#generics: ::fuels::types::traits::Tokenizable + ::fuels::types::traits::Parameterize),*> {
             #(#enum_variants),*

--- a/packages/fuels-code-gen/src/program_bindings/custom_types/structs.rs
+++ b/packages/fuels-code-gen/src/program_bindings/custom_types/structs.rs
@@ -59,8 +59,6 @@ fn struct_decl(
             ::fuels::macros::Tokenizable,
             ::fuels::macros::TryFrom
         )]
-        #[FuelsTypesPath("::fuels::types")]
-        #[FuelsCorePath("::fuels::core")]
         #maybe_disable_std
         pub struct #struct_ident <#(#generic_parameters: ::fuels::types::traits::Tokenizable + ::fuels::types::traits::Parameterize, )*> {
             #(#fields),*

--- a/packages/fuels/Cargo.toml
+++ b/packages/fuels/Cargo.toml
@@ -11,13 +11,13 @@ description = "Fuel Rust SDK."
 
 [dependencies]
 fuel-core = { workspace = true, default-features = false, optional = true }
-fuel-core-client = { workspace = true, default-features = false }
+fuel-core-client = { workspace = true, default-features = false, optional = true }
 fuel-tx = { workspace = true }
-fuels-accounts = { workspace = true }
+fuels-accounts = { workspace = true, optional = true }
 fuels-core = { workspace = true }
 fuels-macros = { workspace = true }
-fuels-programs = { workspace = true }
-fuels-test-helpers = { workspace = true }
+fuels-programs = { workspace = true, optional = true }
+fuels-test-helpers = { workspace = true, optional = true }
 fuels-types = { workspace = true }
 
 [dev-dependencies]
@@ -29,14 +29,18 @@ sha2 = "0.9.5"
 tokio = "1.15.0"
 
 [features]
-default = ["std", "fuels-test-helpers/fuels-accounts"]
+default = ["std", "fuels-test-helpers?/fuels-accounts"]
 std = [
-    "fuels-programs/std",
+    "dep:fuel-core-client",
+    "dep:fuels-accounts",
+    "dep:fuels-programs",
+    "dep:fuels-test-helpers",
+    "fuels-programs?/std",
     "fuels-core/std",
-    "fuels-accounts/std",
-    "fuels-test-helpers/std",
+    "fuels-accounts?/std",
+    "fuels-test-helpers?/std",
     "fuels-types/std",
 ]
 # TODO: To be removed once https://github.com/FuelLabs/fuels-rs/issues/881 is unblocked.
 test-type-paths = []
-fuel-core-lib = ["fuels-test-helpers/fuel-core-lib", "dep:fuel-core"]
+fuel-core-lib = ["fuels-test-helpers?/fuel-core-lib", "dep:fuel-core"]

--- a/packages/fuels/Cargo.toml
+++ b/packages/fuels/Cargo.toml
@@ -30,6 +30,9 @@ tokio = "1.15.0"
 
 [features]
 default = ["std", "fuels-test-helpers?/fuels-accounts"]
+# The crates enabled via `dep:` below are not currently wasm compatible, as
+# such they are only available if `std` is enabled. The `dep:` syntax was
+# used so that we don't get a new feature flag for every optional dependency.
 std = [
     "dep:fuel-core-client",
     "dep:fuels-accounts",

--- a/packages/fuels/src/lib.rs
+++ b/packages/fuels/src/lib.rs
@@ -16,6 +16,7 @@ pub mod tx {
     pub use fuel_tx::*;
 }
 
+#[cfg(feature = "std")]
 pub mod client {
     pub use fuel_core_client::client::*;
 }
@@ -24,6 +25,7 @@ pub mod macros {
     pub use fuels_macros::*;
 }
 
+#[cfg(feature = "std")]
 pub mod programs {
     pub use fuels_programs::*;
 }
@@ -32,6 +34,7 @@ pub mod core {
     pub use fuels_core::*;
 }
 
+#[cfg(feature = "std")]
 pub mod accounts {
     pub use fuels_accounts::*;
 }
@@ -40,10 +43,12 @@ pub mod types {
     pub use fuels_types::*;
 }
 
+#[cfg(feature = "std")]
 pub mod test_helpers {
     pub use fuels_test_helpers::*;
 }
 
+#[cfg(feature = "std")]
 pub mod fuel_node {
     #[cfg(feature = "fuel-core-lib")]
     pub use fuel_core::service::{Config, FuelService};
@@ -62,13 +67,13 @@ pub mod prelude {
     //! # #![allow(unused_imports)]
     //! use fuels::prelude::*;
     //! ```
+    #[cfg(feature = "std")]
     pub use super::{
         accounts::{
             provider::*, wallet::generate_mnemonic_phrase, Account, Signer, ViewOnlyAccount,
             Wallet, WalletUnlocked,
         },
         fuel_node::*,
-        macros::{abigen, setup_contract_test},
         programs::{
             contract::{
                 CallParameters, Contract, DeployConfiguration, MultiContractCallHandler,
@@ -78,6 +83,9 @@ pub mod prelude {
             Configurables,
         },
         test_helpers::*,
+    };
+    pub use super::{
+        macros::{abigen, setup_contract_test},
         tx::Salt,
         types::{
             bech32::{Bech32Address, Bech32ContractId},

--- a/packages/wasm-tests/Cargo.toml
+++ b/packages/wasm-tests/Cargo.toml
@@ -8,9 +8,10 @@ publish = false
 crate-type = ['cdylib']
 
 [dev-dependencies]
-# `fuels` itentionally not specified through `workspace=true`. In the workspace cargo.toml `fuels` has default features
-# enabled (so that our examples don't inherit `fuels` with disabled features). Cargo wouldn't respect any attempts here
-# to disable them again.
+# `fuels` itentionally not specified through `workspace=true`. In
+# the workspace cargo.toml `fuels` has default features enabled (so
+# that our examples don't inherit `fuels` with disabled features).
+# Cargo wouldn't respect any attempts here to disable them again.
 fuels = { path = "../fuels", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen-test = "0.3.34"

--- a/packages/wasm-tests/Cargo.toml
+++ b/packages/wasm-tests/Cargo.toml
@@ -7,11 +7,10 @@ publish = false
 [lib]
 crate-type = ['cdylib']
 
-[dependencies]
-fuels-core = { workspace = true }
-fuels-macros = { workspace = true }
-fuels-types = { workspace = true }
-getrandom = { version = "0.2", features = ["js"] }
-
 [dev-dependencies]
+# `fuels` itentionally not specified through `workspace=true`. In the workspace cargo.toml `fuels` has default features
+# enabled (so that our examples don't inherit `fuels` with disabled features). Cargo wouldn't respect any attempts here
+# to disable them again.
+fuels = { path = "../fuels", default-features = false }
+getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen-test = "0.3.34"

--- a/packages/wasm-tests/src/lib.rs
+++ b/packages/wasm-tests/src/lib.rs
@@ -2,9 +2,11 @@ extern crate alloc;
 
 #[cfg(test)]
 mod tests {
-    use fuels_core::abi_encoder::ABIEncoder;
-    use fuels_macros::wasm_abigen;
-    use fuels_types::{traits::Tokenizable, Bits256};
+    use fuels::{
+        core::abi_encoder::ABIEncoder,
+        macros::wasm_abigen,
+        types::{traits::Tokenizable, Bits256},
+    };
     use wasm_bindgen_test::wasm_bindgen_test;
 
     wasm_abigen!(Contract(


### PR DESCRIPTION
closes: #912 

Read the issue for context. Only implementation notes to follow.

### Breaking changes
* `Abigen` code will now refer to types through the `fuels` package since it is now wasm compatible. @deekerno @ra0x3 the indexer should now just include `fuels` as a dependency taking care to disable the default features (since `std` is the default). You can access `fuels_core` stuff through `fuels::core`; `fuels_types` through `fuels::types`; `fuels_macros` through `fuels::macros`. 

The hotfix is still in place -- mostly to make the Abigen code-writing experience more enjoyable. If we remove it completely then we'd have to do a `no_std` check whenever we use a Vec, `format!`, `String` etc. 

This way we always write `::std::vec::Vec` and leave the rest to the (now smaller) wasm hotfix.

As we become more wasm compatible the rest of the `fuels-*` crates will become exposed through `fuels` reexports.


### Checklist
- [x] I have linked to any relevant issues.
- [x] I have updated the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
