### PR TITLE
chore: set `fuel-core` to `0.18.2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,16 +45,16 @@ elliptic-curve = { version = "0.13.4", default-features = false }
 eth-keystore = "0.5.0"
 fuel-abi-types = "0.2.1"
 fuel-asm = "0.31.1"
-fuel-core = { version = "0.18.1", default-features = false }
-fuel-core-chain-config = { version = "0.18.1", default-features = false }
-fuel-core-client = { version = "0.18.1", default-features = false }
-fuel-core-types = { version = "0.18.1", default-features = false }
+fuel-core = { version = "0.18.2", default-features = false }
+fuel-core-chain-config = { version = "0.18.2", default-features = false }
+fuel-core-client = { version = "0.18.2", default-features = false }
+fuel-core-types = { version = "0.18.2", default-features = false }
 fuel-crypto = "0.31.1"
 fuel-merkle = "0.31.1"
 fuel-storage = "0.31.1"
 fuel-tx = "0.31.1"
 fuel-types = { version = "0.31.1", default-features = false }
-fuel-vm = "0.31.1"
+fuel-vm = "0.31.2"
 fuels = { version = "0.42.0", path = "./packages/fuels" }
 fuels-accounts = { version = "0.42.0", path = "./packages/fuels-accounts", default-features = false }
 fuels-code-gen = { version = "0.42.0", path = "./packages/fuels-code-gen", default-features = false }


### PR DESCRIPTION
cc @xgreenx 

We need to update our min `fuel-core` dependency to incorporate a vm bugfix