### PR TITLE
bug: `Parameterize` and `Tokenizable` for wasm enums is broken

### DIFF
--- a/packages/fuels-macros/src/derive/parameterize.rs
+++ b/packages/fuels-macros/src/derive/parameterize.rs
@@ -96,7 +96,7 @@ fn parameterize_for_enum(
             fn param_type() -> #fuels_types_path::param_types::ParamType {
                 let variants = #std_lib::vec![#(#variant_param_types),*];
 
-                let variants = #fuels_types_path::enum_variants::EnumVariants::new(variants).unwrap_or_else(|_| #std_lib::panic!("{} has no variants which isn't allowed.", #enum_name_str));
+                let variants = #fuels_types_path::enum_variants::EnumVariants::new(variants).unwrap_or_else(|_| ::std::panic!("{} has no variants which isn't allowed.", #enum_name_str));
                 #fuels_types_path::param_types::ParamType::Enum {
                     variants,
                     generics: #std_lib::vec![#(#generic_param_types),*]

--- a/packages/fuels-macros/src/derive/tokenizable.rs
+++ b/packages/fuels-macros/src/derive/tokenizable.rs
@@ -103,7 +103,7 @@ fn tokenizable_for_enum(
 
                 let variants = match <Self as #fuels_types_path::traits::Parameterize>::param_type() {
                     #fuels_types_path::param_types::ParamType::Enum{variants, ..} => variants,
-                    other => #std_lib::panic!("Calling {}::param_type() must return a ParamType::Enum but instead it returned: {:?}", #name_stringified, other)
+                    other => ::std::panic!("Calling {}::param_type() must return a ParamType::Enum but instead it returned: {:?}", #name_stringified, other)
                 };
 
                 #fuels_types_path::Token::Enum(#std_lib::boxed::Box::new((discriminant, token, variants)))

--- a/packages/wasm-tests/src/lib.rs
+++ b/packages/wasm-tests/src/lib.rs
@@ -2,123 +2,115 @@ extern crate alloc;
 
 #[cfg(test)]
 mod tests {
-    use fuels::{
-        core::abi_encoder::ABIEncoder,
-        macros::wasm_abigen,
-        types::{traits::Tokenizable, Bits256},
-    };
+    use fuels::{core::abi_encoder::ABIEncoder, macros::wasm_abigen, types::traits::Tokenizable};
     use wasm_bindgen_test::wasm_bindgen_test;
 
     wasm_abigen!(Contract(
         name = "no_name",
         abi = r#"
-    {
-        "types": [
-          {
-            "typeId": 0,
-            "type": "()",
-            "components": [],
-            "typeParameters": null
-          },
-          {
-            "typeId": 1,
-            "type": "b256",
-            "components": null,
-            "typeParameters": null
-          },
-          {
-            "typeId": 2,
-            "type": "bool",
-            "components": null,
-            "typeParameters": null
-          },
-          {
-            "typeId": 3,
-            "type": "struct AnotherEvent",
-            "components": [
-              {
-                "name": "id",
-                "type": 5,
-                "typeArguments": null
-              },
-              {
-                "name": "hash",
-                "type": 1,
-                "typeArguments": null
-              },
-              {
-                "name": "bar",
-                "type": 2,
-                "typeArguments": null
-              }
-            ],
-            "typeParameters": null
-          },
-          {
-            "typeId": 4,
-            "type": "struct SomeEvent",
-            "components": [
-              {
-                "name": "id",
-                "type": 5,
-                "typeArguments": null
-              },
-              {
-                "name": "account",
-                "type": 1,
-                "typeArguments": null
-              }
-            ],
-            "typeParameters": null
-          },
-          {
-            "typeId": 5,
-            "type": "u64",
-            "components": null,
-            "typeParameters": null
-          }
-        ],
-        "functions": [
-          {
-            "inputs": [
-              {
-                "name": "e1",
-                "type": 4,
-                "typeArguments": null
-              },
-              {
-                "name": "e2",
-                "type": 3,
-                "typeArguments": null
-              }
-            ],
-            "name": "takes_struct",
-            "output": {
-              "name": "",
-              "type": 0,
-              "typeArguments": null
-            }
-          }
-        ],
-        "loggedTypes": []
-      }
-    "#
+                {
+                  "types": [
+                    {
+                      "typeId": 0,
+                      "type": "()",
+                      "components": [],
+                      "typeParameters": null
+                    },
+                    {
+                      "typeId": 1,
+                      "type": "bool",
+                      "components": null,
+                      "typeParameters": null
+                    },
+                    {
+                      "typeId": 2,
+                      "type": "enum SomeEnum",
+                      "components": [
+                        {
+                          "name": "v1",
+                          "type": 0,
+                          "typeArguments": null
+                        },
+                        {
+                          "name": "v2",
+                          "type": 3,
+                          "typeArguments": null
+                        }
+                      ],
+                      "typeParameters": [
+                        3
+                      ]
+                    },
+                    {
+                      "typeId": 3,
+                      "type": "generic T",
+                      "components": null,
+                      "typeParameters": null
+                    },
+                    {
+                      "typeId": 4,
+                      "type": "struct SomeStruct",
+                      "components": [
+                        {
+                          "name": "a",
+                          "type": 5,
+                          "typeArguments": null
+                        },
+                        {
+                          "name": "b",
+                          "type": 1,
+                          "typeArguments": null
+                        }
+                      ],
+                      "typeParameters": null
+                    },
+                    {
+                      "typeId": 5,
+                      "type": "u32",
+                      "components": null,
+                      "typeParameters": null
+                    }
+                  ],
+                  "functions": [
+                    {
+                      "inputs": [
+                        {
+                          "name": "arg",
+                          "type": 2,
+                          "typeArguments": [
+                            {
+                              "name": "",
+                              "type": 4,
+                              "typeArguments": null
+                            }
+                          ]
+                        }
+                      ],
+                      "name": "test_function",
+                      "output": {
+                        "name": "",
+                        "type": 0,
+                        "typeArguments": null
+                      },
+                      "attributes": null
+                    }
+                  ],
+                  "loggedTypes": [],
+                  "messagesTypes": [],
+                  "configurables": []
+        }"#
     ));
 
     #[wasm_bindgen_test]
     fn decoding_and_encoding() {
-        let original_event = AnotherEvent {
-            id: 2,
-            hash: Bits256([2; 32]),
-            bar: true,
-        };
+        let original = SomeEnum::v2(SomeStruct { a: 123, b: false });
 
-        let bytes = ABIEncoder::encode(&[original_event.clone().into_token()])
+        let bytes = ABIEncoder::encode(&[original.clone().into_token()])
             .unwrap()
             .resolve(0);
 
-        let reconstructed_event: AnotherEvent = bytes.try_into().unwrap();
+        let reconstructed = bytes.try_into().unwrap();
 
-        assert_eq!(original_event, reconstructed_event);
+        assert_eq!(original, reconstructed);
     }
 }


### PR DESCRIPTION
closes: #927 

Our wasm tests didn't use enums at all and thus didn't catch that there is no `::alloc::panic` only `::std::panic`. 

The tests have been expanded to include both structs and enums.


### Checklist
- [x] I have linked to any relevant issues.
- [x] I have updated the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
