### PR TITLE
feat: add `Into` for `Address` and `ContractId` fn arguments

### DIFF
--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -350,7 +350,7 @@ mod tests {
 
         // withdraw some tokens to wallet
         let response = contract_methods
-            .transfer_coins_to_output(1_000_000, contract_id.into(), address.into())
+            .transfer_coins_to_output(1_000_000, contract_id, address)
             .append_variable_outputs(1)
             .call()
             .await?;
@@ -435,7 +435,7 @@ mod tests {
         let amount = 100;
 
         let response = contract_methods
-            .increment_from_contract_then_mint(called_contract_id, amount, address.into())
+            .increment_from_contract_then_mint(called_contract_id, amount, address)
             .call()
             .await;
 
@@ -447,7 +447,7 @@ mod tests {
 
         // ANCHOR: dependency_estimation_manual
         let response = contract_methods
-            .increment_from_contract_then_mint(called_contract_id, amount, address.into())
+            .increment_from_contract_then_mint(called_contract_id, amount, address)
             .append_variable_outputs(1)
             .set_contract_ids(&[called_contract_id.into()])
             .call()
@@ -460,7 +460,7 @@ mod tests {
 
         // ANCHOR: dependency_estimation
         let response = contract_methods
-            .increment_from_contract_then_mint(called_contract_id, amount, address.into())
+            .increment_from_contract_then_mint(called_contract_id, amount, address)
             .estimate_tx_dependencies(Some(2))
             .await?
             .call()

--- a/examples/cookbook/src/lib.rs
+++ b/examples/cookbook/src/lib.rs
@@ -57,7 +57,7 @@ mod tests {
             .set_asset_id(base_asset_id);
 
         contract_methods
-            .deposit(wallet.address().into())
+            .deposit(wallet.address())
             .call_params(call_params)?
             .append_variable_outputs(1)
             .call()
@@ -73,7 +73,7 @@ mod tests {
             .set_asset_id(lp_asset_id);
 
         contract_methods
-            .withdraw(wallet.address().into())
+            .withdraw(wallet.address())
             .call_params(call_params)?
             .append_variable_outputs(1)
             .call()

--- a/packages/fuels-code-gen/src/program_bindings/abi_types.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abi_types.rs
@@ -259,13 +259,15 @@ impl FullTypeDeclaration {
     }
 
     pub fn is_enum_type(&self) -> bool {
-        let type_field = &self.type_field;
-        type_field.starts_with("enum ")
+        self.type_field.starts_with("enum ")
     }
 
     pub fn is_struct_type(&self) -> bool {
-        let type_field = &self.type_field;
-        type_field.starts_with("struct ")
+        self.type_field.starts_with("struct ")
+    }
+
+    pub fn wrap_type_into(&self) -> bool {
+        self.type_field.ends_with("Address") || self.type_field.ends_with("ContractId")
     }
 }
 

--- a/packages/fuels-code-gen/src/program_bindings/custom_types/enums.rs
+++ b/packages/fuels-code-gen/src/program_bindings/custom_types/enums.rs
@@ -46,6 +46,7 @@ fn enum_decl(
         |Component {
              field_name,
              field_type,
+             ..
          }| {
             if field_type.is_unit() {
                 quote! {#field_name}

--- a/packages/fuels-code-gen/src/program_bindings/custom_types/structs.rs
+++ b/packages/fuels-code-gen/src/program_bindings/custom_types/structs.rs
@@ -43,6 +43,7 @@ fn struct_decl(
         |Component {
              field_name,
              field_type,
+             ..
          }| {
             quote! { pub #field_name: #field_type }
         },

--- a/packages/fuels-code-gen/src/program_bindings/custom_types/utils.rs
+++ b/packages/fuels-code-gen/src/program_bindings/custom_types/utils.rs
@@ -102,6 +102,7 @@ mod tests {
                     type_name: quote! {u8},
                     generic_params: vec![],
                 },
+                wrap_into: false,
             },
             Component {
                 field_name: ident("b"),
@@ -118,6 +119,7 @@ mod tests {
                         },
                     ],
                 },
+                wrap_into: false,
             },
         ];
 

--- a/packages/fuels-code-gen/src/program_bindings/utils.rs
+++ b/packages/fuels-code-gen/src/program_bindings/utils.rs
@@ -19,6 +19,7 @@ use crate::{
 pub(crate) struct Component {
     pub field_name: Ident,
     pub field_type: ResolvedType,
+    pub wrap_into: bool,
 }
 
 impl Component {
@@ -36,6 +37,7 @@ impl Component {
         Ok(Component {
             field_name: safe_ident(&field_name),
             field_type: TypeResolver::new(mod_of_component).resolve(component)?,
+            wrap_into: component.type_decl.wrap_type_into(),
         })
     }
 }

--- a/packages/fuels/tests/contracts.rs
+++ b/packages/fuels/tests/contracts.rs
@@ -76,7 +76,7 @@ async fn test_contract_calling_contract() -> Result<()> {
 
     let response = contract_caller_instance
         .methods()
-        .increment_from_contracts(lib_contract_id.into(), lib_contract_id2.into(), 42)
+        .increment_from_contracts(lib_contract_id, lib_contract_id2, 42)
         // Note that the two lib_contract_instances have different types
         .set_contracts(&[&lib_contract_instance, &lib_contract_instance2])
         .call()
@@ -87,7 +87,7 @@ async fn test_contract_calling_contract() -> Result<()> {
     // ANCHOR: external_contract
     let response = contract_caller_instance
         .methods()
-        .increment_from_contract(lib_contract_id.into(), 42)
+        .increment_from_contract(lib_contract_id, 42)
         .set_contracts(&[&lib_contract_instance])
         .call()
         .await?;
@@ -98,7 +98,7 @@ async fn test_contract_calling_contract() -> Result<()> {
     // ANCHOR: external_contract_ids
     let response = contract_caller_instance
         .methods()
-        .increment_from_contract(lib_contract_id.into(), 42)
+        .increment_from_contract(lib_contract_id, 42)
         .set_contract_ids(&[lib_contract_id.clone()])
         .call()
         .await?;
@@ -420,7 +420,7 @@ async fn test_auth_msg_sender_from_sdk() -> Result<()> {
     // Contract returns true if `msg_sender()` matches `wallet.address()`.
     let response = contract_instance
         .methods()
-        .check_msg_sender(wallet.address().into())
+        .check_msg_sender(wallet.address())
         .call()
         .await?;
 
@@ -549,7 +549,7 @@ async fn test_contract_setup_macro_deploy_with_salt() -> Result<()> {
     // The first contract can be called because they were deployed on the same provider
     let response = contract_caller_instance
         .methods()
-        .increment_from_contract(lib_contract_id.into(), 42)
+        .increment_from_contract(lib_contract_id, 42)
         .set_contracts(&[&lib_contract_instance])
         .call()
         .await?;
@@ -558,7 +558,7 @@ async fn test_contract_setup_macro_deploy_with_salt() -> Result<()> {
 
     let response = contract_caller_instance2
         .methods()
-        .increment_from_contract(lib_contract_id.into(), 42)
+        .increment_from_contract(lib_contract_id, 42)
         .set_contracts(&[&lib_contract_instance])
         .call()
         .await?;
@@ -943,7 +943,7 @@ async fn test_contract_set_estimation() -> Result<()> {
         // Should fail due to missing external contracts
         let res = contract_caller_instance
             .methods()
-            .increment_from_contract(lib_contract_id.into(), 42)
+            .increment_from_contract(lib_contract_id, 42)
             .call()
             .await;
 
@@ -952,7 +952,7 @@ async fn test_contract_set_estimation() -> Result<()> {
 
     let res = contract_caller_instance
         .methods()
-        .increment_from_contract(lib_contract_id.into(), 42)
+        .increment_from_contract(lib_contract_id, 42)
         .estimate_tx_dependencies(None)
         .await?
         .call()
@@ -1005,7 +1005,7 @@ async fn test_output_variable_contract_id_estimation_multicall() -> Result<()> {
     multi_call_handler.tx_params(Default::default());
 
     (0..3).for_each(|_| {
-        let call_handler = contract_methods.increment_from_contract(lib_contract_id.into(), 42);
+        let call_handler = contract_methods.increment_from_contract(lib_contract_id, 42);
         multi_call_handler.add_call(call_handler);
     });
 

--- a/packages/fuels/tests/logs.rs
+++ b/packages/fuels/tests/logs.rs
@@ -1260,8 +1260,8 @@ async fn contract_token_ops_error_messages() -> Result<()> {
         assert_revert_containing_msg("failed to send message", error);
     }
     {
-        let contract_id = contract_instance.contract_id().into();
-        let address = wallet.address().into();
+        let contract_id = contract_instance.contract_id();
+        let address = wallet.address();
 
         let error = contract_methods
             .transfer_coins_to_output(1_000_000, contract_id, address)

--- a/packages/fuels/tests/providers.rs
+++ b/packages/fuels/tests/providers.rs
@@ -369,7 +369,7 @@ async fn test_amount_and_asset_forwarding() -> Result<()> {
     let contract_methods = contract_instance.methods();
 
     let mut balance_response = contract_methods
-        .get_balance(contract_id.into(), contract_id.into())
+        .get_balance(contract_id, contract_id)
         .call()
         .await?;
     assert_eq!(balance_response.value, 0);
@@ -377,7 +377,7 @@ async fn test_amount_and_asset_forwarding() -> Result<()> {
     contract_methods.mint_coins(5_000_000).call().await?;
 
     balance_response = contract_methods
-        .get_balance(contract_id.into(), contract_id.into())
+        .get_balance(contract_id, contract_id)
         .call()
         .await?;
     assert_eq!(balance_response.value, 5_000_000);
@@ -410,7 +410,7 @@ async fn test_amount_and_asset_forwarding() -> Result<()> {
 
     // withdraw some tokens to wallet
     contract_methods
-        .transfer_coins_to_output(1_000_000, contract_id.into(), address.into())
+        .transfer_coins_to_output(1_000_000, contract_id, address)
         .append_variable_outputs(1)
         .call()
         .await?;


### PR DESCRIPTION
closes: https://github.com/FuelLabs/fuels-rs/issues/962

Our `FunctionGenerator` now generates `impl Into<Address>` and `impl Into<ContractId>` when those types are used as function arguments.

This is reflected on all `contract` methods, `predicate` encode functions, and `script` main functions.

### Checklist
- [x] I have linked to any relevant issues.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
