### PR TITLE
chore: use `#[allow(dead_code)]` in forc projects

### DIFF
--- a/packages/fuels/tests/bindings.rs
+++ b/packages/fuels/tests/bindings.rs
@@ -32,7 +32,7 @@ async fn compile_bindings_from_contract_file() {
 
     let call_handler = simple_contract_instance
         .methods()
-        .takes_ints_returns_bool(42);
+        .takes_int_returns_bool(42);
 
     let encoded_args = call_handler.contract_call.encoded_args.resolve(0);
     let encoded = format!(
@@ -41,7 +41,7 @@ async fn compile_bindings_from_contract_file() {
         hex::encode(encoded_args)
     );
 
-    assert_eq!("000000009593586c000000000000002a", encoded);
+    assert_eq!("000000005f68ee3d000000000000002a", encoded);
 }
 
 #[tokio::test]

--- a/packages/fuels/tests/bindings/sharing_types/contract_a/src/main.sw
+++ b/packages/fuels/tests/bindings/sharing_types/contract_a/src/main.sw
@@ -9,6 +9,7 @@ struct StructSameNameButDifferentInternals {
     a: u32,
 }
 
+#[allow(dead_code)]
 enum EnumSameNameButDifferentInternals {
     a: u32,
 }

--- a/packages/fuels/tests/bindings/sharing_types/contract_b/src/main.sw
+++ b/packages/fuels/tests/bindings/sharing_types/contract_b/src/main.sw
@@ -9,6 +9,7 @@ struct StructSameNameButDifferentInternals {
     a: [u64; 1],
 }
 
+#[allow(dead_code)]
 enum EnumSameNameButDifferentInternals {
     a: [u64; 1],
 }

--- a/packages/fuels/tests/bindings/sharing_types/shared_lib/src/lib.sw
+++ b/packages/fuels/tests/bindings/sharing_types/shared_lib/src/lib.sw
@@ -9,6 +9,7 @@ pub struct SharedStruct2<K> {
     b: SharedStruct1<K>,
 }
 
+#[allow(dead_code)]
 pub enum SharedEnum<L> {
     a: u64,
     b: SharedStruct2<L>,

--- a/packages/fuels/tests/bindings/simple_contract/src/main.sw
+++ b/packages/fuels/tests/bindings/simple_contract/src/main.sw
@@ -1,11 +1,11 @@
 contract;
 
 abi MyContract {
-    fn takes_ints_returns_bool(only_argument: u32) -> bool;
+    fn takes_int_returns_bool(arg: u32) -> bool;
 }
 
 impl MyContract for Contract {
-    fn takes_ints_returns_bool(only_argument: u32) -> bool {
-        true
+    fn takes_int_returns_bool(arg: u32) -> bool {
+        arg == 32u32
     }
 }

--- a/packages/fuels/tests/bindings/type_paths/src/main.sw
+++ b/packages/fuels/tests/bindings/type_paths/src/main.sw
@@ -11,7 +11,7 @@ abi MyContract {
 }
 
 impl MyContract for Contract {
-    fn test_function(arg: AWrapper) -> VeryCommonNameStruct {
+    fn test_function(_arg: AWrapper) -> VeryCommonNameStruct {
         VeryCommonNameStruct { field_a: 10u32 }
     }
 }

--- a/packages/fuels/tests/contracts.rs
+++ b/packages/fuels/tests/contracts.rs
@@ -29,7 +29,7 @@ async fn test_multiple_args() -> Result<()> {
     let contract_methods = contract_instance.methods();
     let response = contract_methods.get(5, 6).call().await?;
 
-    assert_eq!(response.value, 5);
+    assert_eq!(response.value, 11);
 
     let t = MyType { x: 5, y: 6 };
     let response = contract_methods.get_alt(t.clone()).call().await?;
@@ -162,11 +162,11 @@ async fn test_multiple_read_calls() -> Result<()> {
     // Use "simulate" because the methods don't actually run a transaction, but just a dry-run
     // We can notice here that, thanks to this, we don't generate a TransactionId collision,
     // even if the transactions are theoretically the same.
-    let stored = contract_methods.read(0).simulate().await?;
+    let stored = contract_methods.read().simulate().await?;
 
     assert_eq!(stored.value, 42);
 
-    let stored = contract_methods.read(0).simulate().await?;
+    let stored = contract_methods.read().simulate().await?;
 
     assert_eq!(stored.value, 42);
     Ok(())
@@ -1001,7 +1001,7 @@ async fn test_output_variable_contract_id_estimation_multicall() -> Result<()> {
         .call::<(u64, u64, u64, u64)>()
         .await?;
 
-    assert_eq!(call_response.value, (43, 43, 43, 5));
+    assert_eq!(call_response.value, (43, 43, 43, 11));
 
     Ok(())
 }
@@ -1043,7 +1043,7 @@ async fn test_contract_call_with_non_default_max_input() -> Result<()> {
 
     let response = contract_instance.methods().get(5, 6).call().await?;
 
-    assert_eq!(response.value, 5);
+    assert_eq!(response.value, 11);
 
     Ok(())
 }
@@ -1101,7 +1101,7 @@ async fn test_add_custom_assets() -> Result<()> {
         .call()
         .await?;
 
-    assert_eq!(response.value, 5);
+    assert_eq!(response.value, 11);
 
     let balance_asset_1 = wallet_1.get_asset_balance(&asset_id_1).await?;
     let balance_asset_2 = wallet_1.get_asset_balance(&asset_id_2).await?;

--- a/packages/fuels/tests/contracts/asserts/src/main.sw
+++ b/packages/fuels/tests/contracts/asserts/src/main.sw
@@ -5,6 +5,7 @@ struct TestStruct {
     field_2: u64,
 }
 
+#[allow(dead_code)]
 enum TestEnum {
     VariantOne: (),
     VariantTwo: (),

--- a/packages/fuels/tests/contracts/configurables/src/main.sw
+++ b/packages/fuels/tests/contracts/configurables/src/main.sw
@@ -1,5 +1,6 @@
 contract;
 
+#[allow(dead_code)]
 enum EnumWithGeneric<D> {
     VariantOne: D,
     VariantTwo: (),

--- a/packages/fuels/tests/contracts/contract_test/src/main.sw
+++ b/packages/fuels/tests/contracts/contract_test/src/main.sw
@@ -8,10 +8,12 @@ struct MyType {
     y: u64,
 }
 
+#[allow(dead_code)]
 struct Person {
     name: str[4],
 }
 
+#[allow(dead_code)]
 enum State {
     A: (),
     B: (),
@@ -107,7 +109,7 @@ impl TestContract for Contract {
     }
 
     fn get(x: u64, y: u64) -> u64 {
-        x
+        x + y
     }
 
     fn get_alt(t: MyType) -> MyType {

--- a/packages/fuels/tests/contracts/large_return_data/src/main.sw
+++ b/packages/fuels/tests/contracts/large_return_data/src/main.sw
@@ -35,18 +35,18 @@ impl TestContract for Contract {
     }
 
     fn get_small_struct() -> SmallStruct {
-        SmallStruct { foo: 100 }
+        SmallStruct { foo: 100u32 }
     }
 
     fn get_large_struct() -> LargeStruct {
         LargeStruct {
-            foo: 12,
-            bar: 42,
+            foo: 12u8,
+            bar: 42u8,
         }
     }
 
     fn get_large_array() -> [u32; 2] {
-        let x: [u32; 2] = [1, 2];
+        let x: [u32; 2] = [1u32, 2u32];
         x
     }
 

--- a/packages/fuels/tests/contracts/lib_contract_caller/src/main.sw
+++ b/packages/fuels/tests/contracts/lib_contract_caller/src/main.sw
@@ -25,12 +25,12 @@ impl ContractCaller for Contract {
         let contract_instance = abi(LibContract, contract_id.into());
         let contract_instance2 = abi(LibContract, contract_id2.into());
 
-        contract_instance.increment(value) + contract_instance.increment(value)
+        contract_instance.increment(value) + contract_instance2.increment(value)
     }
 
     fn increment_from_contract_then_mint(contract_id: ContractId, amount: u64, address: Address) {
         let contract_instance = abi(LibContract, contract_id.into());
-        let response = contract_instance.increment(42);
+        let _ = contract_instance.increment(42);
 
         mint_to_address(amount, address);
     }

--- a/packages/fuels/tests/contracts/multiple_read_calls/src/main.sw
+++ b/packages/fuels/tests/contracts/multiple_read_calls/src/main.sw
@@ -6,7 +6,7 @@ abi MyContract {
     #[storage(write)]
     fn store(input: u64);
     #[storage(read)]
-    fn read(input: u64) -> u64;
+    fn read() -> u64;
 }
 
 const COUNTER_KEY = 0x0000000000000000000000000000000000000000000000000000000000000000;
@@ -18,8 +18,7 @@ impl MyContract for Contract {
     }
 
     #[storage(read)]
-    fn read(input: u64) -> u64 {
-        let v = read::<u64>(COUNTER_KEY, 0).unwrap_or(0);
-        v
+    fn read() -> u64 {
+        read::<u64>(COUNTER_KEY, 0).unwrap_or(0)
     }
 }

--- a/packages/fuels/tests/contracts/require/src/main.sw
+++ b/packages/fuels/tests/contracts/require/src/main.sw
@@ -2,16 +2,19 @@ contract;
 
 use std::logging::log;
 
+#[allow(dead_code)]
 enum EnumWithGeneric<D> {
     VariantOne: D,
     VariantTwo: (),
 }
 
+#[allow(dead_code)]
 struct StructWithNestedGeneric<D> {
     field_1: D,
     field_2: u64,
 }
 
+#[allow(dead_code)]
 struct StructDeeplyNestedGeneric<D> {
     field_1: D,
     field_2: u64,

--- a/packages/fuels/tests/contracts/token_ops/src/main.sw
+++ b/packages/fuels/tests/contracts/token_ops/src/main.sw
@@ -50,9 +50,9 @@ impl TestFuelCoin for Contract {
 
     fn send_message(recipient: b256, coins: u64) {
         let mut data = Bytes::new();
-        data.push(1);
-        data.push(2);
-        data.push(3);
+        data.push(1u8);
+        data.push(2u8);
+        data.push(3u8);
 
         send_message(recipient, data, coins);
     }

--- a/packages/fuels/tests/logs/contract_logs/src/main.sw
+++ b/packages/fuels/tests/logs/contract_logs/src/main.sw
@@ -3,32 +3,38 @@ contract;
 use std::logging::log;
 use contract_logs::ContractLogs;
 
+#[allow(dead_code)]
 struct TestStruct {
     field_1: bool,
     field_2: b256,
     field_3: u64,
 }
 
+#[allow(dead_code)]
 enum TestEnum {
     VariantOne: (),
     VariantTwo: (),
 }
 
+#[allow(dead_code)]
 struct StructWithGeneric<D> {
     field_1: D,
     field_2: u64,
 }
 
+#[allow(dead_code)]
 enum EnumWithGeneric<D> {
     VariantOne: D,
     VariantTwo: (),
 }
 
+#[allow(dead_code)]
 struct StructWithNestedGeneric<D> {
     field_1: D,
     field_2: u64,
 }
 
+#[allow(dead_code)]
 struct StructDeeplyNestedGeneric<D> {
     field_1: D,
     field_2: u64,

--- a/packages/fuels/tests/logs/script_logs/src/main.sw
+++ b/packages/fuels/tests/logs/script_logs/src/main.sw
@@ -2,32 +2,38 @@ script;
 
 use std::logging::log;
 
+#[allow(dead_code)]
 struct TestStruct {
     field_1: bool,
     field_2: b256,
     field_3: u64,
 }
 
+#[allow(dead_code)]
 enum TestEnum {
     VariantOne: (),
     VariantTwo: (),
 }
 
+#[allow(dead_code)]
 struct StructWithGeneric<D> {
     field_1: D,
     field_2: u64,
 }
 
+#[allow(dead_code)]
 enum EnumWithGeneric<D> {
     VariantOne: D,
     VariantTwo: (),
 }
 
+#[allow(dead_code)]
 struct StructWithNestedGeneric<D> {
     field_1: D,
     field_2: u64,
 }
 
+#[allow(dead_code)]
 struct StructDeeplyNestedGeneric<D> {
     field_1: D,
     field_2: u64,

--- a/packages/fuels/tests/predicates.rs
+++ b/packages/fuels/tests/predicates.rs
@@ -240,7 +240,7 @@ async fn pay_with_predicate_vector_data() -> Result<()> {
         )
     );
 
-    let predicate_data = MyPredicateEncoder::encode_data(2, 4, vec![2, 4, 42]);
+    let predicate_data = MyPredicateEncoder::encode_data(12, 30, vec![2, 4, 42]);
 
     let mut predicate: Predicate = Predicate::load_from(
         "tests/types/predicates/predicate_vector/out/debug/predicate_vector.bin",
@@ -289,7 +289,7 @@ async fn predicate_contract_transfer() -> Result<()> {
             "packages/fuels/tests/types/predicates/predicate_vector/out/debug/predicate_vector-abi.json"
     ));
 
-    let predicate_data = MyPredicateEncoder::encode_data(2, 4, vec![2, 4, 42]);
+    let predicate_data = MyPredicateEncoder::encode_data(2, 40, vec![2, 4, 42]);
 
     let mut predicate: Predicate = Predicate::load_from(
         "tests/types/predicates/predicate_vector/out/debug/predicate_vector.bin",
@@ -353,7 +353,7 @@ async fn predicate_transfer_to_base_layer() -> Result<()> {
             "packages/fuels/tests/types/predicates/predicate_vector/out/debug/predicate_vector-abi.json"
     ));
 
-    let predicate_data = MyPredicateEncoder::encode_data(2, 4, vec![2, 4, 42]);
+    let predicate_data = MyPredicateEncoder::encode_data(22, 20, vec![2, 4, 42]);
 
     let mut predicate: Predicate = Predicate::load_from(
         "tests/types/predicates/predicate_vector/out/debug/predicate_vector.bin",
@@ -400,7 +400,7 @@ async fn predicate_transfer_with_signed_resources() -> Result<()> {
             "packages/fuels/tests/types/predicates/predicate_vector/out/debug/predicate_vector-abi.json"
     ));
 
-    let predicate_data = MyPredicateEncoder::encode_data(2, 4, vec![2, 4, 42]);
+    let predicate_data = MyPredicateEncoder::encode_data(2, 40, vec![2, 4, 42]);
 
     let mut predicate: Predicate = Predicate::load_from(
         "tests/types/predicates/predicate_vector/out/debug/predicate_vector.bin",
@@ -486,7 +486,7 @@ async fn contract_tx_and_call_params_with_predicate() -> Result<()> {
         )
     );
 
-    let predicate_data = MyPredicateEncoder::encode_data(2, 4, vec![2, 4, 42]);
+    let predicate_data = MyPredicateEncoder::encode_data(22, 20, vec![2, 4, 42]);
 
     let mut predicate: Predicate = Predicate::load_from(
         "tests/types/predicates/predicate_vector/out/debug/predicate_vector.bin",
@@ -563,7 +563,7 @@ async fn diff_asset_predicate_payment() -> Result<()> {
         )
     );
 
-    let predicate_data = MyPredicateEncoder::encode_data(2, 4, vec![2, 4, 42]);
+    let predicate_data = MyPredicateEncoder::encode_data(28, 14, vec![2, 4, 42]);
 
     let mut predicate: Predicate = Predicate::load_from(
         "tests/types/predicates/predicate_vector/out/debug/predicate_vector.bin",

--- a/packages/fuels/tests/predicates/basic_predicate/src/main.sw
+++ b/packages/fuels/tests/predicates/basic_predicate/src/main.sw
@@ -1,5 +1,5 @@
 predicate;
 
 fn main(a: u32, b: u64) -> bool {
-    a == b
+    b == a
 }

--- a/packages/fuels/tests/predicates/predicate_configurables/src/main.sw
+++ b/packages/fuels/tests/predicates/predicate_configurables/src/main.sw
@@ -17,7 +17,6 @@ impl Eq for EnumWithGeneric<bool> {
 }
 
 #[allow(dead_code)]
-// ANCHOR: predicate_configurables
 enum EnumWithGeneric<D> {
     VariantOne: D,
     VariantTwo: (),

--- a/packages/fuels/tests/predicates/predicate_configurables/src/main.sw
+++ b/packages/fuels/tests/predicates/predicate_configurables/src/main.sw
@@ -16,6 +16,7 @@ impl Eq for EnumWithGeneric<bool> {
     }
 }
 
+#[allow(dead_code)]
 // ANCHOR: predicate_configurables
 enum EnumWithGeneric<D> {
     VariantOne: D,

--- a/packages/fuels/tests/predicates/predicate_configurables/src/main.sw
+++ b/packages/fuels/tests/predicates/predicate_configurables/src/main.sw
@@ -16,6 +16,7 @@ impl Eq for EnumWithGeneric<bool> {
     }
 }
 
+// ANCHOR: predicate_configurables
 #[allow(dead_code)]
 enum EnumWithGeneric<D> {
     VariantOne: D,

--- a/packages/fuels/tests/scripts/script_asserts/src/main.sw
+++ b/packages/fuels/tests/scripts/script_asserts/src/main.sw
@@ -5,6 +5,7 @@ struct TestStruct {
     field_2: u64,
 }
 
+#[allow(dead_code)]
 enum TestEnum {
     VariantOne: (),
     VariantTwo: (),
@@ -26,6 +27,7 @@ impl Eq for TestEnum {
     }
 }
 
+#[allow(dead_code)]
 enum MatchEnum {
     AssertPrimitive: (u64, u64),
     AssertEqPrimitive: (u64, u64),

--- a/packages/fuels/tests/scripts/script_configurables/src/main.sw
+++ b/packages/fuels/tests/scripts/script_configurables/src/main.sw
@@ -1,10 +1,12 @@
 script;
 
+#[allow(dead_code)]
 enum EnumWithGeneric<D> {
     VariantOne: D,
     VariantTwo: (),
 }
 
+#[allow(dead_code)]
 struct StructWithGeneric<D> {
     field_1: D,
     field_2: u64,

--- a/packages/fuels/tests/scripts/script_require/src/main.sw
+++ b/packages/fuels/tests/scripts/script_require/src/main.sw
@@ -2,21 +2,25 @@ script;
 
 use std::logging::log;
 
+#[allow(dead_code)]
 enum EnumWithGeneric<D> {
     VariantOne: D,
     VariantTwo: (),
 }
 
+#[allow(dead_code)]
 struct StructWithNestedGeneric<D> {
     field_1: D,
     field_2: u64,
 }
 
+#[allow(dead_code)]
 struct StructDeeplyNestedGeneric<D> {
     field_1: D,
     field_2: u64,
 }
 
+#[allow(dead_code)]
 enum MatchEnum {
     RequirePrimitive: (),
     RequireString: (),

--- a/packages/fuels/tests/types/contracts/bytes/src/main.sw
+++ b/packages/fuels/tests/types/contracts/bytes/src/main.sw
@@ -2,6 +2,7 @@ contract;
 
 use std::bytes::Bytes;
 
+#[allow(dead_code)]
 enum SomeEnum<T> {
     First: bool,
     Second: T,
@@ -15,9 +16,9 @@ struct Wrapper<T> {
 fn expected_bytes() -> Bytes {
     let mut bytes = Bytes::new();
 
-    bytes.push(40);
-    bytes.push(41);
-    bytes.push(42);
+    bytes.push(40u8);
+    bytes.push(41u8);
+    bytes.push(42u8);
 
     bytes
 }

--- a/packages/fuels/tests/types/contracts/complex_types_contract/src/main.sw
+++ b/packages/fuels/tests/types/contracts/complex_types_contract/src/main.sw
@@ -4,6 +4,7 @@ use std::storage::storage_api::{read, write};
 
 struct EmptyStruct {}
 
+#[allow(dead_code)]
 struct CounterConfig {
     dummy: bool,
     initial_value: u64,
@@ -40,9 +41,8 @@ impl TestContract for Contract {
     }
 
     fn input_empty_struct(es: EmptyStruct) -> bool {
-        if let EmptyStruct {} = es {
-            return true;
-        }
-        false
+        let EmptyStruct {} = es;
+
+        true
     }
 }

--- a/packages/fuels/tests/types/contracts/empty_arguments/src/main.sw
+++ b/packages/fuels/tests/types/contracts/empty_arguments/src/main.sw
@@ -4,8 +4,6 @@ abi TestContract {
     fn method_with_empty_argument() -> u64;
 }
 
-const COUNTER_KEY = 0x0000000000000000000000000000000000000000000000000000000000000000;
-
 impl TestContract for Contract {
     fn method_with_empty_argument() -> u64 {
         63

--- a/packages/fuels/tests/types/contracts/enum_as_input/src/main.sw
+++ b/packages/fuels/tests/types/contracts/enum_as_input/src/main.sw
@@ -1,11 +1,13 @@
 contract;
 
+#[allow(dead_code)]
 enum StandardEnum {
     One: b256,
     Two: u32,
     Three: bool,
 }
 
+#[allow(dead_code)]
 enum UnitEnum {
     One: (),
     Two: (),
@@ -22,7 +24,7 @@ abi EnumTesting {
 
 impl EnumTesting for Contract {
     fn get_standard_enum() -> StandardEnum {
-        StandardEnum::Two(12345)
+        StandardEnum::Two(12345u32)
     }
     fn check_standard_enum_integrity(arg: StandardEnum) -> bool {
         match arg {

--- a/packages/fuels/tests/types/contracts/enum_encoding/src/main.sw
+++ b/packages/fuels/tests/types/contracts/enum_encoding/src/main.sw
@@ -1,5 +1,6 @@
 contract;
 
+#[allow(dead_code)]
 enum EnumThatHasABigAndSmallVariant {
     Big: b256,
     Small: u32,
@@ -12,6 +13,7 @@ struct BigBundle {
     arg_4: u64,
 }
 
+#[allow(dead_code)]
 enum UnitEnum {
     var1: (),
     var2: (),
@@ -32,7 +34,7 @@ abi EnumTesting {
 
 impl EnumTesting for Contract {
     fn get_big_bundle() -> BigBundle {
-        let arg_1 = EnumThatHasABigAndSmallVariant::Small(12345);
+        let arg_1 = EnumThatHasABigAndSmallVariant::Small(12345u32);
         let arg_2 = 6666;
         let arg_3 = 7777;
         let arg_4 = 8888;

--- a/packages/fuels/tests/types/contracts/enum_inside_struct/src/main.sw
+++ b/packages/fuels/tests/types/contracts/enum_inside_struct/src/main.sw
@@ -1,5 +1,6 @@
 contract;
 
+#[allow(dead_code)]
 enum Shaker {
     Cosmopolitan: u64,
     Mojito: u64,
@@ -17,13 +18,13 @@ abi TestContract {
 
 impl TestContract for Contract {
     fn return_enum_inside_struct(a: u64) -> Cocktail {
-        let b = Cocktail {
-            the_thing_you_mix_in: Shaker::Mojito(222),
+        Cocktail {
+            the_thing_you_mix_in: Shaker::Mojito(a),
             glass: 333,
-        };
-        b
+        }
     }
+
     fn take_enum_inside_struct(c: Cocktail) -> u64 {
-        6666
+        c.glass
     }
 }

--- a/packages/fuels/tests/types/contracts/generics/src/main.sw
+++ b/packages/fuels/tests/types/contracts/generics/src/main.sw
@@ -76,7 +76,9 @@ impl MyContract for Contract {
     }
 
     fn struct_w_generic_in_tuple(arg1: StructWTupleGeneric<u32>) -> StructWTupleGeneric<u32> {
-        let expected = StructWTupleGeneric { a: (1u32, 2u32) };
+        let expected = StructWTupleGeneric {
+            a: (1u32, 2u32),
+        };
         assert(expected.a.0 == arg1.a.0);
         assert(expected.a.1 == arg1.a.1);
 

--- a/packages/fuels/tests/types/contracts/generics/src/main.sw
+++ b/packages/fuels/tests/types/contracts/generics/src/main.sw
@@ -18,11 +18,13 @@ struct StructWTupleGeneric<M> {
     a: (M, M),
 }
 
+#[allow(dead_code)]
 enum EnumWGeneric<N> {
     a: u64,
     b: N,
 }
 
+#[allow(dead_code)]
 struct MegaExample<T, U> {
     a: ([U; 2], T),
     b: Vec<([EnumWGeneric<StructWTupleGeneric<StructWArrayGeneric<PassTheGenericOn<T>>>>; 1], u32)>,
@@ -74,7 +76,7 @@ impl MyContract for Contract {
     }
 
     fn struct_w_generic_in_tuple(arg1: StructWTupleGeneric<u32>) -> StructWTupleGeneric<u32> {
-        let expected = StructWTupleGeneric { a: (1, 2) };
+        let expected = StructWTupleGeneric { a: (1u32, 2u32) };
         assert(expected.a.0 == arg1.a.0);
         assert(expected.a.1 == arg1.a.1);
 
@@ -93,5 +95,5 @@ impl MyContract for Contract {
         EnumWGeneric::b(10)
     }
 
-    fn complex_test(arg1: MegaExample<str[2], b256>) {}
+    fn complex_test(_arg: MegaExample<str[2], b256>) {}
 }

--- a/packages/fuels/tests/types/contracts/nested_structs/src/main.sw
+++ b/packages/fuels/tests/types/contracts/nested_structs/src/main.sw
@@ -15,6 +15,7 @@ pub struct CallData {
     amount_of_gas_to_forward: u64,
 }
 
+#[allow(dead_code)]
 struct MemoryAddress {
     contract_id: ContractId,
     function_selector: u64,

--- a/packages/fuels/tests/types/contracts/raw_slice/src/main.sw
+++ b/packages/fuels/tests/types/contracts/raw_slice/src/main.sw
@@ -1,5 +1,6 @@
 contract;
 
+#[allow(dead_code)]
 enum SomeEnum<T> {
     First: bool,
     Second: T,

--- a/packages/fuels/tests/types/contracts/tuples/src/main.sw
+++ b/packages/fuels/tests/types/contracts/tuples/src/main.sw
@@ -6,6 +6,7 @@ struct Person {
     name: str[4],
 }
 
+#[allow(dead_code)]
 enum State {
     A: (),
     B: (),

--- a/packages/fuels/tests/types/contracts/type_inside_enum/src/main.sw
+++ b/packages/fuels/tests/types/contracts/type_inside_enum/src/main.sw
@@ -1,33 +1,36 @@
 contract;
 
-// String and array inside enum
+#[allow(dead_code)]
 enum SomeEnum {
     SomeStr: str[4],
     SomeArr: [u64; 7],
 }
 
-// Struct inside enum
+#[allow(dead_code)]
 enum Shaker {
     Cosmopolitan: Recipe,
     Mojito: u32,
 }
 
+#[allow(dead_code)]
 struct Recipe {
     ice: u8,
     sugar: u16,
 }
 
-// Enum inside enum
+#[allow(dead_code)]
 enum EnumLevel1 {
     Num: u32,
     check: bool,
 }
 
+#[allow(dead_code)]
 enum EnumLevel2 {
     El1: EnumLevel1,
     Check: bool,
 }
 
+#[allow(dead_code)]
 enum EnumLevel3 {
     El2: EnumLevel2,
     Num: u8,
@@ -37,7 +40,7 @@ abi MyContract {
     fn str_inside_enum(my_enum: SomeEnum) -> SomeEnum;
     fn arr_inside_enum(my_enum: SomeEnum) -> SomeEnum;
 
-    fn return_struct_inside_enum(c: u64) -> Shaker;
+    fn return_struct_inside_enum(c: u16) -> Shaker;
     fn take_struct_inside_enum(s: Shaker) -> u64;
 
     fn get_nested_enum() -> EnumLevel3;
@@ -52,19 +55,18 @@ impl MyContract for Contract {
         my_enum
     }
 
-    fn return_struct_inside_enum(c: u64) -> Shaker {
-        let s = Shaker::Cosmopolitan(Recipe {
-            ice: 22,
-            sugar: 99,
-        });
-        s
+    fn return_struct_inside_enum(c: u16) -> Shaker {
+        Shaker::Cosmopolitan(Recipe {
+            ice: 22u8,
+            sugar: c,
+        })
     }
-    fn take_struct_inside_enum(s: Shaker) -> u64 {
+    fn take_struct_inside_enum(_s: Shaker) -> u64 {
         8888
     }
 
     fn get_nested_enum() -> EnumLevel3 {
-        EnumLevel3::El2(EnumLevel2::El1(EnumLevel1::Num(42)))
+        EnumLevel3::El2(EnumLevel2::El1(EnumLevel1::Num(42u32)))
     }
     fn check_nested_enum_integrity(e: EnumLevel3) -> bool {
         let arg_is_correct = match e {

--- a/packages/fuels/tests/types/contracts/u128/src/main.sw
+++ b/packages/fuels/tests/types/contracts/u128/src/main.sw
@@ -2,6 +2,7 @@ contract;
 
 use std::u128::U128;
 
+#[allow(dead_code)]
 enum SomeEnum<T> {
     A: bool,
     B: T,

--- a/packages/fuels/tests/types/contracts/vectors/src/main.sw
+++ b/packages/fuels/tests/types/contracts/vectors/src/main.sw
@@ -26,15 +26,15 @@ abi MyContract {
 
 impl MyContract for Contract {
     fn u32_vec(arg: Vec<u32>) {
-        let expected = vec_from([0, 1, 2]);
+        let expected = vec_from([0u8, 1u8, 2u8]);
 
         assert(arg == expected);
     }
 
     fn vec_in_vec(arg: Vec<Vec<u32>>) {
         let mut expected = Vec::new();
-        expected.push(vec_from([0, 1, 2]));
-        expected.push(vec_from([0, 1, 2]));
+        expected.push(vec_from([0u8, 1u8, 2u8]));
+        expected.push(vec_from([0u8, 1u8, 2u8]));
 
         assert(expected == arg);
     }
@@ -48,7 +48,7 @@ impl MyContract for Contract {
     }
     fn vec_in_struct(arg: SomeStruct<Vec<u32>>) {
         let expected = SomeStruct {
-            a: vec_from([0, 1, 2]),
+            a: vec_from([0u8, 1u8, 2u8]),
         };
 
         assert(arg.a == expected.a);
@@ -62,35 +62,35 @@ impl MyContract for Contract {
     }
 
     fn vec_in_array(arg: [Vec<u32>; 2]) {
-        let expected = [vec_from([0, 1, 2]), vec_from([0, 1, 2])];
+        let expected = [vec_from([0u8, 1u8, 2u8]), vec_from([0u8, 1u8, 2u8])];
 
         assert(expected == arg);
     }
 
     fn vec_in_enum(arg: SomeEnum<Vec<u32>>) {
-        let vec = vec_from([0, 1, 2]);
+        let vec = vec_from([0u8, 1u8, 2u8]);
         let expected = SomeEnum::a(vec);
 
         assert(expected == arg);
     }
     fn enum_in_vec(arg: Vec<SomeEnum<u32>>) {
         let mut expected = Vec::new();
-        expected.push(SomeEnum::a(0));
-        expected.push(SomeEnum::a(1));
+        expected.push(SomeEnum::a(0u32));
+        expected.push(SomeEnum::a(1u32));
 
         assert(arg == expected);
     }
 
     fn tuple_in_vec(arg: Vec<(u32, u32)>) {
         let mut expected = Vec::new();
-        expected.push((0, 0));
-        expected.push((1, 1));
+        expected.push((0u32, 0u32));
+        expected.push((1u32, 1u32));
 
         assert(arg == expected);
     }
 
     fn vec_in_tuple(arg: (Vec<u32>, Vec<u32>)) {
-        let expected = (vec_from([0, 1, 2]), vec_from([0, 1, 2]));
+        let expected = (vec_from([0u8, 1u8, 2u8]), vec_from([0u8, 1u8, 2u8]));
 
         assert(arg == expected);
     }
@@ -99,20 +99,20 @@ impl MyContract for Contract {
 
         let mut inner_vec_1 = Vec::new();
 
-        let inner_inner_vec_1 = vec_from([0, 1, 2]);
+        let inner_inner_vec_1 = vec_from([0u8, 1u8, 2u8]);
         inner_vec_1.push(inner_inner_vec_1);
 
-        let inner_inner_vec_2 = vec_from([3, 4, 5]);
+        let inner_inner_vec_2 = vec_from([3u8, 4u8, 5u8]);
         inner_vec_1.push(inner_inner_vec_2);
 
         expected.push(SomeStruct { a: inner_vec_1 });
 
         let mut inner_vec_2 = Vec::new();
 
-        let inner_inner_vec_3 = vec_from([6, 7, 8]);
+        let inner_inner_vec_3 = vec_from([6u8, 7u8, 8u8]);
         inner_vec_2.push(inner_inner_vec_3);
 
-        let inner_inner_vec_4 = vec_from([9, 10, 11]);
+        let inner_inner_vec_4 = vec_from([9u8, 10u8, 11u8]);
         inner_vec_2.push(inner_inner_vec_4);
 
         expected.push(SomeStruct { a: inner_vec_2 });

--- a/packages/fuels/tests/types/predicates/enums/src/main.sw
+++ b/packages/fuels/tests/types/predicates/enums/src/main.sw
@@ -1,9 +1,11 @@
 predicate;
 
+#[allow(dead_code)]
 enum TestEnum {
     A: u64,
 }
 
+#[allow(dead_code)]
 enum AnotherTestEnum {
     A: u64,
     B: u64,

--- a/packages/fuels/tests/types/predicates/predicate_bytes/src/main.sw
+++ b/packages/fuels/tests/types/predicates/predicate_bytes/src/main.sw
@@ -2,6 +2,7 @@ predicate;
 
 use std::bytes::Bytes;
 
+#[allow(dead_code)]
 enum SomeEnum<T> {
     First: bool,
     Second: T,
@@ -15,9 +16,9 @@ struct Wrapper<T> {
 fn expected_bytes() -> Bytes {
     let mut bytes = Bytes::new();
 
-    bytes.push(40);
-    bytes.push(41);
-    bytes.push(42);
+    bytes.push(40u8);
+    bytes.push(41u8);
+    bytes.push(42u8);
 
     bytes
 }

--- a/packages/fuels/tests/types/predicates/predicate_generics/src/main.sw
+++ b/packages/fuels/tests/types/predicates/predicate_generics/src/main.sw
@@ -4,6 +4,7 @@ struct GenericStruct<U> {
     value: U,
 }
 
+#[allow(dead_code)]
 enum GenericEnum<T, V> {
     Generic: GenericStruct<T>,
     AnotherGeneric: V,
@@ -14,7 +15,7 @@ fn main(
     generic_enum: GenericEnum<u16, u32>,
 ) -> bool {
     if let GenericEnum::Generic(other_struct) = generic_enum {
-        return generic_struct.value == other_struct.value;
+        return other_struct.value == generic_struct.value;
     }
 
     false

--- a/packages/fuels/tests/types/predicates/predicate_raw_slice/src/main.sw
+++ b/packages/fuels/tests/types/predicates/predicate_raw_slice/src/main.sw
@@ -1,5 +1,6 @@
 predicate;
 
+#[allow(dead_code)]
 enum SomeEnum<T> {
     First: bool,
     Second: T,

--- a/packages/fuels/tests/types/predicates/predicate_tuples/src/main.sw
+++ b/packages/fuels/tests/types/predicates/predicate_tuples/src/main.sw
@@ -4,6 +4,7 @@ struct TestStruct {
     value: u32,
 }
 
+#[allow(dead_code)]
 enum TestEnum {
     Value: u64,
 }
@@ -12,7 +13,7 @@ fn main(input_tuple: (u64, TestStruct, TestEnum), number: u64) -> bool {
     let (u64_number, test_struct, test_enum) = input_tuple;
 
     if let TestEnum::Value(enum_value) = test_enum {
-        return u64_number == 16 && test_struct.value == 32 && enum_value == 64 && number == 128;
+        return u64_number == 16 && test_struct.value == 32u32 && enum_value == 64 && number == 128;
     }
 
     false

--- a/packages/fuels/tests/types/predicates/predicate_vector/src/main.sw
+++ b/packages/fuels/tests/types/predicates/predicate_vector/src/main.sw
@@ -2,5 +2,5 @@ predicate;
 
 fn main(a: u32, b: u64, c: Vec<u64>) -> bool {
     let number: u64 = c.get(2).unwrap();
-    number == 42
+    number == (b + a)
 }

--- a/packages/fuels/tests/types/predicates/predicate_vectors/src/main.sw
+++ b/packages/fuels/tests/types/predicates/predicate_vectors/src/main.sw
@@ -51,7 +51,7 @@ fn main(
 
     result = result && (tuple_in_vec.get(1).unwrap().0 == 128u32);
 
-    let (tuple_a, tuple_b) = vec_in_tuple;
+    let (tuple_a, _) = vec_in_tuple;
     result = result && (tuple_a.get(1).unwrap() == 64u32);
 
     result = result && (vec_in_a_vec_in_a_struct_in_a_vec.get(1).unwrap().a.get(1).unwrap().get(1).unwrap() == 32u32);

--- a/packages/fuels/tests/types/scripts/options_results/src/main.sw
+++ b/packages/fuels/tests/types/scripts/options_results/src/main.sw
@@ -4,7 +4,7 @@ pub enum TestError {
     ZimZam: str[5],
 }
 
-fn main(bim: Option<u32>) -> Result<Option<bool>, TestError> {
+fn main(bim: Option<u32>, _bam: Option<u64>) -> Result<Option<bool>, TestError> {
     if let Option::Some(42) = bim {
         Result::Ok(Option::Some(true))
     } else if let Option::Some(_) = bim {

--- a/packages/fuels/tests/types/scripts/options_results/src/main.sw
+++ b/packages/fuels/tests/types/scripts/options_results/src/main.sw
@@ -4,10 +4,10 @@ pub enum TestError {
     ZimZam: str[5],
 }
 
-fn main(bim: Option<u32>, bam: Option<u64>) -> Result<Option<bool>, TestError> {
+fn main(bim: Option<u32>) -> Result<Option<bool>, TestError> {
     if let Option::Some(42) = bim {
         Result::Ok(Option::Some(true))
-    } else if let Option::Some(b) = bim {
+    } else if let Option::Some(_) = bim {
         Result::Ok(Option::None)
     } else {
         Result::Err(TestError::ZimZam("error"))

--- a/packages/fuels/tests/types/scripts/script_bytes/src/main.sw
+++ b/packages/fuels/tests/types/scripts/script_bytes/src/main.sw
@@ -2,6 +2,7 @@ script;
 
 use std::bytes::Bytes;
 
+#[allow(dead_code)]
 enum SomeEnum<T> {
     First: bool,
     Second: T,
@@ -15,14 +16,14 @@ struct Wrapper<T> {
 fn expected_bytes() -> Bytes {
     let mut bytes = Bytes::new();
 
-    bytes.push(40);
-    bytes.push(41);
-    bytes.push(42);
+    bytes.push(40u8);
+    bytes.push(41u8);
+    bytes.push(42u8);
 
     bytes
 }
 
-fn main(a: u64, wrapper: Wrapper<Vec<Bytes>>) {
+fn main(_arg: u64, wrapper: Wrapper<Vec<Bytes>>) {
     if let SomeEnum::Second(enum_bytes) = wrapper.inner_enum {
         require(enum_bytes == expected_bytes(), "wrapper.inner_enum didn't carry the expected bytes")
     } else {

--- a/packages/fuels/tests/types/scripts/script_generics/src/main.sw
+++ b/packages/fuels/tests/types/scripts/script_generics/src/main.sw
@@ -4,6 +4,7 @@ struct GenericBimbam<U> {
     val: U,
 }
 
+#[allow(dead_code)]
 struct GenericSnack<T, V> {
     twix: GenericBimbam<T>,
     mars: V,
@@ -17,8 +18,8 @@ fn main(
     (
         GenericSnack {
             twix: bot,
-            mars: 2 * bim.val,
+            mars: 2u32 * bim.val,
         },
-        GenericBimbam { val: 255 },
+        GenericBimbam { val: 255u8 },
     )
 }

--- a/packages/fuels/tests/types/scripts/script_raw_slice/src/main.sw
+++ b/packages/fuels/tests/types/scripts/script_raw_slice/src/main.sw
@@ -1,5 +1,6 @@
 script;
 
+#[allow(dead_code)]
 enum SomeEnum<T> {
     First: bool,
     Second: T,
@@ -24,7 +25,7 @@ fn validate_vec(vec: Vec<raw_slice>) {
     validate_raw_slice(vec.get(1).unwrap());
 }
 
-fn main(a: u64, wrapper: Wrapper<Vec<raw_slice>>) -> raw_slice {
+fn main(_arg: u64, wrapper: Wrapper<Vec<raw_slice>>) -> raw_slice {
     if let SomeEnum::Second(enum_raw_slice) = wrapper.inner_enum
     {
         validate_raw_slice(enum_raw_slice);

--- a/packages/fuels/tests/types/scripts/script_tuples/src/main.sw
+++ b/packages/fuels/tests/types/scripts/script_tuples/src/main.sw
@@ -1,18 +1,21 @@
 script;
 
+#[allow(dead_code)]
 struct Bim {
     bim: u64,
 }
 
+#[allow(dead_code)]
 struct Bam {
     bam: str[5],
 }
 
+#[allow(dead_code)]
 struct Boum {
     boum: bool,
 }
 
-fn main(my_tuple: (Bim, Bam, Boum), zim: Bam) -> ((Boum, Bim, Bam), u64) {
+fn main(_my_tuple: (Bim, Bam, Boum), _zim: Bam) -> ((Boum, Bim, Bam), u64) {
     (
         (
             Boum { boum: true },

--- a/packages/fuels/tests/types/scripts/script_vectors/src/main.sw
+++ b/packages/fuels/tests/types/scripts/script_vectors/src/main.sw
@@ -22,14 +22,14 @@ fn main(
     vec_in_a_vec_in_a_struct_in_a_vec: Vec<SomeStruct<Vec<Vec<u32>>>>,
 ) -> bool {
      {
-        let exp_u32_vec = vec_from([0, 1, 2]);
+        let exp_u32_vec = vec_from([0u32, 1u32, 2u32]);
 
         require(u32_vec == exp_u32_vec, "u32_vec_error");
     }
      {
         let mut exp_vec_in_vec = Vec::new();
-        exp_vec_in_vec.push(vec_from([0, 1, 2]));
-        exp_vec_in_vec.push(vec_from([0, 1, 2]));
+        exp_vec_in_vec.push(vec_from([0u32, 1u32, 2u32]));
+        exp_vec_in_vec.push(vec_from([0u32, 1u32, 2u32]));
 
         require(vec_in_vec == exp_vec_in_vec, "vec_in_vec err");
     }
@@ -42,7 +42,7 @@ fn main(
     }
      {
         let exp_vec_in_struct = SomeStruct {
-            a: vec_from([0, 1, 2]),
+            a: vec_from([0u32, 1u32, 2u32]),
         };
 
         require(vec_in_struct.a == exp_vec_in_struct.a, "vec_in_struct err");
@@ -55,32 +55,32 @@ fn main(
         require(array_in_vec == exp_array_in_vec, "array_in_vec err");
     }
      {
-        let exp_vec_in_array = [vec_from([0, 1, 2]), vec_from([0, 1, 2])];
+        let exp_vec_in_array = [vec_from([0u32, 1u32, 2u32]), vec_from([0u32, 1u32, 2u32])];
 
         require(vec_in_array == exp_vec_in_array, "vec_in_array err");
     }
      {
-        let exp_u32_vec = vec_from([0, 1, 2]);
+        let exp_u32_vec = vec_from([0u32, 1u32, 2u32]);
         let exp_vec_in_enum = SomeEnum::a(exp_u32_vec);
 
         require(vec_in_enum == exp_vec_in_enum, "vec_in_enum err");
     }
      {
         let mut exp_enum_in_vec = Vec::new();
-        exp_enum_in_vec.push(SomeEnum::a(0));
-        exp_enum_in_vec.push(SomeEnum::a(1));
+        exp_enum_in_vec.push(SomeEnum::a(0u32));
+        exp_enum_in_vec.push(SomeEnum::a(1u32));
 
         require(enum_in_vec == exp_enum_in_vec, "enum_in_vec err");
     }
      {
         let mut exp_tuple_in_vec = Vec::new();
-        exp_tuple_in_vec.push((0, 0));
-        exp_tuple_in_vec.push((1, 1));
+        exp_tuple_in_vec.push((0u32, 0u32));
+        exp_tuple_in_vec.push((1u32, 1u32));
 
         require(tuple_in_vec == exp_tuple_in_vec, "tuple_in_vec err");
     }
      {
-        let exp_vec_in_tuple = (vec_from([0, 1, 2]), vec_from([0, 1, 2]));
+        let exp_vec_in_tuple = (vec_from([0u32, 1u32, 2u32]), vec_from([0u32, 1u32, 2u32]));
 
         require(vec_in_tuple == exp_vec_in_tuple, "vec_in_tuple err");
     }
@@ -89,20 +89,20 @@ fn main(
 
         let mut inner_vec_1 = Vec::new();
 
-        let inner_inner_vec_1 = vec_from([0, 1, 2]);
+        let inner_inner_vec_1 = vec_from([0u32, 1u32, 2u32]);
         inner_vec_1.push(inner_inner_vec_1);
 
-        let inner_inner_vec_2 = vec_from([3, 4, 5]);
+        let inner_inner_vec_2 = vec_from([3u32, 4u32, 5u32]);
         inner_vec_1.push(inner_inner_vec_2);
 
         exp_vec_in_a_vec_in_a_struct_in_a_vec.push(SomeStruct { a: inner_vec_1 });
 
         let mut inner_vec_2 = Vec::new();
 
-        let inner_inner_vec_3 = vec_from([6, 7, 8]);
+        let inner_inner_vec_3 = vec_from([6u32, 7u32, 8u32]);
         inner_vec_2.push(inner_inner_vec_3);
 
-        let inner_inner_vec_4 = vec_from([9, 10, 11]);
+        let inner_inner_vec_4 = vec_from([9u32, 10u32, 11u32]);
         inner_vec_2.push(inner_inner_vec_4);
 
         exp_vec_in_a_vec_in_a_struct_in_a_vec.push(SomeStruct { a: inner_vec_2 });

--- a/packages/fuels/tests/types_contracts.rs
+++ b/packages/fuels/tests/types_contracts.rs
@@ -511,7 +511,7 @@ async fn test_enum_inside_struct() -> Result<()> {
     );
 
     let expected = Cocktail {
-        the_thing_you_mix_in: Shaker::Mojito(222),
+        the_thing_you_mix_in: Shaker::Mojito(11),
         glass: 333,
     };
 
@@ -533,7 +533,7 @@ async fn test_enum_inside_struct() -> Result<()> {
         .call()
         .await?;
 
-    assert_eq!(response.value, 6666);
+    assert_eq!(response.value, 555);
     Ok(())
 }
 
@@ -764,8 +764,9 @@ async fn type_inside_enum() -> Result<()> {
         .return_struct_inside_enum(11)
         .call()
         .await?;
-    let expected = Shaker::Cosmopolitan(Recipe { ice: 22, sugar: 99 });
+    let expected = Shaker::Cosmopolitan(Recipe { ice: 22, sugar: 11 });
     assert_eq!(response.value, expected);
+
     let struct_inside_enum = Shaker::Cosmopolitan(Recipe { ice: 22, sugar: 66 });
     let response = contract_methods
         .take_struct_inside_enum(struct_inside_enum)

--- a/packages/fuels/tests/types_predicates.rs
+++ b/packages/fuels/tests/types_predicates.rs
@@ -214,7 +214,7 @@ async fn spend_predicate_coins_messages_vector() -> Result<()> {
             "packages/fuels/tests/types/predicates/predicate_vector/out/debug/predicate_vector-abi.json"
     ));
 
-    let data = MyPredicateEncoder::encode_data(2, 4, vec![2, 4, 42]);
+    let data = MyPredicateEncoder::encode_data(18, 24, vec![2, 4, 42]);
 
     assert_predicate_spendable(data, "tests/types/predicates/predicate_vector").await?;
 


### PR DESCRIPTION
`#[allow(dead_code)]` was recently added to `sway` so I have updated our test projects to lower the number of warnings we get when building them.

I have also removed some other warnings like unused variables etc.