### PR TITLE
feat: macro recompile trigger

### DIFF
--- a/examples/cookbook/src/lib.rs
+++ b/examples/cookbook/src/lib.rs
@@ -88,8 +88,7 @@ mod tests {
     #[tokio::test]
     async fn custom_chain() -> Result<()> {
         // ANCHOR: custom_chain_import
-        use fuels::fuel_node::ChainConfig;
-        use fuels::{prelude::*, tx::ConsensusParameters};
+        use fuels::{fuel_node::ChainConfig, prelude::*, tx::ConsensusParameters};
         // ANCHOR_END: custom_chain_import
 
         // ANCHOR: custom_chain_consensus

--- a/examples/cookbook/src/lib.rs
+++ b/examples/cookbook/src/lib.rs
@@ -87,10 +87,9 @@ mod tests {
 
     #[tokio::test]
     async fn custom_chain() -> Result<()> {
-        use fuels::prelude::*;
         // ANCHOR: custom_chain_import
         use fuels::fuel_node::ChainConfig;
-        use fuels::tx::ConsensusParameters;
+        use fuels::{prelude::*, tx::ConsensusParameters};
         // ANCHOR_END: custom_chain_import
 
         // ANCHOR: custom_chain_consensus
@@ -188,8 +187,9 @@ mod tests {
     #[tokio::test]
     #[cfg(any(not(feature = "fuel-core-lib"), feature = "rocksdb"))]
     async fn create_or_use_rocksdb() -> Result<()> {
-        use fuels::prelude::*;
         use std::path::PathBuf;
+
+        use fuels::prelude::*;
 
         // ANCHOR: create_or_use_rocksdb
         let provider_config = Config {

--- a/packages/fuels-accounts/src/lib.rs
+++ b/packages/fuels-accounts/src/lib.rs
@@ -318,9 +318,9 @@ pub trait Account: ViewOnlyAccount {
 
 #[cfg(test)]
 mod tests {
-    use fuel_core_client::client::FuelClient;
     use std::str::FromStr;
 
+    use fuel_core_client::client::FuelClient;
     use fuel_crypto::{Message, SecretKey};
     use fuel_tx::{Address, ConsensusParameters, Output};
     use fuels_core::types::transaction::Transaction;

--- a/packages/fuels-code-gen/src/program_bindings/abigen.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen.rs
@@ -103,10 +103,27 @@ impl Abigen {
     ) -> Result<GeneratedCode> {
         let mod_name = ident(&format!("{}_mod", &target.name.to_snake_case()));
 
-        let types = generate_types(&target.source.types, shared_types, no_std)?;
-        let bindings = generate_bindings(target, no_std)?;
+        let recompile_trigger = {
+            let code = target
+                .source
+                .path
+                .as_ref()
+                .map(|path| {
+                    let stringified_path = path.display().to_string();
+                    quote! {
+                        const _: &[u8] = include_bytes!(#stringified_path);
+                    }
+                })
+                .unwrap_or_default();
+            GeneratedCode::new(code, Default::default(), no_std)
+        };
 
-        Ok(types.merge(bindings).wrap_in_mod(mod_name))
+        let types = generate_types(&target.source.abi.types, shared_types, no_std)?;
+        let bindings = generate_bindings(target, no_std)?;
+        Ok(recompile_trigger
+            .merge(types)
+            .merge(bindings)
+            .wrap_in_mod(mod_name))
     }
 
     fn parse_targets(targets: Vec<AbigenTarget>) -> Result<Vec<ParsedAbigenTarget>> {
@@ -135,7 +152,7 @@ impl Abigen {
     ) -> impl Iterator<Item = &FullTypeDeclaration> {
         all_types
             .iter()
-            .flat_map(|target| &target.source.types)
+            .flat_map(|target| &target.source.abi.types)
             .filter(|ttype| ttype.is_custom_type())
     }
 

--- a/packages/fuels-code-gen/src/program_bindings/abigen.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 pub use abigen_target::{AbigenTarget, ProgramType};
+use fuel_abi_types::abi::full_program::FullTypeDeclaration;
 use inflector::Inflector;
 use itertools::Itertools;
 use proc_macro2::TokenStream;
@@ -16,8 +17,6 @@ use crate::{
     },
     utils::ident,
 };
-
-use fuel_abi_types::abi::full_program::FullTypeDeclaration;
 
 mod abigen_target;
 mod bindings;

--- a/packages/fuels-code-gen/src/program_bindings/abigen/abigen_target.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/abigen_target.rs
@@ -16,14 +16,14 @@ pub struct AbigenTarget {
     pub program_type: ProgramType,
 }
 
-pub(crate) struct ABI {
+pub(crate) struct Abi {
     pub(crate) path: Option<PathBuf>,
     pub(crate) abi: FullProgramABI,
 }
 
 pub(crate) struct ParsedAbigenTarget {
     pub name: String,
-    pub source: ABI,
+    pub source: Abi,
     pub program_type: ProgramType,
 }
 
@@ -39,13 +39,13 @@ impl TryFrom<AbigenTarget> for ParsedAbigenTarget {
     }
 }
 
-fn parse_program_abi(abi_source: &str) -> Result<ABI> {
+fn parse_program_abi(abi_source: &str) -> Result<Abi> {
     let source = Source::parse(abi_source).expect("failed to parse JSON ABI");
 
     let json_abi_str = source.get().expect("failed to parse JSON ABI from string");
     let abi = FullProgramABI::from_json_abi(&json_abi_str)?;
     let path = source.path();
-    Ok(ABI { path, abi })
+    Ok(Abi { path, abi })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/packages/fuels-code-gen/src/program_bindings/abigen/abigen_target.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/abigen_target.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom, str::FromStr};
+use std::{convert::TryFrom, path::PathBuf, str::FromStr};
 
 use proc_macro2::Ident;
 
@@ -17,9 +17,14 @@ pub struct AbigenTarget {
     pub program_type: ProgramType,
 }
 
+pub(crate) struct ABI {
+    pub(crate) path: Option<PathBuf>,
+    pub(crate) abi: FullProgramABI,
+}
+
 pub(crate) struct ParsedAbigenTarget {
     pub name: String,
-    pub source: FullProgramABI,
+    pub source: ABI,
     pub program_type: ProgramType,
 }
 
@@ -35,10 +40,13 @@ impl TryFrom<AbigenTarget> for ParsedAbigenTarget {
     }
 }
 
-fn parse_program_abi(abi_source: &str) -> Result<FullProgramABI> {
+fn parse_program_abi(abi_source: &str) -> Result<ABI> {
     let source = Source::parse(abi_source).expect("failed to parse JSON ABI");
+
     let json_abi_str = source.get().expect("failed to parse JSON ABI from string");
-    FullProgramABI::from_json_abi(&json_abi_str).map_err(|e| e.into())
+    let abi = FullProgramABI::from_json_abi(&json_abi_str)?;
+    let path = source.path();
+    Ok(ABI { path, abi })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/packages/fuels-code-gen/src/program_bindings/abigen/abigen_target.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/abigen_target.rs
@@ -1,5 +1,6 @@
 use std::{convert::TryFrom, path::PathBuf, str::FromStr};
 
+use fuel_abi_types::abi::full_program::FullProgramABI;
 use proc_macro2::Ident;
 
 use crate::{
@@ -7,8 +8,6 @@ use crate::{
     error::{Error, Result},
     utils::Source,
 };
-
-use fuel_abi_types::abi::full_program::FullProgramABI;
 
 #[derive(Debug, Clone)]
 pub struct AbigenTarget {

--- a/packages/fuels-code-gen/src/program_bindings/abigen/bindings.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/bindings.rs
@@ -27,6 +27,6 @@ pub(crate) fn generate_bindings(target: ParsedAbigenTarget, no_std: bool) -> Res
     };
 
     let name = ident(&target.name);
-    let abi = target.source;
+    let abi = target.source.abi;
     bindings_generator(&name, abi, no_std)
 }

--- a/packages/fuels-code-gen/src/program_bindings/abigen/bindings/contract.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/bindings/contract.rs
@@ -1,3 +1,4 @@
+use fuel_abi_types::abi::full_program::{FullABIFunction, FullProgramABI};
 use itertools::Itertools;
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, TokenStreamExt};
@@ -8,14 +9,12 @@ use crate::{
         abigen::{
             bindings::function_generator::FunctionGenerator,
             configurables::generate_code_for_configurable_constants,
-            logs::log_formatters_instantiation_code, abigen_target::ABI,
+            logs::log_formatters_instantiation_code,
         },
         generated_code::GeneratedCode,
     },
     utils::{ident, TypePath},
 };
-
-use fuel_abi_types::abi::full_program::{FullABIFunction, FullProgramABI};
 
 pub(crate) fn contract_bindings(
     name: &Ident,

--- a/packages/fuels-code-gen/src/program_bindings/abigen/bindings/contract.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/bindings/contract.rs
@@ -8,7 +8,7 @@ use crate::{
         abigen::{
             bindings::function_generator::FunctionGenerator,
             configurables::generate_code_for_configurable_constants,
-            logs::log_formatters_instantiation_code,
+            logs::log_formatters_instantiation_code, abigen_target::ABI,
         },
         generated_code::GeneratedCode,
     },

--- a/packages/fuels-code-gen/src/program_bindings/abigen/bindings/function_generator.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/bindings/function_generator.rs
@@ -1,3 +1,4 @@
+use fuel_abi_types::abi::full_program::{FullABIFunction, FullTypeApplication};
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 
@@ -9,8 +10,6 @@ use crate::{
     },
     utils::{safe_ident, TypePath},
 };
-
-use fuel_abi_types::abi::full_program::{FullABIFunction, FullTypeApplication};
 
 #[derive(Debug)]
 pub(crate) struct FunctionGenerator {

--- a/packages/fuels-code-gen/src/program_bindings/abigen/bindings/predicate.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/bindings/predicate.rs
@@ -5,6 +5,7 @@ use crate::{
     error::Result,
     program_bindings::{
         abigen::{
+            abigen_target::ABI,
             bindings::{function_generator::FunctionGenerator, utils::extract_main_fn},
             configurables::generate_code_for_configurable_constants,
         },
@@ -15,11 +16,7 @@ use crate::{
 
 use fuel_abi_types::abi::full_program::FullProgramABI;
 
-pub(crate) fn predicate_bindings(
-    name: &Ident,
-    abi: FullProgramABI,
-    no_std: bool,
-) -> Result<GeneratedCode> {
+pub(crate) fn predicate_bindings(name: &Ident, abi: FullProgramABI, no_std: bool) -> Result<GeneratedCode> {
     if no_std {
         return Ok(GeneratedCode::default());
     }
@@ -28,8 +25,10 @@ pub(crate) fn predicate_bindings(
     let encoder_struct_name = ident(&format!("{name}Encoder"));
 
     let configuration_struct_name = ident(&format!("{name}Configurables"));
-    let constant_configuration_code =
-        generate_code_for_configurable_constants(&configuration_struct_name, &abi.configurables)?;
+    let constant_configuration_code = generate_code_for_configurable_constants(
+        &configuration_struct_name,
+        &abi.configurables,
+    )?;
 
     let code = quote! {
         pub struct #encoder_struct_name;

--- a/packages/fuels-code-gen/src/program_bindings/abigen/bindings/predicate.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/bindings/predicate.rs
@@ -1,3 +1,4 @@
+use fuel_abi_types::abi::full_program::FullProgramABI;
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 
@@ -5,7 +6,6 @@ use crate::{
     error::Result,
     program_bindings::{
         abigen::{
-            abigen_target::ABI,
             bindings::{function_generator::FunctionGenerator, utils::extract_main_fn},
             configurables::generate_code_for_configurable_constants,
         },
@@ -14,9 +14,11 @@ use crate::{
     utils::{ident, TypePath},
 };
 
-use fuel_abi_types::abi::full_program::FullProgramABI;
-
-pub(crate) fn predicate_bindings(name: &Ident, abi: FullProgramABI, no_std: bool) -> Result<GeneratedCode> {
+pub(crate) fn predicate_bindings(
+    name: &Ident,
+    abi: FullProgramABI,
+    no_std: bool,
+) -> Result<GeneratedCode> {
     if no_std {
         return Ok(GeneratedCode::default());
     }
@@ -25,10 +27,8 @@ pub(crate) fn predicate_bindings(name: &Ident, abi: FullProgramABI, no_std: bool
     let encoder_struct_name = ident(&format!("{name}Encoder"));
 
     let configuration_struct_name = ident(&format!("{name}Configurables"));
-    let constant_configuration_code = generate_code_for_configurable_constants(
-        &configuration_struct_name,
-        &abi.configurables,
-    )?;
+    let constant_configuration_code =
+        generate_code_for_configurable_constants(&configuration_struct_name, &abi.configurables)?;
 
     let code = quote! {
         pub struct #encoder_struct_name;

--- a/packages/fuels-code-gen/src/program_bindings/abigen/bindings/script.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/bindings/script.rs
@@ -5,6 +5,7 @@ use crate::{
     error::Result,
     program_bindings::{
         abigen::{
+            abigen_target::ABI,
             bindings::{function_generator::FunctionGenerator, utils::extract_main_fn},
             configurables::generate_code_for_configurable_constants,
             logs::log_formatters_instantiation_code,
@@ -16,11 +17,7 @@ use crate::{
 
 use fuel_abi_types::abi::full_program::FullProgramABI;
 
-pub(crate) fn script_bindings(
-    name: &Ident,
-    abi: FullProgramABI,
-    no_std: bool,
-) -> Result<GeneratedCode> {
+pub(crate) fn script_bindings(name: &Ident, abi: FullProgramABI, no_std: bool) -> Result<GeneratedCode> {
     if no_std {
         return Ok(GeneratedCode::default());
     }
@@ -33,8 +30,10 @@ pub(crate) fn script_bindings(
     );
 
     let configuration_struct_name = ident(&format!("{name}Configurables"));
-    let constant_configuration_code =
-        generate_code_for_configurable_constants(&configuration_struct_name, &abi.configurables)?;
+    let constant_configuration_code = generate_code_for_configurable_constants(
+        &configuration_struct_name,
+        &abi.configurables,
+    )?;
 
     let code = quote! {
         #[derive(Debug)]

--- a/packages/fuels-code-gen/src/program_bindings/abigen/bindings/script.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/bindings/script.rs
@@ -1,3 +1,4 @@
+use fuel_abi_types::abi::full_program::FullProgramABI;
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 
@@ -5,7 +6,6 @@ use crate::{
     error::Result,
     program_bindings::{
         abigen::{
-            abigen_target::ABI,
             bindings::{function_generator::FunctionGenerator, utils::extract_main_fn},
             configurables::generate_code_for_configurable_constants,
             logs::log_formatters_instantiation_code,
@@ -15,9 +15,11 @@ use crate::{
     utils::{ident, TypePath},
 };
 
-use fuel_abi_types::abi::full_program::FullProgramABI;
-
-pub(crate) fn script_bindings(name: &Ident, abi: FullProgramABI, no_std: bool) -> Result<GeneratedCode> {
+pub(crate) fn script_bindings(
+    name: &Ident,
+    abi: FullProgramABI,
+    no_std: bool,
+) -> Result<GeneratedCode> {
     if no_std {
         return Ok(GeneratedCode::default());
     }
@@ -30,10 +32,8 @@ pub(crate) fn script_bindings(name: &Ident, abi: FullProgramABI, no_std: bool) -
     );
 
     let configuration_struct_name = ident(&format!("{name}Configurables"));
-    let constant_configuration_code = generate_code_for_configurable_constants(
-        &configuration_struct_name,
-        &abi.configurables,
-    )?;
+    let constant_configuration_code =
+        generate_code_for_configurable_constants(&configuration_struct_name, &abi.configurables)?;
 
     let code = quote! {
         #[derive(Debug)]

--- a/packages/fuels-code-gen/src/program_bindings/abigen/bindings/utils.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/bindings/utils.rs
@@ -1,6 +1,6 @@
-use crate::error::{error, Result};
-
 use fuel_abi_types::abi::full_program::FullABIFunction;
+
+use crate::error::{error, Result};
 
 pub(crate) fn extract_main_fn(abi: &[FullABIFunction]) -> Result<&FullABIFunction> {
     let candidates = abi
@@ -24,8 +24,9 @@ pub(crate) fn extract_main_fn(abi: &[FullABIFunction]) -> Result<&FullABIFunctio
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use fuel_abi_types::abi::full_program::{FullTypeApplication, FullTypeDeclaration};
+
+    use super::*;
 
     #[test]
     fn correctly_extracts_the_main_fn() {

--- a/packages/fuels-code-gen/src/program_bindings/abigen/configurables.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/configurables.rs
@@ -1,3 +1,4 @@
+use fuel_abi_types::abi::full_program::FullConfigurable;
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 
@@ -6,8 +7,6 @@ use crate::{
     program_bindings::resolved_type::{ResolvedType, TypeResolver},
     utils::safe_ident,
 };
-
-use fuel_abi_types::abi::full_program::FullConfigurable;
 
 #[derive(Debug)]
 pub(crate) struct ResolvedConfigurable {

--- a/packages/fuels-code-gen/src/program_bindings/abigen/logs.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/logs.rs
@@ -1,9 +1,8 @@
+use fuel_abi_types::abi::full_program::FullLoggedType;
 use proc_macro2::TokenStream;
 use quote::quote;
 
 use crate::program_bindings::resolved_type::TypeResolver;
-
-use fuel_abi_types::abi::full_program::FullLoggedType;
 
 pub(crate) fn log_formatters_instantiation_code(
     contract_id: TokenStream,

--- a/packages/fuels-code-gen/src/program_bindings/custom_types.rs
+++ b/packages/fuels-code-gen/src/program_bindings/custom_types.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use fuel_abi_types::abi::full_program::FullTypeDeclaration;
 use itertools::Itertools;
 use quote::quote;
 
@@ -12,8 +13,6 @@ use crate::{
     },
     utils::TypePath,
 };
-
-use fuel_abi_types::abi::full_program::FullTypeDeclaration;
 
 mod enums;
 mod structs;

--- a/packages/fuels-code-gen/src/program_bindings/custom_types/enums.rs
+++ b/packages/fuels-code-gen/src/program_bindings/custom_types/enums.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use fuel_abi_types::abi::full_program::FullTypeDeclaration;
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 
@@ -11,8 +12,6 @@ use crate::{
         utils::Component,
     },
 };
-
-use fuel_abi_types::abi::full_program::FullTypeDeclaration;
 
 /// Returns a TokenStream containing the declaration, `Parameterize`,
 /// `Tokenizable` and `TryFrom` implementations for the enum described by the

--- a/packages/fuels-code-gen/src/program_bindings/custom_types/structs.rs
+++ b/packages/fuels-code-gen/src/program_bindings/custom_types/structs.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use fuel_abi_types::abi::full_program::FullTypeDeclaration;
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 
@@ -11,8 +12,6 @@ use crate::{
         utils::Component,
     },
 };
-
-use fuel_abi_types::abi::full_program::FullTypeDeclaration;
 
 /// Returns a TokenStream containing the declaration, `Parameterize`,
 /// `Tokenizable` and `TryFrom` implementations for the struct described by the

--- a/packages/fuels-code-gen/src/program_bindings/custom_types/utils.rs
+++ b/packages/fuels-code-gen/src/program_bindings/custom_types/utils.rs
@@ -1,13 +1,11 @@
-use fuel_abi_types::utils::extract_generic_name;
+use fuel_abi_types::{
+    abi::full_program::FullTypeDeclaration,
+    utils::{extract_generic_name, ident, TypePath},
+};
 use proc_macro2::TokenStream;
 use quote::quote;
 
 use crate::{error::Result, program_bindings::utils::Component};
-
-use fuel_abi_types::{
-    abi::full_program::FullTypeDeclaration,
-    utils::{ident, TypePath},
-};
 
 /// Transforms components from inside the given `FullTypeDeclaration` into a vector
 /// of `Components`. Will fail if there are no components.

--- a/packages/fuels-code-gen/src/program_bindings/utils.rs
+++ b/packages/fuels-code-gen/src/program_bindings/utils.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use fuel_abi_types::abi::full_program::FullTypeApplication;
 use inflector::Inflector;
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, ToTokens};
@@ -9,8 +10,6 @@ use crate::{
     program_bindings::resolved_type::{ResolvedType, TypeResolver},
     utils::{safe_ident, TypePath},
 };
-
-use fuel_abi_types::abi::full_program::FullTypeApplication;
 
 // Represents a component of either a struct(field name) or an enum(variant
 // name).
@@ -69,8 +68,9 @@ pub(crate) fn single_param_type_call(field_type: &ResolvedType) -> TokenStream {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use fuel_abi_types::abi::full_program::FullTypeDeclaration;
+
+    use super::*;
 
     #[test]
     fn respects_snake_case_flag() -> Result<()> {

--- a/packages/fuels-code-gen/src/utils/source.rs
+++ b/packages/fuels-code-gen/src/utils/source.rs
@@ -71,6 +71,14 @@ impl Source {
             Source::String(abi) => Ok(abi.clone()),
         }
     }
+
+    /// If the abigen is given a path, will return it here.
+    pub fn path(&self) -> Option<PathBuf> {
+        match self {
+            Source::Local(path) => Some(path.clone()),
+            _ => None
+        }
+    }
 }
 
 fn get_local_contract(path: &Path) -> Result<String> {

--- a/packages/fuels-code-gen/src/utils/source.rs
+++ b/packages/fuels-code-gen/src/utils/source.rs
@@ -76,7 +76,7 @@ impl Source {
     pub fn path(&self) -> Option<PathBuf> {
         match self {
             Source::Local(path) => Some(path.clone()),
-            _ => None
+            _ => None,
         }
     }
 }

--- a/packages/fuels-code-gen/src/utils/source.rs
+++ b/packages/fuels-code-gen/src/utils/source.rs
@@ -64,7 +64,7 @@ impl Source {
 
     /// Retrieves the source JSON of the artifact this will either read the JSON
     /// from the file system or retrieve a contract ABI from the network
-    /// dependending on the source type.
+    /// depending on the source type.
     pub fn get(&self) -> Result<String> {
         match self {
             Source::Local(path) => get_local_contract(path),
@@ -72,7 +72,6 @@ impl Source {
         }
     }
 
-    /// If the abigen is given a path, will return it here.
     pub fn path(&self) -> Option<PathBuf> {
         match self {
             Source::Local(path) => Some(path.clone()),

--- a/packages/fuels-core/src/types.rs
+++ b/packages/fuels-core/src/types.rs
@@ -1,10 +1,8 @@
 use std::fmt;
 
 pub use fuel_tx::{Address, AssetId, ContractId, TxPointer, UtxoId};
-pub use fuel_types::Nonce;
-
 use fuel_types::bytes::padded_len;
-pub use fuel_types::MessageId;
+pub use fuel_types::{MessageId, Nonce};
 
 pub use crate::types::{core::*, wrappers::*};
 use crate::types::{

--- a/packages/fuels-core/src/types/wrappers/block.rs
+++ b/packages/fuels-core/src/types/wrappers/block.rs
@@ -1,8 +1,10 @@
 #![cfg(feature = "std")]
 
 use chrono::{DateTime, NaiveDateTime, Utc};
-use fuel_core_client::client::types::block::{Block as ClientBlock, Header as ClientHeader};
-use fuel_core_client::client::types::primitives::Bytes32;
+use fuel_core_client::client::types::{
+    block::{Block as ClientBlock, Header as ClientHeader},
+    primitives::Bytes32,
+};
 
 #[derive(Debug)]
 pub struct Header {

--- a/packages/fuels-core/src/types/wrappers/chain_info.rs
+++ b/packages/fuels-core/src/types/wrappers/chain_info.rs
@@ -1,8 +1,10 @@
 #![cfg(feature = "std")]
 
+use fuel_core_client::client::types::{
+    chain_info::ChainInfo as ClientChainInfo, ConsensusParameters,
+};
+
 use crate::types::block::Block;
-use fuel_core_client::client::types::chain_info::ChainInfo as ClientChainInfo;
-use fuel_core_client::client::types::ConsensusParameters;
 
 #[derive(Debug)]
 pub struct ChainInfo {

--- a/packages/fuels-core/src/types/wrappers/message_proof.rs
+++ b/packages/fuels-core/src/types/wrappers/message_proof.rs
@@ -1,8 +1,7 @@
 #![cfg(feature = "std")]
 
-use fuel_core_client::client::types::primitives::Nonce;
 use fuel_core_client::client::types::{
-    MerkleProof as ClientMerkleProof, MessageProof as ClientMessageProof,
+    primitives::Nonce, MerkleProof as ClientMerkleProof, MessageProof as ClientMessageProof,
 };
 use fuel_types::Bytes32;
 

--- a/packages/fuels-core/src/types/wrappers/transaction_response.rs
+++ b/packages/fuels-core/src/types/wrappers/transaction_response.rs
@@ -7,9 +7,9 @@ use fuel_core_client::client::types::{
     TransactionResponse as ClientTransactionResponse, TransactionStatus as ClientTransactionStatus,
 };
 use fuel_tx::Transaction;
+use fuel_types::Bytes32;
 
 use crate::types::transaction::{CreateTransaction, ScriptTransaction, TransactionType};
-use fuel_types::Bytes32;
 
 #[derive(Debug, Clone)]
 pub struct TransactionResponse {

--- a/packages/fuels-macros/src/derive/utils.rs
+++ b/packages/fuels-macros/src/derive/utils.rs
@@ -13,11 +13,21 @@ pub(crate) fn get_path_from_attr_or(
     };
 
     let Meta::NameValue(name_value) = &attr.meta else {
-        return Err(Error::new_spanned(attr.meta.path(), "Expected name='value'"));
+        return Err(Error::new_spanned(
+            attr.meta.path(),
+            "Expected name='value'",
+        ));
     };
 
-    let Expr::Lit(ExprLit{lit: Lit::Str(lit_str),..}) = &name_value.value else {
-        return Err(Error::new_spanned(&name_value.value, "Expected string literal"));
+    let Expr::Lit(ExprLit {
+        lit: Lit::Str(lit_str),
+        ..
+    }) = &name_value.value
+    else {
+        return Err(Error::new_spanned(
+            &name_value.value,
+            "Expected string literal",
+        ));
     };
 
     TypePath::new(lit_str.value())

--- a/packages/fuels-test-helpers/src/node.rs
+++ b/packages/fuels-test-helpers/src/node.rs
@@ -10,8 +10,7 @@ use std::{
 pub use fuel_core_chain_config::ChainConfig;
 use fuel_core_chain_config::StateConfig;
 use fuel_core_client::client::FuelClient;
-use fuel_types::BlockHeight;
-use fuel_types::Word;
+use fuel_types::{BlockHeight, Word};
 use fuels_core::{
     constants::WORD_SIZE,
     types::{

--- a/packages/fuels/tests/contracts.rs
+++ b/packages/fuels/tests/contracts.rs
@@ -1,8 +1,8 @@
-use fuel_core::chain_config::ChainConfig;
 #[allow(unused_imports)]
 use std::future::Future;
 use std::vec;
 
+use fuel_core::chain_config::ChainConfig;
 use fuels::{
     accounts::{predicate::Predicate, Account},
     core::codec::{calldata, fn_selector},
@@ -1324,13 +1324,13 @@ async fn low_level_call() -> Result<()> {
 #[cfg(any(not(feature = "fuel-core-lib"), feature = "rocksdb"))]
 #[test]
 fn db_rocksdb() {
-    use fuels::accounts::fuel_crypto::SecretKey;
-    use fuels::accounts::wallet::WalletUnlocked;
-    use fuels::client::{PageDirection, PaginationRequest};
-    use fuels::prelude::DEFAULT_COIN_AMOUNT;
-    use fuels::prelude::{setup_test_provider, Config, DbType, ViewOnlyAccount};
-    use std::fs;
-    use std::str::FromStr;
+    use std::{fs, str::FromStr};
+
+    use fuels::{
+        accounts::{fuel_crypto::SecretKey, wallet::WalletUnlocked},
+        client::{PageDirection, PaginationRequest},
+        prelude::{setup_test_provider, Config, DbType, ViewOnlyAccount, DEFAULT_COIN_AMOUNT},
+    };
 
     let temp_dir = tempfile::tempdir()
         .expect("Failed to make tempdir")

--- a/packages/fuels/tests/providers.rs
+++ b/packages/fuels/tests/providers.rs
@@ -1,5 +1,4 @@
-use std::ops::Add;
-use std::{iter, str::FromStr, vec};
+use std::{iter, ops::Add, str::FromStr, vec};
 
 use chrono::{DateTime, Duration, NaiveDateTime, TimeZone, Utc};
 use fuel_core::service::{Config as CoreConfig, FuelService, ServiceTrait};

--- a/packages/fuels/tests/wallets.rs
+++ b/packages/fuels/tests/wallets.rs
@@ -1,9 +1,7 @@
 use std::iter::repeat;
 
-use fuel_tx::input::coin::CoinSigned;
-use fuel_tx::{Bytes32, Input, Output, TxPointer, UtxoId};
-use fuels::prelude::*;
-use fuels::types::transaction_builders::ScriptTransactionBuilder;
+use fuel_tx::{input::coin::CoinSigned, Bytes32, Input, Output, TxPointer, UtxoId};
+use fuels::{prelude::*, types::transaction_builders::ScriptTransactionBuilder};
 use fuels_accounts::wallet::{Wallet, WalletUnlocked};
 use fuels_test_helpers::setup_test_provider;
 


### PR DESCRIPTION
closes: #1060 

The solution (until Rust has an official way of doing it) is to call `include_bytes` inside your macro. This is detected by the compiler and it will watch the path for changes. 

I've assigned it to a `const _: &[u8] = include_bytes!(...)` and it seems it gets optimized away. 

Couldn't find a trace of the JSON file in the resulting executable (even under debug build). 

So we might have gotten away with a no-downsides hack.

Tested via a separate e2e suite. Didn't include it in the PR since it would require compiling the whole SDK twice during testing. 

### Checklist
- [x] I have linked to any relevant issues.
- [x] I have updated the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
