### PR TITLE
bug: reexport lost fuels::tx::Output under fuels::types::output::Output

### DIFF
--- a/packages/fuels-types/src/lib.rs
+++ b/packages/fuels-types/src/lib.rs
@@ -26,4 +26,8 @@ pub mod unresolved_bytes;
 
 pub use fuel_tx::{Address, AssetId, ContractId};
 
+pub mod output {
+    pub use fuel_tx::Output;
+}
+
 pub use crate::core::*;


### PR DESCRIPTION
We've recently lost our `fuels::tx::Output` reexport of the `fuel_tx::Output`, this PR introduces it back but under a less surprising location (`fuels::types::output::Output` to mimic the already existing `fuels::types::input::Input`)

Although I'm not a fan of the `output::Output` verbosity, I decided to leave it so that it doesn't surprise users. 

We should probably reexport the types under `fuels::types::{Input, Output}` rather than needlessly mention the internal mod structure.

### Checklist
- [x] I have linked to any relevant issues.
- [x] I have updated the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
