### PR TITLE
Docs Nits

### DIFF
--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -502,7 +502,7 @@ mod tests {
                 "0x65b6a3d081966040bbccbb7f79ac91b48c635729c59a4c02f15ae7da999b32d3"
                     .parse()
                     .expect("Invalid ID");
-            let connected_contract_instance = MyContract::new(contract_id, wallet);
+            let connected_contract_instance = MyContract::new(contract_id.into(), wallet);
             // ANCHOR_END: deployed_contracts_hex
         }
 


### PR DESCRIPTION
A set of small docs nits.

1. `.into` for ContractID