### PR TITLE
chore: reorganize and bump external dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ members = [
     "examples/types",
     "examples/wallets",
     "packages/fuels",
+    "packages/fuels-accounts",
     "packages/fuels-code-gen",
     "packages/fuels-core",
     "packages/fuels-macros",
     "packages/fuels-programs",
-    "packages/fuels-accounts",
     "packages/fuels-test-helpers",
     "packages/fuels-types",
     "packages/wasm-tests",
@@ -37,23 +37,52 @@ rust-version = "1.68.0"
 version = "0.41.0"
 
 [workspace.dependencies]
+Inflector = "0.11.4"
+async-trait = { version = "0.1.68", default-features = false }
+bech32 = "0.9.1"
+bytes = { version = "1.4.0", default-features = false }
+chrono = "0.4.24"
+elliptic-curve = { version = "0.13.4", default-features = false }
+eth-keystore = "0.5.0"
+fuel-abi-types = "0.2.1"
 fuel-asm = "0.26"
+fuel-core = { version = "0.17", default-features = false }
+fuel-core-chain-config = { version = "0.17", default-features = false }
+fuel-core-client = { version = "0.17", default-features = false }
+fuel-core-types = { version = "0.17", default-features = false }
 fuel-crypto = "0.26"
 fuel-merkle = "0.26"
 fuel-storage = "0.26"
 fuel-tx = "0.26"
 fuel-types = { version = "0.26", default-features = false }
-fuel-abi-types = "0.2.1"
-fuel-core = { version = "0.17", default-features = false }
-fuel-core-client = { version = "0.17", default-features = false }
-fuel-core-chain-config = { version = "0.17", default-features = false }
-fuel-core-types = { version = "0.17", default-features = false }
 fuel-vm = "0.26"
 fuels = { version = "0.41.0", path = "./packages/fuels" }
+fuels-accounts = { version = "0.41.0", path = "./packages/fuels-accounts", default-features = false }
 fuels-code-gen = { version = "0.41.0", path = "./packages/fuels-code-gen", default-features = false }
 fuels-core = { version = "0.41.0", path = "./packages/fuels-core", default-features = false }
 fuels-macros = { version = "0.41.0", path = "./packages/fuels-macros", default-features = false }
 fuels-programs = { version = "0.41.0", path = "./packages/fuels-programs", default-features = false }
-fuels-accounts = { version = "0.41.0", path = "./packages/fuels-accounts", default-features = false }
 fuels-test-helpers = { version = "0.41.0", path = "./packages/fuels-test-helpers", default-features = false }
 fuels-types = { version = "0.41.0", path = "./packages/fuels-types", default-features = false }
+futures = "0.3.26"
+hex = { version = "0.4.3", default-features = false }
+itertools = "0.10"
+portpicker = "0.1.1"
+proc-macro2 = "1.0"
+quote = "1.0"
+rand = "0.8"
+regex = "1.8.1"
+serde = { version = "1.0", default-features = false }
+serde_json = "1.0.96"
+serde_with = { version = "2.3.2", default-features = false }
+sha2 = "0.10.6"
+strum = "0.24"
+strum_macros = "0.24"
+syn = "1.0.107"
+tai64 = { version = "4.0", default-features = false }
+tempfile = "3.5.0"
+thiserror = { version = "1.0.40", default-features = false }
+tokio = { version = "1.27.0", default-features = false }
+trybuild = "1.0.80"
+which = { version = "4.4", default-features = false }
+

--- a/examples/abigen/Cargo.toml
+++ b/examples/abigen/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "fuels-example-abigen"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
 publish = false
-version = "0.0.0"
-authors = ["Fuel Labs <contact@fuel.sh>"]
-edition = "2021"
-homepage = "https://fuel.network/"
-license = "Apache-2.0"
-repository = "https://github.com/FuelLabs/fuels-rs"
+repository = { workspace = true }
 description = "Fuel Rust SDK abigen examples."
 
 [dev-dependencies]
 fuels = { workspace = true }
-tokio = { version = "1.10", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }

--- a/examples/contracts/Cargo.toml
+++ b/examples/contracts/Cargo.toml
@@ -1,19 +1,18 @@
 [package]
 name = "fuels-example-contracts"
-version = "0.0.0"
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
 publish = false
-authors = ["Fuel Labs <contact@fuel.sh>"]
-homepage = "https://fuel.network/"
-license = "Apache-2.0"
-repository = "https://github.com/FuelLabs/fuels-rs"
+repository = { workspace = true }
 description = "Fuel Rust SDK contract examples."
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
+[dev-dependencies]
 fuels = { workspace = true }
-rand = "0.8"
-tokio = { version = "1.10", features = ["full"] }
+rand = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
 
 [features]
 fuel-core-lib = ["fuels/fuel-core-lib"]

--- a/examples/cookbook/Cargo.toml
+++ b/examples/cookbook/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "fuels-example-cookbook"
-version = "0.0.0"
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
 publish = false
-authors = ["Fuel Labs <contact@fuel.sh>"]
-homepage = "https://fuel.network/"
-license = "Apache-2.0"
-repository = "https://github.com/FuelLabs/fuels-rs"
+repository = { workspace = true }
 description = "Fuel Rust SDK cookbook examples."
 
-[dependencies]
+[dev-dependencies]
 fuels = { workspace = true }
-rand = "0.8"
-tokio = { version = "1.10", features = ["full"] }
+rand = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/examples/debugging/Cargo.toml
+++ b/examples/debugging/Cargo.toml
@@ -1,19 +1,17 @@
 [package]
 name = "fuels-example-debugging"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
 publish = false
-version = "0.0.0"
-authors = ["Fuel Labs <contact@fuel.sh>"]
-edition = "2021"
-homepage = "https://fuel.network/"
-license = "Apache-2.0"
-repository = "https://github.com/FuelLabs/fuels-rs"
+repository = { workspace = true }
 description = "Fuel Rust SDK debugging examples."
 
-[dependencies]
-fuel-abi-types = "0.2.0"
-fuels = { workspace = true }
-rand = "0.8.5"
-tokio = { version = "1.10", features = ["full"] }
-
 [dev-dependencies]
-serde_json = "1.0.86"
+fuel-abi-types = { workspace = true }
+fuels = { workspace = true }
+rand = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/examples/predicates/Cargo.toml
+++ b/examples/predicates/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "fuels-example-predicates"
-version = "0.0.0"
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
 publish = false
-authors = ["Fuel Labs <contact@fuel.sh>"]
-homepage = "https://fuel.network/"
-license = "Apache-2.0"
-repository = "https://github.com/FuelLabs/fuels-rs"
-description = "Fuel Rust SDK cookbook examples."
+repository = { workspace = true }
+description = "Fuel Rust SDK predicate examples."
 
-[dependencies]
+[dev-dependencies]
 fuels = { workspace = true }
-rand = "0.8"
-tokio = { version = "1.10", features = ["full"] }
+rand = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/examples/providers/Cargo.toml
+++ b/examples/providers/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "fuels-example-providers"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
 publish = false
-version = "0.0.0"
-authors = ["Fuel Labs <contact@fuel.sh>"]
-edition = "2021"
-homepage = "https://fuel.network/"
-license = "Apache-2.0"
-repository = "https://github.com/FuelLabs/fuels-rs"
+repository = { workspace = true }
 description = "Fuel Rust SDK provider examples."
 
-[dependencies]
+[dev-dependencies]
 fuels = { workspace = true }
-rand = "0.8.5"
-tokio = { version = "1.10", features = ["full"] }
+rand = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/examples/rust_bindings/Cargo.toml
+++ b/examples/rust_bindings/Cargo.toml
@@ -1,18 +1,17 @@
 [package]
 name = "fuels-example-rust-bindings"
-version = "0.0.0"
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
 publish = false
-authors = ["Fuel Labs <contact@fuel.sh>"]
-homepage = "https://fuel.network/"
-license = "Apache-2.0"
-repository = "https://github.com/FuelLabs/fuels-rs"
+repository = { workspace = true }
 description = "Fuel Rust SDK examples for Rust-native bindings"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
+[dev-dependencies]
 fuels = { workspace = true }
 fuels-macros = { workspace = true }
-proc-macro2 = "1.0"
-rand = "0.8"
-tokio = { version = "1.10", features = ["full"] }
+proc-macro2 = { workspace = true }
+rand = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/examples/types/Cargo.toml
+++ b/examples/types/Cargo.toml
@@ -1,16 +1,15 @@
 [package]
 name = "fuels-example-types"
-version = "0.0.0"
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
 publish = false
-authors = ["Fuel Labs <contact@fuel.sh>"]
-homepage = "https://fuel.network/"
-license = "Apache-2.0"
-repository = "https://github.com/FuelLabs/fuels-rs"
+repository = { workspace = true }
 description = "Fuel Rust SDK types examples."
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
+[dev-dependencies]
 fuels = { workspace = true }
-rand = "0.8"
-tokio = { version = "1.10", features = ["full"] }
+rand = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/examples/wallets/Cargo.toml
+++ b/examples/wallets/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "fuels-example-wallets"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
 publish = false
-version = "0.0.0"
-authors = ["Fuel Labs <contact@fuel.sh>"]
-edition = "2021"
-homepage = "https://fuel.network/"
-license = "Apache-2.0"
-repository = "https://github.com/FuelLabs/fuels-rs"
+repository = { workspace = true }
 description = "Fuel Rust SDK wallet examples."
 
-[dependencies]
+[dev-dependencies]
 fuels = { workspace = true }
-rand = "0.8.5"
-tokio = { version = "1.10", features = ["full"] }
+rand = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/packages/fuels-accounts/Cargo.toml
+++ b/packages/fuels-accounts/Cargo.toml
@@ -10,11 +10,11 @@ rust-version = { workspace = true }
 description = "Fuel Rust SDK accounts."
 
 [dependencies]
-async-trait = { version = "0.1.50", default-features = false }
-bytes = { version = "1.1.0", features = ["serde"] }
-chrono = "0.4.2"
-elliptic-curve = { version = "0.11.6", default-features = false }
-eth-keystore = { version = "0.3.0" }
+async-trait = { workspace = true, default-features = false }
+bytes = { workspace = true, features = ["serde"] }
+chrono = { workspace = true }
+elliptic-curve = { workspace = true, default-features = false }
+eth-keystore =  { workspace = true }
 fuel-core = { workspace = true, default-features = false, optional = true }
 fuel-core-client = { workspace = true, features = ["default"] }
 fuel-crypto = { workspace = true, features = ["random"] }
@@ -23,18 +23,18 @@ fuel-types = { workspace = true, features = ["random"] }
 fuel-vm = { workspace = true }
 fuels-core = { workspace = true }
 fuels-types = { workspace = true }
-hex = { version = "0.4.3", default-features = false, features = ["std"] }
-itertools = "0.10"
-rand = { version = "0.8.4", default-features = false }
-serde = { version = "1.0.124", default-features = true, features = ["derive"] }
-sha2 = { version = "0.9.8", default-features = false }
-tai64 = { version = "4.0", features = ["serde"] }
-thiserror = { version = "1.0.30", default-features = false }
-tokio = { version = "1.10.1", features = ["full"] }
+hex = { workspace = true, default-features = false, features = ["std"] }
+itertools = { workspace = true }
+rand = { workspace = true, default-features = false }
+serde = { workspace = true, default-features = true, features = ["derive"] }
+sha2 = { workspace = true, default-features = false }
+tai64 = { workspace = true, features = ["serde"] }
+thiserror = { workspace = true, default-features = false }
+tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
-hex = { version = "0.4.3", default-features = false, features = ["std"] }
-tempfile = "3.3.0"
+hex = { workspace = true, default-features = false, features = ["std"] }
+tempfile = { workspace = true }
 
 [features]
 default = ["std"]

--- a/packages/fuels-accounts/src/wallet.rs
+++ b/packages/fuels-accounts/src/wallet.rs
@@ -180,7 +180,7 @@ impl WalletUnlocked {
         R: Rng + CryptoRng + rand_core::CryptoRng,
         S: AsRef<[u8]>,
     {
-        let (secret, uuid) = eth_keystore::new(dir, rng, password)?;
+        let (secret, uuid) = eth_keystore::new(dir, rng, password, None)?;
 
         let secret_key = unsafe { SecretKey::from_slice_unchecked(&secret) };
 
@@ -203,6 +203,7 @@ impl WalletUnlocked {
             &mut rng,
             *self.private_key,
             password,
+            None,
         )?)
     }
 

--- a/packages/fuels-code-gen/Cargo.toml
+++ b/packages/fuels-code-gen/Cargo.toml
@@ -10,12 +10,11 @@ rust-version = { workspace = true }
 description = "Used for code generation in the Fuel Rust SDK"
 
 [dependencies]
-Inflector = "0.11.4"
-fuel-abi-types = "0.2.0"
-itertools = "0.10.5"
-lazy_static = "1.4.0"
-proc-macro2 = "1.0.50"
-quote = "1.0.23"
-regex = "1.7.1"
-serde_json = "1.0.91"
-syn = { version = "1.0.107" }
+Inflector = { workspace = true }
+fuel-abi-types = { workspace = true }
+itertools = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+regex = { workspace = true }
+serde_json = { workspace = true }
+syn = { workspace = true }

--- a/packages/fuels-core/Cargo.toml
+++ b/packages/fuels-core/Cargo.toml
@@ -14,9 +14,9 @@ fuel-tx = { workspace = true }
 fuel-types = { workspace = true, features = ["default"] }
 fuel-vm = { workspace = true }
 fuels-types = { workspace = true }
-hex = { version = "0.4.3", features = ["std"] }
-itertools = "0.10"
-sha2 = "0.9.5"
+hex = { workspace = true, features = ["std"] }
+itertools = { workspace = true }
+sha2 = { workspace = true }
 
 [features]
 default = ["std"]

--- a/packages/fuels-macros/Cargo.toml
+++ b/packages/fuels-macros/Cargo.toml
@@ -13,18 +13,17 @@ description = "Fuel Rust SDK marcros to generate types from ABI."
 proc-macro = true
 
 [dependencies]
-Inflector = "0.11"
-fuel-abi-types = "0.2.0"
+Inflector = { workspace = true }
+fuel-abi-types = { workspace = true }
 fuels-code-gen = { workspace = true }
-itertools = "0.10.5"
-lazy_static = "1.4.0"
-proc-macro2 = "1.0"
-quote = "1.0"
-rand = "0.8"
-regex = "1.7.1"
-serde_json = "1.0.91"
-syn = { version = "1.0.107", features = ["extra-traits"] }
+itertools = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+rand = { workspace = true }
+regex = { workspace = true }
+serde_json = { workspace = true }
+syn = { workspace = true, features = ["extra-traits"] }
 
 [dev-dependencies]
-trybuild = "1.0.73"
+trybuild = { workspace = true }
 

--- a/packages/fuels-programs/Cargo.toml
+++ b/packages/fuels-programs/Cargo.toml
@@ -10,8 +10,8 @@ rust-version = { workspace = true }
 description = "Fuel Rust SDK contracts."
 
 [dependencies]
-async-trait = { version = "0.1.50", default-features = false }
-bytes = { version = "1.0.1", features = ["serde"] }
+async-trait = { workspace = true, default-features = false }
+bytes = { workspace = true, features = ["serde"] }
 fuel-abi-types = { workspace = true }
 fuel-tx = { workspace = true }
 fuel-types = { workspace = true, features = ["default"] }
@@ -19,19 +19,18 @@ fuel-vm = { workspace = true }
 fuels-accounts = { workspace = true }
 fuels-core = { workspace = true }
 fuels-types = { workspace = true }
-futures = "0.3.21"
-hex = { version = "0.4.3", default-features = false, features = ["std"] }
-itertools = "0.10.3"
-proc-macro2 = "1.0"
-rand = "0.8"
-regex = "1.5.4"
-serde = { version = "1.0.124", default-features = false, features = ["derive"] }
-serde_json = { version = "1.0.64", default-features = true }
-sha2 = "0.9.5"
-strum = "0.21"
-strum_macros = "0.21"
-thiserror = { version = "1.0.26", default-features = false }
-tokio = "1.12"
+hex = { workspace = true, default-features = false, features = ["std"] }
+itertools = { workspace = true }
+proc-macro2 = { workspace = true }
+rand = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true, default-features = false, features = ["derive"] }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+thiserror = { workspace = true, default-features = false }
+tokio = { workspace = true }
 
 [features]
 default = ["std"]

