### PR TITLE
refactor: unify type import path

### DIFF
--- a/examples/types/src/lib.rs
+++ b/examples/types/src/lib.rs
@@ -46,7 +46,7 @@ mod tests {
         // ANCHOR: address
         use std::str::FromStr;
 
-        use fuels::tx::Address;
+        use fuels::types::Address;
 
         // Zeroed Bytes32
         let address = Address::zeroed();
@@ -70,10 +70,7 @@ mod tests {
     #[tokio::test]
     async fn bech32() -> Result<()> {
         // ANCHOR: bech32
-        use fuels::{
-            prelude::Bech32Address,
-            tx::{Address, Bytes32},
-        };
+        use fuels::{prelude::Bech32Address, tx::Bytes32, types::Address};
 
         // New from HRP string and a hash
         let hrp = "fuel";
@@ -107,7 +104,7 @@ mod tests {
         // ANCHOR: asset_id
         use std::str::FromStr;
 
-        use fuels::tx::AssetId;
+        use fuels::types::AssetId;
 
         // Zeroed Bytes32
         let asset_id = AssetId::zeroed();
@@ -133,7 +130,7 @@ mod tests {
         // ANCHOR: contract_id
         use std::str::FromStr;
 
-        use fuels::tx::ContractId;
+        use fuels::types::ContractId;
 
         // Zeroed Bytes32
         let contract_id = ContractId::zeroed();
@@ -159,7 +156,7 @@ mod tests {
     #[tokio::test]
     async fn type_conversion() -> Result<()> {
         // ANCHOR: type_conversion
-        use fuels::tx::{AssetId, ContractId};
+        use fuels::types::{AssetId, ContractId};
 
         let contract_id = ContractId::new([1u8; 32]);
 

--- a/examples/wallets/src/lib.rs
+++ b/examples/wallets/src/lib.rs
@@ -315,7 +315,7 @@ mod tests {
                 launch_provider_and_get_wallet, BASE_ASSET_ID, DEFAULT_COIN_AMOUNT,
                 DEFAULT_NUM_COINS,
             },
-            tx::AssetId,
+            types::AssetId,
         };
 
         let wallet = launch_provider_and_get_wallet().await;

--- a/packages/fuels-types/src/resource.rs
+++ b/packages/fuels-types/src/resource.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "std")]
 
 use fuel_core_client::client::schema::resource::Resource as ClientResource;
-use fuel_tx::AssetId;
+use fuel_types::AssetId;
 
 use crate::{coin::Coin, constants::BASE_ASSET_ID, message::Message};
 

--- a/packages/fuels/src/lib.rs
+++ b/packages/fuels/src/lib.rs
@@ -18,7 +18,9 @@ pub mod tx {
 
 #[cfg(feature = "std")]
 pub mod client {
-    pub use fuel_core_client::client::*;
+    pub use fuel_core_client::client::FuelClient;
+    pub use fuel_core_client::client::PageDirection;
+    pub use fuel_core_client::client::PaginationRequest;
 }
 
 pub mod macros {

--- a/packages/fuels/src/lib.rs
+++ b/packages/fuels/src/lib.rs
@@ -13,14 +13,12 @@
 //! the [test suite](https://github.com/FuelLabs/fuels-rs/tree/master/packages/fuels/tests)
 
 pub mod tx {
-    pub use fuel_tx::*;
+    pub use fuel_tx::{Bytes32, ConsensusParameters, Receipt, Salt, StorageSlot};
 }
 
 #[cfg(feature = "std")]
 pub mod client {
-    pub use fuel_core_client::client::FuelClient;
-    pub use fuel_core_client::client::PageDirection;
-    pub use fuel_core_client::client::PaginationRequest;
+    pub use fuel_core_client::client::{FuelClient, PageDirection, PaginationRequest};
 }
 
 pub mod macros {

--- a/packages/fuels/tests/predicates.rs
+++ b/packages/fuels/tests/predicates.rs
@@ -1,7 +1,7 @@
 use fuel_tx::Output;
 use fuels::{
     prelude::*,
-    tx::AssetId,
+    types::AssetId,
     types::{coin::Coin, message::Message},
 };
 use fuels_accounts::{predicate::Predicate, Account};

--- a/packages/fuels/tests/types_predicates.rs
+++ b/packages/fuels/tests/types_predicates.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use fuels::{
     prelude::*,
-    tx::AssetId,
+    types::AssetId,
     types::{coin::Coin, message::Message},
 };
 use fuels_accounts::{predicate::Predicate, Account};


### PR DESCRIPTION
Closes #926 by removing the glob `*` pattern exports of `fuel-core-client` and `fuel-tx` module. 
