### PR TITLE
feat!: add predicate configurables

### DIFF
--- a/docs/src/contracts/configurable-constants.md
+++ b/docs/src/contracts/configurable-constants.md
@@ -5,7 +5,7 @@ In Sway, you can define `configurable` constants which can be changed during the
 ```rust,ignore
 {{#include ../../../packages/fuels/tests/contracts/configurables/src/main.sw}}
 ```
-Each of the configurable constants will get a dedicated `set` method in the SDK. For example, the constant `STR_4` will get the `set_STR_4` method which accepts the same types as defined in the contract code. Below is an example where we chain several `set` methods and deploy the contract with the new constants.
+Each of the configurable constants will get a dedicated `set` method in the SDK. For example, the constant `STR_4` will get the `set_STR_4` method which accepts the same type as defined in the contract code. Below is an example where we chain several `set` methods and deploy the contract with the new constants.
 
 ```rust,ignore
 {{#include ../../../packages/fuels/tests/configurables.rs:contract_configurables}}

--- a/docs/src/getting-started/predicates.md
+++ b/docs/src/getting-started/predicates.md
@@ -42,12 +42,12 @@ Then we can transfer assets owned by the predicate via the [Account](../getting-
 
 ## Configurable constants
 
-Same as contracts and scripts, you can define configurable constants in `predicates` which can be changed during the predicate execution. Here is an example how the constants are defined.
+Same as contracts and scripts, you can define configurable constants in `predicates`, which can be changed during the predicate execution. Here is an example of how the constants are defined.
 
 ```rust,ignore
 {{#include ../../../packages/fuels/tests/predicates/predicate_configurables/src/main.sw:predicate_configurables}}
 ```
-Each of the configurable constants will get a dedicated `set` method in the SDK. For example, the constant `U8` will get the `set_U8` method which accepts the same type as defined in sway. Below is an example where we chain several `set` methods and update the predicate with the new constants.
+Each configurable constant will get a dedicated `set` method in the SDK. For example, the constant `U8` will get the `set_U8` method which accepts the same type defined in sway. Below is an example where we chain several `set` methods and update the predicate with the new constants.
 
 ```rust,ignore
 {{#include ../../../packages/fuels/tests/predicates.rs:predicate_configurables}}

--- a/docs/src/getting-started/predicates.md
+++ b/docs/src/getting-started/predicates.md
@@ -12,7 +12,11 @@ Let's consider the following predicate example:
 
 We will look at a complete example of using the SDK to send and receive funds from a predicate.
 
-First, we set up the wallets, node, and a predicate encoder instance. The call to the `abigen!` macro will generate all the types specified in the predicate plus a custom encoder with an `encode_data` function that will conveniently encode all the arguments of the main function for us.
+First, we set up the wallets and a node instance. The call to the `abigen!` macro will generate all the types specified in the predicate plus two custom stucts:
+- an encoder with an `encode_data`  function that will conveniently encode all the arguments of the main function for us.
+- a configurables struct which holds methods for setting all the configurables mentioned in the predicate
+
+> Note: The `abigen!` macro will append `Encoder` and `Configurables` to the predicate's `name` field. Fox example, `name="MyPredicate"` will result in two structs called `MyPredicateEncoder` and `MyPredicateConfigurables`.
 
 ```rust,ignore
 {{#include ../../../examples/predicates/src/lib.rs:predicate_data_setup}}
@@ -35,3 +39,15 @@ Then we can transfer assets owned by the predicate via the [Account](../getting-
 ```rust,ignore
 {{#include ../../../examples/predicates/src/lib.rs:predicate_data_unlock}}
 ```
+
+## Configurable constants
+
+Same as contracts and scripts, you can define configurable constants in `predicates` which can be changed during the predicate execution. Here is an example how the constants are defined.
+
+```rust,ignore
+{{#include ../../../packages/fuels/tests/predicates/predicate_configurables/src/main.sw:predicate_configurables}}
+```
+Each of the configurable constants will get a dedicated `set` method in the SDK. For example, the constant `U8` will get the `set_U8` method which accepts the same type as defined in sway. Below is an example where we chain several `set` methods and update the predicate with the new constants.
+
+```rust,ignore
+{{#include ../../../packages/fuels/tests/predicates.rs:predicate_configurables}}

--- a/docs/src/getting-started/running-scripts.md
+++ b/docs/src/getting-started/running-scripts.md
@@ -42,7 +42,7 @@ Same as contracts, you can define `configurable` constants in `scripts` which ca
 ```rust,ignore
 {{#include ../../../packages/fuels/tests/scripts/script_configurables/src/main.sw}}
 ```
-Each of the configurable constants will get a dedicated `set` method in the SDK. For example, the constant `STR_4` will get the `set_STR_4` method which accepts the same type as defined in sway. Below is an example where we chain several `set` methods and execute the script with the new constants.
+Each configurable constant will get a dedicated `set` method in the SDK. For example, the constant `STR_4` will get the `set_STR_4` method which accepts the same type defined in sway. Below is an example where we chain several `set` methods and execute the script with the new constants.
 
 ```rust,ignore
 {{#include ../../../packages/fuels/tests/configurables.rs:script_configurables}}

--- a/docs/src/getting-started/running-scripts.md
+++ b/docs/src/getting-started/running-scripts.md
@@ -42,7 +42,7 @@ Same as contracts, you can define `configurable` constants in `scripts` which ca
 ```rust,ignore
 {{#include ../../../packages/fuels/tests/scripts/script_configurables/src/main.sw}}
 ```
-Each of the configurable constants will get a dedicated `set` method in the SDK. For example, the constant `STR_4` will get the `set_str_4` method which accepts the same types as defined in sway. Below is an example where we chain several `set` methods and execute the script with the new constants.
+Each of the configurable constants will get a dedicated `set` method in the SDK. For example, the constant `STR_4` will get the `set_STR_4` method which accepts the same type as defined in sway. Below is an example where we chain several `set` methods and execute the script with the new constants.
 
 ```rust,ignore
 {{#include ../../../packages/fuels/tests/configurables.rs:script_configurables}}

--- a/docs/src/testing/the-setup-program-test-macro.md
+++ b/docs/src/testing/the-setup-program-test-macro.md
@@ -37,7 +37,7 @@ Abigen
 ---
 
 Example:
-```rust,noplayground
+```rust,ignore
 Abigen(
     Contract(
         name = "MyContract",

--- a/examples/predicates/src/lib.rs
+++ b/examples/predicates/src/lib.rs
@@ -74,7 +74,7 @@ mod tests {
 
         // ANCHOR: predicate_load
         abigen!(Predicate(
-            name = "MyPredicateEncoder",
+            name = "MyPredicate",
             abi = "packages/fuels/tests/predicates/signatures/out/debug/signatures-abi.json"
         ));
 
@@ -143,7 +143,7 @@ mod tests {
         let first_wallet = &wallets[0];
         let second_wallet = &wallets[1];
 
-        abigen!(Predicate(name="MyPredicateEncoder", abi="packages/fuels/tests/predicates/basic_predicate/out/debug/basic_predicate-abi.json"));
+        abigen!(Predicate(name="MyPredicate", abi="packages/fuels/tests/predicates/basic_predicate/out/debug/basic_predicate-abi.json"));
         // ANCHOR_END: predicate_data_setup
 
         // ANCHOR: with_predicate_data

--- a/packages/fuels-accounts/src/predicate.rs
+++ b/packages/fuels-accounts/src/predicate.rs
@@ -2,6 +2,7 @@ use std::{fmt::Debug, fs};
 
 use fuel_tx::Contract;
 use fuel_types::{Address, AssetId};
+use fuels_core::Configurables;
 use fuels_types::{
     bech32::Bech32Address, constants::BASE_ASSET_ID, errors::Result, input::Input,
     transaction_builders::TransactionBuilder, unresolved_bytes::UnresolvedBytes,
@@ -74,6 +75,17 @@ impl Predicate {
     pub fn with_provider(mut self, provider: Provider) -> Predicate {
         self.set_provider(provider);
         self
+    }
+
+    pub fn with_configurables(mut self, configurables: impl Into<Configurables>) -> Self {
+        let configurables: Configurables = configurables.into();
+        configurables.update_constants_in(&mut self.code);
+
+        Self {
+            data: self.data,
+            provider: self.provider,
+            ..Self::from_code(self.code)
+        }
     }
 }
 

--- a/packages/fuels-code-gen/src/program_bindings/abigen/bindings/script.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/bindings/script.rs
@@ -59,10 +59,10 @@ pub(crate) fn script_bindings(
                ::core::result::Result::Ok(#name { account, binary: self.binary, log_decoder: self.log_decoder})
             }
 
-            pub fn with_configurables(mut self, configurables: impl Into<::fuels::programs::Configurables>)
+            pub fn with_configurables(mut self, configurables: impl Into<::fuels::core::Configurables>)
                 -> Self
             {
-                let configurables: ::fuels::programs::Configurables = configurables.into();
+                let configurables: ::fuels::core::Configurables = configurables.into();
                 configurables.update_constants_in(&mut self.binary);
                 self
             }

--- a/packages/fuels-code-gen/src/program_bindings/abigen/configurables.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/configurables.rs
@@ -108,9 +108,9 @@ fn generate_encoder_code(ttype: &ResolvedType) -> TokenStream {
 
 fn generate_from_impl(configurable_struct_name: &Ident) -> TokenStream {
     quote! {
-        impl From<#configurable_struct_name> for ::fuels::programs::Configurables {
+        impl From<#configurable_struct_name> for ::fuels::core::Configurables {
             fn from(config: #configurable_struct_name) -> Self {
-                ::fuels::programs::Configurables::new(config.offsets_with_data)
+                ::fuels::core::Configurables::new(config.offsets_with_data)
             }
         }
     }

--- a/packages/fuels-core/src/lib.rs
+++ b/packages/fuels-core/src/lib.rs
@@ -10,6 +10,24 @@ pub mod abi_encoder;
 pub mod function_selector;
 pub mod utils;
 
+#[derive(Debug, Clone, Default)]
+pub struct Configurables {
+    offsets_with_data: Vec<(u64, Vec<u8>)>,
+}
+
+impl Configurables {
+    pub fn new(offsets_with_data: Vec<(u64, Vec<u8>)>) -> Self {
+        Self { offsets_with_data }
+    }
+
+    pub fn update_constants_in(&self, binary: &mut [u8]) {
+        for (offset, data) in &self.offsets_with_data {
+            let offset = *offset as usize;
+            binary[offset..offset + data.len()].copy_from_slice(data)
+        }
+    }
+}
+
 pub fn try_from_bytes<T>(bytes: &[u8]) -> Result<T>
 where
     T: Parameterize + Tokenizable,

--- a/packages/fuels-programs/src/contract.rs
+++ b/packages/fuels-programs/src/contract.rs
@@ -7,7 +7,7 @@ use fuel_tx::{
 };
 use fuel_vm::fuel_asm::PanicReason;
 use fuels_accounts::{provider::TransactionCost, Account};
-use fuels_core::abi_encoder::ABIEncoder;
+use fuels_core::{abi_encoder::ABIEncoder, Configurables};
 use fuels_types::{
     bech32::{Bech32Address, Bech32ContractId},
     constants::{BASE_ASSET_ID, DEFAULT_CALL_PARAMS_AMOUNT},
@@ -26,7 +26,6 @@ use crate::{
     call_utils::build_tx_from_contract_calls,
     logs::{map_revert_error, LogDecoder},
     receipt_parser::ReceiptParser,
-    Configurables,
 };
 
 #[derive(Debug, Clone)]

--- a/packages/fuels-programs/src/lib.rs
+++ b/packages/fuels-programs/src/lib.rs
@@ -4,21 +4,3 @@ pub mod contract;
 pub mod logs;
 pub mod receipt_parser;
 pub mod script_calls;
-
-#[derive(Debug, Clone, Default)]
-pub struct Configurables {
-    offsets_with_data: Vec<(u64, Vec<u8>)>,
-}
-
-impl Configurables {
-    pub fn new(offsets_with_data: Vec<(u64, Vec<u8>)>) -> Self {
-        Self { offsets_with_data }
-    }
-
-    pub fn update_constants_in(&self, binary: &mut [u8]) {
-        for (offset, data) in &self.offsets_with_data {
-            let offset = *offset as usize;
-            binary[offset..offset + data.len()].copy_from_slice(data)
-        }
-    }
-}

--- a/packages/fuels/Forc.toml
+++ b/packages/fuels/Forc.toml
@@ -30,6 +30,7 @@ members = [
   'tests/logs/script_logs',
   'tests/logs/script_with_contract_logs',
   'tests/predicates/basic_predicate',
+  'tests/predicates/predicate_configurables',
   'tests/predicates/signatures',
   'tests/scripts/arguments',
   'tests/scripts/basic_script',

--- a/packages/fuels/src/lib.rs
+++ b/packages/fuels/src/lib.rs
@@ -80,7 +80,6 @@ pub mod prelude {
                 SettableContract, StorageConfiguration,
             },
             logs::{LogDecoder, LogId},
-            Configurables,
         },
         test_helpers::*,
     };

--- a/packages/fuels/tests/predicates/predicate_configurables/Forc.toml
+++ b/packages/fuels/tests/predicates/predicate_configurables/Forc.toml
@@ -1,0 +1,7 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "predicate_configurables"
+
+[dependencies]

--- a/packages/fuels/tests/predicates/predicate_configurables/src/main.sw
+++ b/packages/fuels/tests/predicates/predicate_configurables/src/main.sw
@@ -1,0 +1,48 @@
+predicate;
+
+impl Eq for StructWithGeneric<u8> {
+    fn eq(self, other: Self) -> bool {
+        self.field_1 == other.field_1 && self.field_2 == other.field_2
+    }
+}
+
+impl Eq for EnumWithGeneric<bool> {
+    fn eq(self, other: Self) -> bool {
+        match (self, other) {
+            (EnumWithGeneric::VariantOne, EnumWithGeneric::VariantOne) => true,
+            (EnumWithGeneric::VariantTwo, EnumWithGeneric::VariantTwo) => true,
+            _ => false,
+        }
+    }
+}
+
+// ANCHOR: predicate_configurables
+enum EnumWithGeneric<D> {
+    VariantOne: D,
+    VariantTwo: (),
+}
+
+struct StructWithGeneric<D> {
+    field_1: D,
+    field_2: u64,
+}
+
+configurable {
+    U8: u8 = 8u8,
+    BOOL: bool = true,
+    STRUCT: StructWithGeneric<u8> = StructWithGeneric {
+        field_1: 8u8,
+        field_2: 16,
+    },
+    ENUM: EnumWithGeneric<bool> = EnumWithGeneric::VariantOne(true),
+}
+
+fn main(
+    u_8: u8,
+    switch: bool,
+    some_struct: StructWithGeneric<u8>,
+    some_enum: EnumWithGeneric<bool>,
+) -> bool {
+    u_8 == U8 && switch == BOOL && some_struct == STRUCT && some_enum == ENUM
+}
+// ANCHOR_END: predicate_configurables

--- a/packages/fuels/tests/types_predicates.rs
+++ b/packages/fuels/tests/types_predicates.rs
@@ -138,7 +138,7 @@ async fn setup_predicate_test(
 #[tokio::test]
 async fn spend_predicate_coins_messages_single_u64() -> Result<()> {
     abigen!(Predicate(
-        name = "MyPredicateEncoder",
+        name = "MyPredicate",
         abi = "packages/fuels/tests/types/predicates/u64/out/debug/u64-abi.json"
     ));
 
@@ -152,7 +152,7 @@ async fn spend_predicate_coins_messages_single_u64() -> Result<()> {
 #[tokio::test]
 async fn spend_predicate_coins_messages_address() -> Result<()> {
     abigen!(Predicate(
-        name = "MyPredicateEncoder",
+        name = "MyPredicate",
         abi = "packages/fuels/tests/types/predicates/address/out/debug/address-abi.json"
     ));
 
@@ -166,10 +166,11 @@ async fn spend_predicate_coins_messages_address() -> Result<()> {
 
     Ok(())
 }
+
 #[tokio::test]
 async fn spend_predicate_coins_messages_enums() -> Result<()> {
     abigen!(Predicate(
-        name = "MyPredicateEncoder",
+        name = "MyPredicate",
         abi = "packages/fuels/tests/types/predicates/enums/out/debug/enums-abi.json"
     ));
 
@@ -183,7 +184,7 @@ async fn spend_predicate_coins_messages_enums() -> Result<()> {
 #[tokio::test]
 async fn spend_predicate_coins_messages_structs() -> Result<()> {
     abigen!(Predicate(
-        name = "MyPredicateEncoder",
+        name = "MyPredicate",
         abi = "packages/fuels/tests/types/predicates/structs/out/debug/structs-abi.json"
     ));
 
@@ -203,7 +204,7 @@ async fn spend_predicate_coins_messages_structs() -> Result<()> {
 #[tokio::test]
 async fn spend_predicate_coins_messages_tuple() -> Result<()> {
     abigen!(Predicate(
-        name = "MyPredicateEncoder",
+        name = "MyPredicate",
         abi = "packages/fuels/tests/types/predicates/predicate_tuples/out/debug/predicate_tuples-abi.json"
     ));
 
@@ -218,7 +219,7 @@ async fn spend_predicate_coins_messages_tuple() -> Result<()> {
 #[tokio::test]
 async fn spend_predicate_coins_messages_vector() -> Result<()> {
     abigen!(Predicate(
-        name = "MyPredicateEncoder",
+        name = "MyPredicate",
         abi =
             "packages/fuels/tests/types/predicates/predicate_vector/out/debug/predicate_vector-abi.json"
     ));
@@ -232,7 +233,7 @@ async fn spend_predicate_coins_messages_vector() -> Result<()> {
 
 #[tokio::test]
 async fn spend_predicate_coins_messages_vectors() -> Result<()> {
-    abigen!(Predicate(name="MyPredicateEncoder", abi="packages/fuels/tests/types/predicates/predicate_vectors/out/debug/predicate_vectors-abi.json"));
+    abigen!(Predicate(name="MyPredicate", abi="packages/fuels/tests/types/predicates/predicate_vectors/out/debug/predicate_vectors-abi.json"));
 
     let u32_vec = vec![0, 4, 3];
     let vec_in_vec = vec![vec![0, 2, 2], vec![0, 1, 2]];
@@ -275,7 +276,7 @@ async fn spend_predicate_coins_messages_vectors() -> Result<()> {
 
 #[tokio::test]
 async fn spend_predicate_coins_messages_generics() -> Result<()> {
-    abigen!(Predicate(name="MyPredicateEncoder", abi="packages/fuels/tests/types/predicates/predicate_generics/out/debug/predicate_generics-abi.json"));
+    abigen!(Predicate(name="MyPredicate", abi="packages/fuels/tests/types/predicates/predicate_generics/out/debug/predicate_generics-abi.json"));
 
     let data = MyPredicateEncoder::encode_data(
         GenericStruct { value: 64u8 },
@@ -290,7 +291,7 @@ async fn spend_predicate_coins_messages_generics() -> Result<()> {
 #[tokio::test]
 async fn spend_predicate_coins_messages_bytes() -> Result<()> {
     abigen!(Predicate(
-        name = "MyPredicateEncoder",
+        name = "MyPredicate",
         abi = "packages/fuels/tests/types/predicates/predicate_bytes/out/debug/predicate_bytes-abi.json"
     ));
 
@@ -310,7 +311,7 @@ async fn spend_predicate_coins_messages_bytes() -> Result<()> {
 #[tokio::test]
 async fn spend_predicate_coins_messages_raw_slice() -> Result<()> {
     abigen!(Predicate(
-        name = "MyPredicateEncoder",
+        name = "MyPredicate",
         abi = "packages/fuels/tests/types/predicates/predicate_raw_slice/out/debug/predicate_raw_slice-abi.json"
     ));
 


### PR DESCRIPTION
closes: https://github.com/FuelLabs/fuels-rs/issues/931

Adds configurables for predicates the same way we did for scripts. The `Predicate` struct now has a method called `with_configurables` that creates a new updated predicate. Here is an example:
```rust
    abigen!(Predicate(
        name = "MyPredicate",
        abi = "packages/fuels/tests/predicates/predicate_configurables/out/debug/predicate_configurables-abi.json"
    ));

    let new_struct = StructWithGeneric {
        field_1: 32u8,
        field_2: 64,
    };
    let new_enum = EnumWithGeneric::VariantTwo;

    let configurables = MyPredicateConfigurables::new()
        .set_STRUCT(new_struct.clone())
        .set_ENUM(new_enum.clone());

    let predicate_data = MyPredicateEncoder::encode_data(8u8, true, new_struct, new_enum);

    let mut predicate: Predicate = Predicate::load_from(
        "tests/predicates/predicate_configurables/out/debug/predicate_configurables.bin",
    )?
    .with_data(predicate_data)
    .with_configurables(configurables);
```
- I had to move `Configurables` to `fuels-core` to avoid a circular dependency with `fuels-programs`.
- the `abigen!` name field for predicates does not include `Encoder` anymore. I append both `Encoder` and `Configurables` on the provided name.

### Checklist
- [x] I have linked to any relevant issues.
- [x] I have updated the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.

### Breaking changes
- `abigen!` name field for predicates does not contain the `Encoder` part anymore.