--- a/packages/fuels-test-helpers/Cargo.toml
+++ b/packages/fuels-test-helpers/Cargo.toml
@@ -19,16 +19,16 @@ fuel-types = { workspace = true, features = ["random"] }
 fuel-vm = { workspace = true }
 fuels-accounts = { workspace = true, optional = true }
 fuels-types = { workspace = true }
-futures = "0.3.26"
-hex = { version = "0.4.3", default-features = false, features = ["std", "serde"] }
-portpicker = { version = "0.1.1" }
-rand = { version = "0.8.4", default-features = false }
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = { version = "1.0", features = ["raw_value"] }
-serde_with = { version = "1.11", features = ["serde_json"] }
-tempfile = { version = "3.0.1", default-features = false }
-tokio = { version = "1.15", default-features = false }
-which = { version = "4.3", default-features = false }
+futures = { workspace = true }
+hex = { workspace = true, default-features = false, features = ["std", "serde"] }
+portpicker = { workspace = true }
+rand = { workspace = true, default-features = false }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["raw_value"] }
+serde_with = { workspace = true }
+tempfile = { workspace = true, default-features = false }
+tokio = { workspace = true, default-features = false }
+which = { workspace = true, default-features = false }
 
 [features]
 default = ["fuels-accounts", "std"]

