### PR TITLE
docs: show README.md for fuels on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
+readme = "README.md"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuels-rs"
 rust-version = "1.68.0"

--- a/packages/fuels/Cargo.toml
+++ b/packages/fuels/Cargo.toml
@@ -4,6 +4,7 @@ version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
+readme = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }


### PR DESCRIPTION
Should show the top-level `README.md` for `fuels` (`packages/fuels`) on [crates.io](https://crates.io/crates/fuels).
Not sure on how to test this besides merging and cutting a release to check crates.io.

Close #1025.

### Checklist
- [x] I have linked to any relevant issues.
- [x] I have updated the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
