### PR TITLE
feat: add `build_tx` to `ScriptCallHandler`

### DIFF
--- a/packages/fuels-programs/src/script_calls.rs
+++ b/packages/fuels-programs/src/script_calls.rs
@@ -208,7 +208,7 @@ where
             .sum()
     }
 
-    /// Returns the script that executes the script call
+    /// Returns the transaction that executes the script call
     pub async fn build_tx(&self) -> Result<ScriptTransaction> {
         let tb = self.prepare_builder().await?;
         let base_amount = self.calculate_base_asset_sum();

--- a/packages/fuels-programs/src/script_calls.rs
+++ b/packages/fuels-programs/src/script_calls.rs
@@ -14,7 +14,7 @@ use fuels_core::{
         bech32::Bech32ContractId,
         errors::Result,
         input::Input,
-        transaction::{Transaction, TxParameters},
+        transaction::{ScriptTransaction, Transaction, TxParameters},
         transaction_builders::ScriptTransactionBuilder,
         unresolved_bytes::UnresolvedBytes,
     },
@@ -208,18 +208,25 @@ where
             .sum()
     }
 
-    /// Call a script on the node. If `simulate == true`, then the call is done in a
-    /// read-only manner, using a `dry-run`. The [`FuelCallResponse`] struct contains the `main`'s value
-    /// in its `value` field as an actual typed value `D` (if your method returns `bool`,
-    /// it will be a bool, works also for structs thanks to the `abigen!()`).
-    /// The other field of [`FuelCallResponse`], `receipts`, contains the receipts of the transaction.
-    async fn call_or_simulate(&mut self, simulate: bool) -> Result<FuelCallResponse<D>> {
+    /// Returns the script that executes the script call
+    pub async fn build_tx(&self) -> Result<ScriptTransaction> {
         let tb = self.prepare_builder().await?;
         let base_amount = self.calculate_base_asset_sum();
         let tx = self
             .account
             .add_fee_resources(tb, base_amount, None)
             .await?;
+
+        Ok(tx)
+    }
+
+    /// Call a script on the node. If `simulate == true`, then the call is done in a
+    /// read-only manner, using a `dry-run`. The [`FuelCallResponse`] struct contains the `main`'s value
+    /// in its `value` field as an actual typed value `D` (if your method returns `bool`,
+    /// it will be a bool, works also for structs thanks to the `abigen!()`).
+    /// The other field of [`FuelCallResponse`], `receipts`, contains the receipts of the transaction.
+    async fn call_or_simulate(&mut self, simulate: bool) -> Result<FuelCallResponse<D>> {
+        let tx = self.build_tx().await?;
         let consensus_parameters = self.provider.consensus_parameters();
         self.cached_tx_id = Some(tx.id(consensus_parameters.chain_id.into()));
 


### PR DESCRIPTION
After doing some script debugging, I have seen that we did not have a way to extract the `tx` from a `ScriptCallHandler` as we do with the `ContractCallHandler`.

### Checklist
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
