### PR TITLE
test: implement tests over `Bytes` type

### DIFF
--- a/packages/fuels-code-gen/src/program_bindings/resolved_type.rs
+++ b/packages/fuels-code-gen/src/program_bindings/resolved_type.rs
@@ -419,6 +419,69 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_bytes() -> Result<()> {
+        test_resolve_first_type(
+            ":: fuels :: types :: Bytes",
+            &[
+                TypeDeclaration {
+                    type_id: 0,
+                    type_field: "struct String".to_string(),
+                    components: Some(vec![TypeApplication {
+                        name: "bytes".to_string(),
+                        type_id: 1,
+                        ..Default::default()
+                    }]),
+                    ..Default::default()
+                },
+                TypeDeclaration {
+                    type_id: 0,
+                    type_field: "struct std::bytes::Bytes".to_string(),
+                    components: Some(vec![
+                        TypeApplication {
+                            name: "buf".to_string(),
+                            type_id: 1,
+                            ..Default::default()
+                        },
+                        TypeApplication {
+                            name: "len".to_string(),
+                            type_id: 3,
+                            ..Default::default()
+                        },
+                    ]),
+                    ..Default::default()
+                },
+                TypeDeclaration {
+                    type_id: 1,
+                    type_field: "struct std::bytes::RawBytes".to_string(),
+                    components: Some(vec![
+                        TypeApplication {
+                            name: "ptr".to_string(),
+                            type_id: 2,
+                            ..Default::default()
+                        },
+                        TypeApplication {
+                            name: "cap".to_string(),
+                            type_id: 3,
+                            ..Default::default()
+                        },
+                    ]),
+                    ..Default::default()
+                },
+                TypeDeclaration {
+                    type_id: 2,
+                    type_field: "raw untyped ptr".to_string(),
+                    ..Default::default()
+                },
+                TypeDeclaration {
+                    type_id: 3,
+                    type_field: "u64".to_string(),
+                    ..Default::default()
+                },
+            ],
+        )
+    }
+
+    #[test]
     fn test_resolve_string() -> Result<()> {
         test_resolve_primitive_type("str[3]", ":: fuels :: types :: SizedAsciiString < 3usize >")
     }

--- a/packages/fuels-core/src/codec/abi_decoder.rs
+++ b/packages/fuels-core/src/codec/abi_decoder.rs
@@ -495,6 +495,17 @@ mod tests {
     }
 
     #[test]
+    fn decode_bytes() -> Result<()> {
+        let data = [0xFF, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05];
+        let decoded = ABIDecoder::decode_single(&ParamType::Bytes, &data)?;
+
+        let expected = Token::Bytes(data.to_vec());
+
+        assert_eq!(decoded, expected);
+        Ok(())
+    }
+
+    #[test]
     fn decode_enum() -> Result<()> {
         // enum MyEnum {
         //     x: u32,

--- a/packages/fuels-core/src/codec/function_selector.rs
+++ b/packages/fuels-core/src/codec/function_selector.rs
@@ -178,6 +178,15 @@ mod tests {
     }
 
     #[test]
+    fn handles_bytes() {
+        let inputs = [ParamType::Bytes];
+
+        let selector = resolve_fn_signature("some_fun", &inputs);
+
+        assert_eq!(selector, "some_fun(s(s(rawptr,u64),u64))")
+    }
+
+    #[test]
     fn handles_enums() {
         let types = vec![ParamType::U64, ParamType::U32];
         let variants = EnumVariants::new(types).unwrap();


### PR DESCRIPTION
Realized some were missing while working on `String` support.