### PR TITLE
chore: update `sway` to `0.38.0` and `fuel-core` to `0.17.11`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ env:
   CARGO_TERM_COLOR: always
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
   RUSTFLAGS: "-D warnings"
-  FUEL_CORE_VERSION: 0.17.4
+  FUEL_CORE_VERSION: 0.17.11
   RUST_VERSION: 1.68.0
-  FORC_VERSION: 0.35.5
+  FORC_VERSION: 0.38.0
   FORC_PATCH_BRANCH: ""
   FORC_PATCH_REVISION: ""
 

--- a/ci_checks.sh
+++ b/ci_checks.sh
@@ -2,16 +2,19 @@
 
 # Requires installed:
 # The latest version of the `forc`,`forc-fmt` and `fuel-core`.
-# `cargo install fuel-core-bin --git https://github.com/FuelLabs/fuel-core --tag v0.16.1 --locked`
-# `cargo install forc --git https://github.com/FuelLabs/sway --tag v0.35.1 --locked`
-# `cargo install forc-fmt --git https://github.com/FuelLabs/sway --tag v0.35.1 --locked`
+# `cargo install fuel-core-bin --git https://github.com/FuelLabs/fuel-core --tag v0.17.11 --locked`
+# `cargo install forc --git https://github.com/FuelLabs/sway --tag v0.38.0 --locked`
+# `cargo install forc-fmt --git https://github.com/FuelLabs/sway --tag v0.38.0 --locked`
 # Note, if you need a custom branch, you can replace `--tag {RELEASE}` with the `--branch {BRANCH_NAME}`.
 
-cargo run --bin test-projects -- build &&
-cargo run --bin test-projects -- format --check &&
-cargo fmt --all --verbose -- --check &&
+cargo fmt --all -- --check &&
+forc fmt --check --path packages/fuels &&
+forc build --terse --path packages/fuels &&
+forc build --terse --json-abi-with-callpaths --path packages/fuels &&
+cargo clippy --all-targets &&
 cargo clippy --all-targets --all-features &&
 cargo test --all-targets --all-features &&
-cargo test --all-targets &&
-# May fail after `cargo doc`
-cargo run --bin check-docs
+cargo test --all-targets --all-features --workspace &&
+cargo test --all-targets --workspace &&
+cargo run --bin check-docs &&
+cargo doc |& grep -A 6  "warning: unresolved link to"

--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -107,7 +107,7 @@ mod tests {
             .await?;
         // ANCHOR_END: contract_call_cost_estimation
 
-        assert_eq!(transaction_cost.gas_used, 430);
+        assert_eq!(transaction_cost.gas_used, 505);
 
         Ok(())
     }
@@ -676,7 +676,7 @@ mod tests {
             .await?;
         // ANCHOR_END: multi_call_cost_estimation
 
-        assert_eq!(transaction_cost.gas_used, 700);
+        assert_eq!(transaction_cost.gas_used, 790);
 
         Ok(())
     }

