### PR TITLE
fix: validate multi-calls wrt to heap types

### DIFF
--- a/docs/src/calling-contracts/multicalls.md
+++ b/docs/src/calling-contracts/multicalls.md
@@ -30,4 +30,4 @@ You can also interact with the `FuelCallResponse` by moving the type annotation 
 {{#include ../../../examples/contracts/src/lib.rs:multi_contract_call_response}}
 ```
 
-> **Note:** The `MultiContractCallHandler` supports only one contract call that returns a heap type. Because of the way heap types are handled, this contract call needs to be at the last position, i.e., added last with `add_call`. This is a temporary limitation that we hope to lift soon. in the meantime, If you have multiple calls handling heap types, split them across multiple regular, single calls.
+> **Note:** The `MultiContractCallHandler` supports only one contract call that returns a heap type. Because of the way heap types are handled, this contract call needs to be at the last position, i.e., added last with `add_call`. This is a temporary limitation that we hope to lift soon. In the meantime, if you have multiple calls handling heap types, split them across multiple regular, single calls.

--- a/docs/src/calling-contracts/multicalls.md
+++ b/docs/src/calling-contracts/multicalls.md
@@ -16,8 +16,6 @@ Next, you provide the prepared calls to your `MultiContractCallHandler` and opti
 
 > **Note:** any transaction parameters configured on separate contract calls are disregarded in favor of the parameters provided to `MultiContractCallHandler`.
 
-> **Note:** The `MultiContractCallHandler` supports only one contract call that returns a heap type. Because of the way heap types are handled, this contract call needs to be at the last position, i.e., added last with `add_call`.
-
 ## Output values
 
 To get the output values of the bundled calls, you need to provide explicit type annotations when saving the result of `call()` or `simulate()` to a variable:
@@ -31,3 +29,5 @@ You can also interact with the `FuelCallResponse` by moving the type annotation 
 ```rust,ignore
 {{#include ../../../examples/contracts/src/lib.rs:multi_contract_call_response}}
 ```
+
+> **Note:** The `MultiContractCallHandler` supports only one contract call that returns a heap type. Because of the way heap types are handled, this contract call needs to be at the last position, i.e., added last with `add_call`.

--- a/docs/src/calling-contracts/multicalls.md
+++ b/docs/src/calling-contracts/multicalls.md
@@ -30,4 +30,4 @@ You can also interact with the `FuelCallResponse` by moving the type annotation 
 {{#include ../../../examples/contracts/src/lib.rs:multi_contract_call_response}}
 ```
 
-> **Note:** The `MultiContractCallHandler` supports only one contract call that returns a heap type. Because of the way heap types are handled, this contract call needs to be at the last position, i.e., added last with `add_call`.
+> **Note:** The `MultiContractCallHandler` supports only one contract call that returns a heap type. Because of the way heap types are handled, this contract call needs to be at the last position, i.e., added last with `add_call`. This is a temporary limitation that we hope to lift soon. in the meantime, If you have multiple calls handling heap types, split them across multiple regular, single calls.

--- a/docs/src/calling-contracts/multicalls.md
+++ b/docs/src/calling-contracts/multicalls.md
@@ -1,6 +1,6 @@
 # Multiple contract calls
 
-With `ContractMultiCallHandler`, you can execute multiple contract calls within a single transaction. To achieve this, you first prepare all the contract calls that you want to bundle:
+With `MultiContractCallHandler`, you can execute multiple contract calls within a single transaction. To achieve this, you first prepare all the contract calls that you want to bundle:
 
 ```rust,ignore
 {{#include ../../../examples/contracts/src/lib.rs:multi_call_prepare}}
@@ -8,13 +8,15 @@ With `ContractMultiCallHandler`, you can execute multiple contract calls within 
 
 You can also set call parameters, variable outputs, or external contracts for every contract call, as long as you don't execute it with `call()` or `simulate()`.
 
-Next, you provide the prepared calls to your `ContractMultiCallHandler` and optionally configure transaction parameters:
+Next, you provide the prepared calls to your `MultiContractCallHandler` and optionally configure transaction parameters:
 
 ```rust,ignore
 {{#include ../../../examples/contracts/src/lib.rs:multi_call_build}}
 ```
 
-> **Note:** any transaction parameters configured on separate contract calls are disregarded in favor of the parameters provided to `ContractMultiCallHandler`.
+> **Note:** any transaction parameters configured on separate contract calls are disregarded in favor of the parameters provided to `MultiContractCallHandler`.
+
+> **Note:** The `MultiContractCallHandler` supports only one contract call that returns a heap type. Because of the way heap types are handled, this contract call needs to be at the last position, i.e., added last with `add_call`.
 
 ## Output values
 

--- a/packages/fuels-programs/src/contract.rs
+++ b/packages/fuels-programs/src/contract.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Debug, fs, marker::PhantomData, panic, path::Path};
+use std::{collections::HashMap, fmt::Debug, fs, marker::PhantomData, path::Path};
 
 use fuel_tx::{
     AssetId, Bytes32, Contract as FuelContract, ContractId, Output, Receipt, Salt, StorageSlot,
@@ -699,11 +699,49 @@ impl<T: Account> MultiContractCallHandler<T> {
         self
     }
 
+    fn validate_contract_calls(&self) -> Result<()> {
+        if self.contract_calls.is_empty() {
+            return Err(error!(
+                InvalidData,
+                "No calls added. Have you used '.add_calls()'?"
+            ));
+        }
+
+        let number_of_heap_type_calls: u64 = self
+            .contract_calls
+            .iter()
+            .map(|cc| cc.output_param.is_vm_heap_type() as u64)
+            .sum();
+
+        if number_of_heap_type_calls > 1 {
+            return Err(error!(
+                InvalidData,
+                "`MultiContractCallHandler` can have only one call that returns a heap type"
+            ));
+        }
+
+        if number_of_heap_type_calls == 1 {
+            let last_call_return_is_heap = self
+                .contract_calls
+                .last()
+                .expect("is not empty")
+                .output_param
+                .is_vm_heap_type();
+
+            if !last_call_return_is_heap {
+                return Err(error!(
+                    InvalidData,
+                    "The contract call with the heap type return must be at the last position"
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
     /// Returns the script that executes the contract calls
     pub async fn build_tx(&self) -> Result<ScriptTransaction> {
-        if self.contract_calls.is_empty() {
-            panic!("No calls added. Have you used '.add_calls()'?");
-        }
+        self.validate_contract_calls()?;
 
         build_tx_from_contract_calls(&self.contract_calls, self.tx_parameters, &self.account).await
     }

--- a/packages/fuels-programs/src/contract.rs
+++ b/packages/fuels-programs/src/contract.rs
@@ -711,7 +711,7 @@ impl<T: Account> MultiContractCallHandler<T> {
             .contract_calls
             .iter()
             .filter(|cc| cc.output_param.is_vm_heap_type())
-            .count() as u64;
+            .count();
 
         match number_of_heap_type_calls {
             0 => Ok(()),


### PR DESCRIPTION
closes: https://github.com/FuelLabs/fuels-rs/issues/1085

The `MultiContractCallHandler` can have one call with a heap return type but it must be placed on the last position.

### Checklist
- [x] I have linked to any relevant issues.
- [x] I have updated the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
