### PR TITLE
chore: default-features warnings on cargo nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,12 @@ fuel-crypto = "0.26"
 fuel-merkle = "0.26"
 fuel-storage = "0.26"
 fuel-tx = "0.26"
-fuel-types = "0.26"
+fuel-types = { version = "0.26", default-features = false }
 fuel-abi-types = "0.2.1"
 fuel-core = { version = "0.17", default-features = false }
-fuel-core-client = "0.17"
-fuel-core-chain-config = "0.17"
-fuel-core-types = "0.17"
+fuel-core-client = { version = "0.17", default-features = false }
+fuel-core-chain-config = { version = "0.17", default-features = false }
+fuel-core-types = { version = "0.17", default-features = false }
 fuel-vm = "0.26"
 fuels = { version = "0.38.1", path = "./packages/fuels" }
 fuels-code-gen = { version = "0.38.1", path = "./packages/fuels-code-gen", default-features = false }

--- a/packages/fuels-accounts/Cargo.toml
+++ b/packages/fuels-accounts/Cargo.toml
@@ -16,10 +16,10 @@ chrono = "0.4.2"
 elliptic-curve = { version = "0.11.6", default-features = false }
 eth-keystore = { version = "0.3.0" }
 fuel-core = { workspace = true, default-features = false, optional = true }
-fuel-core-client = { workspace = true, default-features = false }
+fuel-core-client = { workspace = true, features = ["default"] }
 fuel-crypto = { workspace = true, features = ["random"] }
 fuel-tx = { workspace = true }
-fuel-types = { workspace = true, default-features = false, features = ["random"] }
+fuel-types = { workspace = true, features = ["random"] }
 fuel-vm = { workspace = true }
 fuels-core = { workspace = true }
 fuels-types = { workspace = true }

--- a/packages/fuels-core/Cargo.toml
+++ b/packages/fuels-core/Cargo.toml
@@ -11,7 +11,7 @@ description = "Fuel Rust SDK core."
 
 [dependencies]
 fuel-tx = { workspace = true }
-fuel-types = { workspace = true }
+fuel-types = { workspace = true, features = ["default"] }
 fuel-vm = { workspace = true }
 fuels-types = { workspace = true }
 hex = { version = "0.4.3", features = ["std"] }

--- a/packages/fuels-programs/Cargo.toml
+++ b/packages/fuels-programs/Cargo.toml
@@ -14,7 +14,7 @@ async-trait = { version = "0.1.50", default-features = false }
 bytes = { version = "1.0.1", features = ["serde"] }
 fuel-abi-types = { workspace = true }
 fuel-tx = { workspace = true }
-fuel-types = { workspace = true }
+fuel-types = { workspace = true, features = ["default"] }
 fuel-vm = { workspace = true }
 fuels-accounts = { workspace = true }
 fuels-core = { workspace = true }

--- a/packages/fuels-test-helpers/Cargo.toml
+++ b/packages/fuels-test-helpers/Cargo.toml
@@ -11,11 +11,11 @@ description = "Fuel Rust SDK test helpers."
 
 [dependencies]
 fuel-core = { workspace = true, default-features = false, optional = true }
-fuel-core-chain-config = { workspace = true, default-features = false }
-fuel-core-client = { workspace = true, default-features = false }
-fuel-core-types = { workspace = true, default-features = false }
+fuel-core-chain-config = { workspace = true }
+fuel-core-client = { workspace = true }
+fuel-core-types = { workspace = true }
 fuel-tx = { workspace = true }
-fuel-types = { workspace = true, default-features = false, features = ["random"] }
+fuel-types = { workspace = true, features = ["random"] }
 fuel-vm = { workspace = true }
 fuels-accounts = { workspace = true, optional = true }
 fuels-types = { workspace = true }

--- a/packages/fuels-types/Cargo.toml
+++ b/packages/fuels-types/Cargo.toml
@@ -15,12 +15,12 @@ lazy_static = "1.4.0"
 bech32 = "0.9.0"
 chrono = "0.4.2"
 fuel-tx = { workspace = true }
-fuel-types = { workspace = true }
+fuel-types = { workspace = true, features = ["default"] }
 fuel-asm = { workspace = true }
 fuel-abi-types = { workspace = true }
 fuel-core = { workspace = true, default-features = false, optional = true }
-fuel-core-chain-config = { workspace = true, default-features = false }
-fuel-core-client = { workspace = true, default-features = false, optional = true }
+fuel-core-chain-config = { workspace = true }
+fuel-core-client = { workspace = true, optional = true }
 hex = { version = "0.4.3", features = ["std"] }
 proc-macro2 = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/packages/fuels/Cargo.toml
+++ b/packages/fuels/Cargo.toml
@@ -11,7 +11,7 @@ description = "Fuel Rust SDK."
 
 [dependencies]
 fuel-core = { workspace = true, default-features = false, optional = true }
-fuel-core-client = { workspace = true, default-features = false, optional = true }
+fuel-core-client = { workspace = true, optional = true }
 fuel-tx = { workspace = true }
 fuels-accounts = { workspace = true, optional = true }
 fuels-core = { workspace = true }
@@ -23,7 +23,7 @@ fuels-types = { workspace = true }
 [dev-dependencies]
 chrono = "0.4.2"
 fuel-core = { workspace = true, default-features = false }
-fuel-core-types = { workspace = true, default-features = false }
+fuel-core-types = { workspace = true }
 hex = { version = "0.4.3", default-features = false }
 sha2 = "0.9.5"
 tokio = "1.15.0"


### PR DESCRIPTION
closes: #918 

From [the cargo book](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html):
> Other than optional and features, inherited dependencies cannot use any other dependency key (such as version or default-features).

We've been inheriting workspace deps and then trying to disable default features. Cargo doesn't support this. If a dep has default features enabled when defined at the workspace level, those features are there to stay. You can only add more to them via `features` or make the dep itself optional in the place you're using it via `optional=true`.

The check for this still hasn't landed in cargo stable. I opted not to add a CI step to build `fuels-rs` with the nightly toolchain to check for regressions in this regard.

Functionally nothing has changed. The changes are primarily so we don't mislead ourselves and so we don't run into an error when this does reach stable.

### Checklist
- [x] I have linked to any relevant issues.
- [x] I have updated the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