--- a/packages/fuels/tests/bindings/sharing_types/shared_lib/src/lib.sw
+++ b/packages/fuels/tests/bindings/sharing_types/shared_lib/src/lib.sw
@@ -1,4 +1,4 @@
-library shared_lib;
+library;
 
 pub struct SharedStruct1<T> {
     a: T,

--- a/packages/fuels/tests/bindings/type_paths/src/another_lib.sw
+++ b/packages/fuels/tests/bindings/type_paths/src/another_lib.sw
@@ -1,4 +1,4 @@
-library another_lib;
+library;
 
 pub struct VeryCommonNameStruct {
     field_a: u32,

--- a/packages/fuels/tests/bindings/type_paths/src/contract_a_types.sw
+++ b/packages/fuels/tests/bindings/type_paths/src/contract_a_types.sw
@@ -1,4 +1,4 @@
-library contract_a_types;
+library;
 
 pub struct VeryCommonNameStruct {
     another_field: u32,

--- a/packages/fuels/tests/bindings/type_paths/src/main.sw
+++ b/packages/fuels/tests/bindings/type_paths/src/main.sw
@@ -1,7 +1,7 @@
 contract;
 
-dep contract_a_types;
-dep another_lib;
+mod contract_a_types;
+mod another_lib;
 
 use contract_a_types::AWrapper;
 use another_lib::VeryCommonNameStruct;

--- a/packages/fuels/tests/contracts.rs
+++ b/packages/fuels/tests/contracts.rs
@@ -275,7 +275,7 @@ async fn test_contract_call_fee_estimation() -> Result<()> {
     let tolerance = 0.2;
 
     let expected_min_gas_price = 0; // This is the default min_gas_price from the ConsensusParameters
-    let expected_gas_used = 516;
+    let expected_gas_used = 606;
     let expected_metered_bytes_size = 720;
     let expected_total_fee = 368;
 

--- a/packages/fuels/tests/contracts/auth_testing_abi/src/main.sw
+++ b/packages/fuels/tests/contracts/auth_testing_abi/src/main.sw
@@ -1,4 +1,4 @@
-library auth_testing_abi;
+library;
 
 abi AuthTesting {
     fn is_caller_external() -> bool;

--- a/packages/fuels/tests/contracts/configurables/src/main.sw
+++ b/packages/fuels/tests/contracts/configurables/src/main.sw
@@ -27,7 +27,7 @@ abi TestContract {
 }
 
 impl TestContract for Contract {
-    fn return_configurables(    ) -> (u8, bool, [u32; 3], str[4], StructWithGeneric<u8>, EnumWithGeneric<bool>) {
+    fn return_configurables() -> (u8, bool, [u32; 3], str[4], StructWithGeneric<u8>, EnumWithGeneric<bool>) {
         (U8, BOOL, ARRAY, STR_4, STRUCT, ENUM)
     }
 }

--- a/packages/fuels/tests/contracts/contract_test/src/main.sw
+++ b/packages/fuels/tests/contracts/contract_test/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::storage::{get, store};
+use std::storage::storage_api::{read, write};
 use std::context::msg_amount;
 
 struct MyType {
@@ -47,20 +47,20 @@ impl TestContract for Contract {
     // ANCHOR_END: msg_amount
     #[storage(write)]
     fn initialize_counter(value: u64) -> u64 {
-        store(COUNTER_KEY, value);
+        write(COUNTER_KEY, 0, value);
         value
     }
 
     #[storage(read, write)]
     fn increment_counter(value: u64) -> u64 {
-        let new_value = get::<u64>(COUNTER_KEY).unwrap_or(0) + value;
-        store(COUNTER_KEY, new_value);
+        let new_value = read::<u64>(COUNTER_KEY, 0).unwrap_or(0) + value;
+        write(COUNTER_KEY, 0, new_value);
         new_value
     }
 
     #[storage(read)]
     fn get_counter() -> u64 {
-        get::<u64>(COUNTER_KEY).unwrap_or(0)
+        read::<u64>(COUNTER_KEY, 0).unwrap_or(0)
     }
 
     fn get(x: u64, y: u64) -> u64 {

--- a/packages/fuels/tests/contracts/lib_contract_abi/src/main.sw
+++ b/packages/fuels/tests/contracts/lib_contract_abi/src/main.sw
@@ -1,4 +1,4 @@
-library contract_abi;
+library;
 
 abi LibContract {
     fn increment(value: u64) -> u64;

--- a/packages/fuels/tests/contracts/library_test/src/main.sw
+++ b/packages/fuels/tests/contracts/library_test/src/main.sw
@@ -1,4 +1,4 @@
-library increment_abi;
+library;
 
 abi Incrementor {
     fn initialize(gas: u64, amt: u64, coin: b256, initial_value: u64) -> u64;

--- a/packages/fuels/tests/contracts/multiple_read_calls/src/main.sw
+++ b/packages/fuels/tests/contracts/multiple_read_calls/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::storage::{get, store};
+use std::storage::storage_api::{read, write};
 
 abi MyContract {
     #[storage(write)]
@@ -14,12 +14,12 @@ const COUNTER_KEY = 0x0000000000000000000000000000000000000000000000000000000000
 impl MyContract for Contract {
     #[storage(write)]
     fn store(input: u64) {
-        store(COUNTER_KEY, input);
+        write(COUNTER_KEY, 0, input);
     }
 
     #[storage(read)]
     fn read(input: u64) -> u64 {
-        let v = get::<u64>(COUNTER_KEY).unwrap_or(0);
+        let v = read::<u64>(COUNTER_KEY, 0).unwrap_or(0);
         v
     }
 }

--- a/packages/fuels/tests/contracts/storage/src/main.sw
+++ b/packages/fuels/tests/contracts/storage/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::storage::get;
+use std::storage::storage_api::read;
 
 storage {
     x: u64 = 64,
@@ -17,11 +17,11 @@ abi MyContract {
 impl MyContract for Contract {
     #[storage(read)]
     fn get_value_b256(key: b256) -> b256 {
-        get::<b256>(key).unwrap()
+        read::<b256>(key, 0).unwrap()
     }
 
     #[storage(read)]
     fn get_value_u64(key: b256) -> u64 {
-        get::<u64>(key).unwrap()
+        read::<u64>(key, 0).unwrap()
     }
 }

--- a/packages/fuels/tests/logs/contract_logs/src/main.sw
+++ b/packages/fuels/tests/logs/contract_logs/src/main.sw
@@ -123,8 +123,8 @@ impl ContractLogs for Contract {
     }
 
     fn produce_bad_logs() {
-       // produce a custom log with log id 128
-       // this log id will not be present in abi JSON
+        // produce a custom log with log id 128
+        // this log id will not be present in abi JSON
         asm(r1: 0, r2: 128, r3: 0, r4: 0) {
             log  r1 r2 r3 r4;
         }

--- a/packages/fuels/tests/logs/contract_logs_abi/src/main.sw
+++ b/packages/fuels/tests/logs/contract_logs_abi/src/main.sw
@@ -1,4 +1,4 @@
-library contract_logs_abi;
+library;
 
 use std::logging::log;
 

--- a/packages/fuels/tests/types/contracts/call_empty_return/src/main.sw
+++ b/packages/fuels/tests/types/contracts/call_empty_return/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::storage::{get, store};
+use std::storage::storage_api::write;
 
 abi TestContract {
     #[storage(write)]
@@ -12,6 +12,6 @@ const COUNTER_KEY = 0x0000000000000000000000000000000000000000000000000000000000
 impl TestContract for Contract {
     #[storage(write)]
     fn store_value(val: u64) {
-        store(COUNTER_KEY, val);
+        write(COUNTER_KEY, 0, val);
     }
 }

--- a/packages/fuels/tests/types/contracts/complex_types_contract/src/main.sw
+++ b/packages/fuels/tests/types/contracts/complex_types_contract/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::storage::{get, store};
+use std::storage::storage_api::{read, write};
 
 struct EmptyStruct {}
 
@@ -24,14 +24,14 @@ impl TestContract for Contract {
     #[storage(write)]
     fn initialize_counter(config: CounterConfig) -> u64 {
         let value = config.initial_value;
-        store(COUNTER_KEY, value);
+        write(COUNTER_KEY, 0, value);
         value
     }
 
     #[storage(read, write)]
     fn increment_counter(amount: u64) -> u64 {
-        let value = get::<u64>(COUNTER_KEY).unwrap_or(0) + amount;
-        store(COUNTER_KEY, value);
+        let value = read::<u64>(COUNTER_KEY, 0).unwrap_or(0) + amount;
+        write(COUNTER_KEY, 0, value);
         value
     }
 

--- a/packages/fuels/tests/types/contracts/empty_arguments/src/main.sw
+++ b/packages/fuels/tests/types/contracts/empty_arguments/src/main.sw
@@ -1,7 +1,5 @@
 contract;
 
-use std::storage::{get, store};
-
 abi TestContract {
     fn method_with_empty_argument() -> u64;
 }

--- a/packages/fuels/tests/types/contracts/vector_output/src/main.sw
+++ b/packages/fuels/tests/types/contracts/vector_output/src/main.sw
@@ -26,7 +26,6 @@ abi VectorsOutputContract {
     fn u16_in_vec(len: u16) -> Vec<u16>;
     fn u32_in_vec(len: u32) -> Vec<u32>;
     fn u64_in_vec(len: u64) -> Vec<u64>;
-    fn u64_in_vec(len: u64) -> Vec<u64>;
     fn u8_in_vec(len: u8) -> Vec<u8>;
 }
 

--- a/packages/fuels/tests/types/contracts/vectors/src/data_structures.sw
+++ b/packages/fuels/tests/types/contracts/vectors/src/data_structures.sw
@@ -1,4 +1,4 @@
-library data_structures;
+library;
 
 pub struct SomeStruct<T> {
     a: T,

--- a/packages/fuels/tests/types/contracts/vectors/src/eq_impls.sw
+++ b/packages/fuels/tests/types/contracts/vectors/src/eq_impls.sw
@@ -1,8 +1,6 @@
-library eq_impls;
+library;
 
-dep data_structures;
-
-use data_structures::{SomeEnum, SomeStruct};
+use ::data_structures::{SomeEnum, SomeStruct};
 use core::ops::Eq;
 
 impl Eq for (u32, u32) {

--- a/packages/fuels/tests/types/contracts/vectors/src/main.sw
+++ b/packages/fuels/tests/types/contracts/vectors/src/main.sw
@@ -1,8 +1,8 @@
 contract;
 
-dep eq_impls;
-dep data_structures;
-dep utils;
+mod data_structures;
+mod eq_impls;
+mod utils;
 
 use eq_impls::*;
 use utils::*;

--- a/packages/fuels/tests/types/contracts/vectors/src/utils.sw
+++ b/packages/fuels/tests/types/contracts/vectors/src/utils.sw
@@ -1,4 +1,4 @@
-library utils;
+library;
 
 pub fn vec_from(vals: [u32; 3]) -> Vec<u32> {
     let mut vec = Vec::new();

--- a/packages/fuels/tests/types/scripts/script_vectors/src/data_structures.sw
+++ b/packages/fuels/tests/types/scripts/script_vectors/src/data_structures.sw
@@ -1,4 +1,4 @@
-library data_structures;
+library;
 
 pub struct SomeStruct<T> {
     a: T,

--- a/packages/fuels/tests/types/scripts/script_vectors/src/eq_impls.sw
+++ b/packages/fuels/tests/types/scripts/script_vectors/src/eq_impls.sw
@@ -1,8 +1,6 @@
-library eq_impls;
+library;
 
-dep data_structures;
-
-use data_structures::{SomeEnum, SomeStruct};
+use ::data_structures::{SomeEnum, SomeStruct};
 use core::ops::Eq;
 
 impl Eq for (u32, u32) {

--- a/packages/fuels/tests/types/scripts/script_vectors/src/main.sw
+++ b/packages/fuels/tests/types/scripts/script_vectors/src/main.sw
@@ -1,8 +1,8 @@
 script;
 
-dep eq_impls;
-dep data_structures;
-dep utils;
+mod data_structures;
+mod eq_impls;
+mod utils;
 
 use eq_impls::*;
 use utils::*;

--- a/packages/fuels/tests/types/scripts/script_vectors/src/utils.sw
+++ b/packages/fuels/tests/types/scripts/script_vectors/src/utils.sw
@@ -1,4 +1,4 @@
-library utils;
+library;
 
 pub fn vec_from(vals: [u32; 3]) -> Vec<u32> {
     let mut vec = Vec::new();


### PR DESCRIPTION
Bumping the sway to `0.38.0` and `fuel-core` to `0.17.11`. Updated contracts according to new breaching changes.

It is preparation for the `fuel-core 0.18.0`. I extracted it into a separate change not to mix breaking changes from the `fuel-core` with breaking changes from the `sway`. 
