### PR TITLE
add TransactionType enum

### DIFF
--- a/packages/fuels-types/src/transaction.rs
+++ b/packages/fuels-types/src/transaction.rs
@@ -60,6 +60,12 @@ impl Default for TxParameters {
 }
 use fuel_tx::field::{BytecodeLength, BytecodeWitnessIndex, Salt, StorageSlots};
 
+#[derive(Debug, Clone)]
+pub enum TransactionType {
+    Script(ScriptTransaction),
+    Create(CreateTransaction),
+}
+
 pub trait Transaction: Into<FuelTransaction> + Send {
     fn fee_checked_from_tx(&self, params: &ConsensusParameters) -> Option<TransactionFee>;
 
@@ -81,7 +87,7 @@ pub trait Transaction: Into<FuelTransaction> + Send {
 
     fn gas_limit(&self) -> u64;
 
-    fn with_gas_limit(self, gas_price: u64) -> Self;
+    fn with_gas_limit(self, gas_limit: u64) -> Self;
 
     fn with_tx_params(self, tx_params: TxParameters) -> Self;
 

--- a/packages/fuels-types/src/transaction_response.rs
+++ b/packages/fuels-types/src/transaction_response.rs
@@ -6,11 +6,13 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use fuel_core_client::client::types::{
     TransactionResponse as ClientTransactionResponse, TransactionStatus as ClientTransactionStatus,
 };
-use fuel_tx::{Bytes32, Transaction};
+use fuel_tx::Bytes32;
+
+use crate::transaction::{CreateTransaction, ScriptTransaction, TransactionType};
 
 #[derive(Debug, Clone)]
 pub struct TransactionResponse {
-    pub transaction: Transaction,
+    pub transaction: TransactionType,
     pub status: TransactionStatus,
     pub block_id: Option<Bytes32>,
     pub time: Option<DateTime<Utc>>,
@@ -46,8 +48,18 @@ impl From<ClientTransactionResponse> for TransactionResponse {
             }
         };
 
+        let transaction = match client_response.transaction {
+            fuel_tx::Transaction::Script(tx) => {
+                TransactionType::Script(ScriptTransaction::from(tx))
+            }
+            fuel_tx::Transaction::Create(tx) => {
+                TransactionType::Create(CreateTransaction::from(tx))
+            }
+            fuel_tx::Transaction::Mint(_) => unimplemented!(),
+        };
+
         Self {
-            transaction: client_response.transaction,
+            transaction,
             status: client_response.status.into(),
             block_id,
             time,

--- a/packages/fuels/tests/contracts.rs
+++ b/packages/fuels/tests/contracts.rs
@@ -275,7 +275,7 @@ async fn test_contract_call_fee_estimation() -> Result<()> {
     let tolerance = 0.2;
 
     let expected_min_gas_price = 0; // This is the default min_gas_price from the ConsensusParameters
-    let expected_gas_used = 606;
+    let expected_gas_used = 516;
     let expected_metered_bytes_size = 720;
     let expected_total_fee = 368;
 

--- a/packages/fuels/tests/wallets.rs
+++ b/packages/fuels/tests/wallets.rs
@@ -258,7 +258,10 @@ async fn send_transfer_transactions() -> Result<()> {
         .await?
         .unwrap();
 
-    let script: ScriptTransaction = res.transaction.as_script().cloned().unwrap().into();
+    let script: ScriptTransaction = match res.transaction {
+        TransactionType::Script(tx) => tx,
+        _ => panic!("Received unexpected tx type!"),
+    };
     assert_eq!(script.gas_limit(), gas_limit);
     assert_eq!(script.gas_price(), gas_price);
     assert_eq!(script.maturity(), maturity);


### PR DESCRIPTION
Closes #959

I've explored several approaches to make our API consistent here. 

One option was to have `TransactionResponse` hold a `Box<dyn Transaction>, but because of the object safety requirements, this had the following downsides:
- No `Into<FuelTransaction>` super trait possible, this would need to become a separate method
- `TransactionResponse` would no longer be `Clone`
- Box needs to be cloned internally to keep `with_` methods + a Box would have to be returned which could cause confusion
- And the worst one, a user would need to downcast the tx from a TransactionResponse to either `Script` or `Create`

The second option was to use an enum for the implementors of `Transaction` and then have the enum implement it too. The downside here is that we get a lot of repeated match statements to delegate every method of `Transaction` to the corresponding variant. Macros didn't provide a significant improvement here either.

Ultimately I decided to keep the enum but not implement `Transaction` for it. This means that we don't change our API anywhere else but also that the user has to potentially match the enum every time to use the underlying `Transaction` methods.

### Checklist
- [ ] I have linked to any relevant issues.
- [ ] I have updated the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary labels.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