--- a/packages/fuels-types/Cargo.toml
+++ b/packages/fuels-types/Cargo.toml
@@ -10,26 +10,25 @@ rust-version = { workspace = true }
 description = "Serializable type representation for working with the Fuel VM ABI."
 
 [dependencies]
-regex = "1.6.0"
-lazy_static = "1.4.0"
-bech32 = "0.9.0"
-chrono = "0.4.2"
-fuel-tx = { workspace = true }
-fuel-types = { workspace = true, features = ["default"] }
-fuel-asm = { workspace = true }
+bech32 = { workspace = true }
+chrono = { workspace = true }
 fuel-abi-types = { workspace = true }
+fuel-asm = { workspace = true }
 fuel-core = { workspace = true, default-features = false, optional = true }
 fuel-core-chain-config = { workspace = true }
 fuel-core-client = { workspace = true, optional = true }
-hex = { version = "0.4.3", features = ["std"] }
-proc-macro2 = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0.64", default-features = true }
-strum = "0.21"
-strum_macros = "0.21"
-itertools = "0.10.5"
-thiserror = { version = "1.0.26", default-features = false }
+fuel-tx = { workspace = true }
+fuel-types = { workspace = true, features = ["default"] }
 fuels-macros = { workspace = true }
+hex = { workspace = true, features = ["std"] }
+itertools = { workspace = true }
+proc-macro2 = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+thiserror = { workspace = true, default-features = false }
 
 [features]
 default = ["std"]

