### PR TITLE
Bump version to 0.44.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ readme = "README.md"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuels-rs"
 rust-version = "1.70.0"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies]
 Inflector = "0.11.4"
@@ -56,13 +56,13 @@ fuel-storage = "0.34.0"
 fuel-tx = "0.34.0"
 fuel-types = { version = "0.34.0", default-features = false }
 fuel-vm = "0.34.0"
-fuels = { version = "0.43.0", path = "./packages/fuels" }
-fuels-accounts = { version = "0.43.0", path = "./packages/fuels-accounts", default-features = false }
-fuels-code-gen = { version = "0.43.0", path = "./packages/fuels-code-gen", default-features = false }
-fuels-core = { version = "0.43.0", path = "./packages/fuels-core", default-features = false }
-fuels-macros = { version = "0.43.0", path = "./packages/fuels-macros", default-features = false }
-fuels-programs = { version = "0.43.0", path = "./packages/fuels-programs", default-features = false }
-fuels-test-helpers = { version = "0.43.0", path = "./packages/fuels-test-helpers", default-features = false }
+fuels = { version = "0.44.0", path = "./packages/fuels" }
+fuels-accounts = { version = "0.44.0", path = "./packages/fuels-accounts", default-features = false }
+fuels-code-gen = { version = "0.44.0", path = "./packages/fuels-code-gen", default-features = false }
+fuels-core = { version = "0.44.0", path = "./packages/fuels-core", default-features = false }
+fuels-macros = { version = "0.44.0", path = "./packages/fuels-macros", default-features = false }
+fuels-programs = { version = "0.44.0", path = "./packages/fuels-programs", default-features = false }
+fuels-test-helpers = { version = "0.44.0", path = "./packages/fuels-test-helpers", default-features = false }
 futures = "0.3.26"
 hex = { version = "0.4.3", default-features = false }
 itertools = "0.10"

--- a/docs/src/connecting/short-lived.md
+++ b/docs/src/connecting/short-lived.md
@@ -27,7 +27,7 @@ let wallet = launch_provider_and_get_wallet().await;
 The `fuel-core-lib` feature allows us to run a `fuel-core` node without installing the `fuel-core` binary on the local machine. Using the `fuel-core-lib` feature flag entails downloading all the dependencies needed to run the fuel-core node.
 
 ```rust,ignore
-fuels = { version = "0.43.0", features = ["fuel-core-lib"] }
+fuels = { version = "0.44.0", features = ["fuel-core-lib"] }
 ```
 
 ## RocksDb
@@ -35,5 +35,5 @@ fuels = { version = "0.43.0", features = ["fuel-core-lib"] }
 The `rocksdb` is an additional feature that, when combined with `fuel-core-lib`, provides persistent storage capabilities while using `fuel-core` as a library.
 
 ```rust,ignore
-fuels = { version = "0.43.0", features = ["rocksdb"] }
+fuels = { version = "0.44.0", features = ["rocksdb"] }
 ```


### PR DESCRIPTION
Prepare for 0.44.0 release with `fuel-core` updated to 0.19.1. Unblocks https://github.com/FuelLabs/forc-wallet/pull/123 and after that, https://github.com/FuelLabs/sway/pull/4718

Is the release prodedure in this repo to just add a new github-release after bumping the version number in this PR?