--- a/packages/fuels/Cargo.toml
+++ b/packages/fuels/Cargo.toml
@@ -21,12 +21,12 @@ fuels-test-helpers = { workspace = true, optional = true }
 fuels-types = { workspace = true }
 
 [dev-dependencies]
-chrono = "0.4.2"
+chrono = { workspace = true }
 fuel-core = { workspace = true, default-features = false }
 fuel-core-types = { workspace = true }
-hex = { version = "0.4.3", default-features = false }
-sha2 = "0.9.5"
-tokio = "1.15.0"
+hex = { workspace = true, default-features = false }
+sha2 = { workspace = true }
+tokio = { workspace = true }
 
 [features]
 default = ["std", "fuels-test-helpers?/fuels-accounts"]

--- a/packages/wasm-tests/Cargo.toml
+++ b/packages/wasm-tests/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
 name = "wasm-tests"
-version = "0.0.0"
+version = { workspace = true }
+authors = { workspace = true }
 edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
 publish = false
+repository = { workspace = true }
+rust-version = { workspace = true }
 
 [lib]
 crate-type = ['cdylib']


### PR DESCRIPTION
In this PR, I moved all our package dependencies to the workspace `Cargo.toml` and bumped all* to their latest versions (*except for `syn` - I will handle `syn` in a new PR as it introduced a lot of breaking changes)

### Checklist
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
