### PR TITLE
chore: bump `forc` to `0.45.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   RUSTFLAGS: "-D warnings"
   FUEL_CORE_VERSION: 0.20.4
   RUST_VERSION: 1.71.1
-  FORC_VERSION: 0.44.0
+  FORC_VERSION: 0.45.0
   FORC_PATCH_BRANCH: ""
   FORC_PATCH_REVISION: ""
 
@@ -60,7 +60,7 @@ jobs:
         working-directory: packages/fuels
 
       - name: Build Sway test projects
-        run: forc build --terse
+        run: forc build --terse --error-on-warnings
         working-directory: packages/fuels
 
       - uses: actions/upload-artifact@v2

--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -389,7 +389,7 @@ mod tests {
         let amount = 100;
 
         let response = contract_methods
-            .increment_from_contract_then_mint(called_contract_id, amount, address)
+            .mint_then_increment_from_contract(called_contract_id, amount, address)
             .call()
             .await;
 
@@ -401,7 +401,7 @@ mod tests {
 
         // ANCHOR: dependency_estimation_manual
         let response = contract_methods
-            .increment_from_contract_then_mint(called_contract_id, amount, address)
+            .mint_then_increment_from_contract(called_contract_id, amount, address)
             .append_variable_outputs(1)
             .with_contract_ids(&[called_contract_id.into()])
             .call()
@@ -414,7 +414,7 @@ mod tests {
 
         // ANCHOR: dependency_estimation
         let response = contract_methods
-            .increment_from_contract_then_mint(called_contract_id, amount, address)
+            .mint_then_increment_from_contract(called_contract_id, amount, address)
             .estimate_tx_dependencies(Some(2))
             .await?
             .call()

--- a/packages/fuels-core/Cargo.toml
+++ b/packages/fuels-core/Cargo.toml
@@ -17,10 +17,10 @@ fuel-asm = { workspace = true }
 fuel-core = { workspace = true, default-features = false, optional = true }
 fuel-core-chain-config = { workspace = true }
 fuel-core-client = { workspace = true, optional = true }
+fuel-crypto = { workspace = true }
 fuel-tx = { workspace = true }
 fuel-types = { workspace = true, features = ["default"] }
 fuel-vm = { workspace = true }
-fuel-crypto = { workspace = true }
 fuels-macros = { workspace = true }
 hex = { workspace = true, features = ["std"] }
 itertools = { workspace = true }

--- a/packages/fuels/tests/contracts/lib_contract_caller/src/main.sw
+++ b/packages/fuels/tests/contracts/lib_contract_caller/src/main.sw
@@ -7,7 +7,7 @@ use std::constants::ZERO_B256;
 abi ContractCaller {
     fn increment_from_contract(contract_id: ContractId, value: u64) -> u64;
     fn increment_from_contracts(contract_id: ContractId, contract_id2: ContractId, value: u64) -> u64;
-    fn increment_from_contract_then_mint(contract_id: ContractId, amount: u64, address: Address);
+    fn mint_then_increment_from_contract(contract_id: ContractId, amount: u64, address: Address);
     fn require_from_contract(contract_id: ContractId);
 }
 
@@ -29,11 +29,11 @@ impl ContractCaller for Contract {
         contract_instance.increment(value) + contract_instance2.increment(value)
     }
 
-    fn increment_from_contract_then_mint(contract_id: ContractId, amount: u64, address: Address) {
+    fn mint_then_increment_from_contract(contract_id: ContractId, amount: u64, address: Address) {
+        mint_to_address(address, ZERO_B256, amount);
+
         let contract_instance = abi(LibContract, contract_id.into());
         let _ = contract_instance.increment(42);
-
-        mint_to_address(address, ZERO_B256, amount);
     }
 
     fn require_from_contract(contract_id: ContractId) {

--- a/packages/fuels/tests/contracts/storage/src/main.sw
+++ b/packages/fuels/tests/contracts/storage/src/main.sw
@@ -8,6 +8,8 @@ storage {
 }
 
 abi MyContract {
+    #[storage(write)]
+    fn set_storage(x: u64, y: b256);
     #[storage(read)]
     fn get_value_b256(key: b256) -> b256;
     #[storage(read)]
@@ -15,6 +17,12 @@ abi MyContract {
 }
 
 impl MyContract for Contract {
+    #[storage(write)]
+    fn set_storage(x: u64, y: b256) {
+        storage.x.write(x);
+        storage.y.write(y);
+    }
+
     #[storage(read)]
     fn get_value_b256(key: b256) -> b256 {
         read::<b256>(key, 0).unwrap()

--- a/packages/fuels/tests/scripts/script_enum/src/main.sw
+++ b/packages/fuels/tests/scripts/script_enum/src/main.sw
@@ -1,5 +1,6 @@
 script;
 
+#[allow(dead_code)]
 enum MyEnum {
     One: (),
     Two: (),

--- a/packages/fuels/tests/types/contracts/generics/src/main.sw
+++ b/packages/fuels/tests/types/contracts/generics/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::hash::sha256;
+use std::hash::*;
 
 struct SimpleGeneric<T> {
     single_generic_param: T,
@@ -28,6 +28,12 @@ enum EnumWGeneric<N> {
 struct MegaExample<T, U> {
     a: ([U; 2], T),
     b: Vec<([EnumWGeneric<StructWTupleGeneric<StructWArrayGeneric<PassTheGenericOn<T>>>>; 1], u32)>,
+}
+
+impl Hash for str[3] {
+    fn hash(self, ref mut state: Hasher) {
+        state.write_str(self);
+    }
 }
 
 abi MyContract {

--- a/packages/fuels/tests/types/contracts/identity/src/main.sw
+++ b/packages/fuels/tests/types/contracts/identity/src/main.sw
@@ -4,8 +4,10 @@ struct TestStruct {
     identity: Identity,
 }
 
+#[allow(dead_code)]
 enum TestEnum {
     EnumIdentity: Identity,
+    OtherValue: bool,
 }
 
 const ADDR = 0xd58573593432a30a800f97ad32f877425c223a9e427ab557aab5d5bb89156db0;

--- a/packages/fuels/tests/types/contracts/options/src/main.sw
+++ b/packages/fuels/tests/types/contracts/options/src/main.sw
@@ -4,8 +4,10 @@ struct TestStruct {
     option: Option<Address>,
 }
 
+#[allow(dead_code)]
 enum TestEnum {
     EnumOption: Option<Address>,
+    OtherValue: bool,
 }
 
 const ADDR = 0xd58573593432a30a800f97ad32f877425c223a9e427ab557aab5d5bb89156db0;

--- a/packages/fuels/tests/types/contracts/results/src/main.sw
+++ b/packages/fuels/tests/types/contracts/results/src/main.sw
@@ -10,6 +10,7 @@ enum TestEnum {
 
 pub enum TestError {
     NoAddress: str[5],
+    OtherError: (),
 }
 
 const ADDR = 0xd58573593432a30a800f97ad32f877425c223a9e427ab557aab5d5bb89156db0;
@@ -66,7 +67,7 @@ impl MyContract for Contract {
     fn input_error(test_result: Result<Address, TestError>) -> bool {
         if let Result::Err(test_error) = test_result {
             if let TestError::NoAddress(_err_msg) = test_error {
-                return true
+                return true;
             }
         }
         false

--- a/packages/fuels/tests/types/contracts/tuples/src/main.sw
+++ b/packages/fuels/tests/types/contracts/tuples/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::{constants::ZERO_B256, hash::sha256};
+use std::{constants::ZERO_B256, hash::*};
 
 struct Person {
     name: str[4],
@@ -11,6 +11,12 @@ enum State {
     A: (),
     B: (),
     C: (),
+}
+
+impl Hash for str[4] {
+    fn hash(self, ref mut state: Hasher) {
+        state.write_str(self);
+    }
 }
 
 abi MyContract {

--- a/packages/fuels/tests/types/predicates/enums/src/main.sw
+++ b/packages/fuels/tests/types/predicates/enums/src/main.sw
@@ -3,6 +3,7 @@ predicate;
 #[allow(dead_code)]
 enum TestEnum {
     A: u64,
+    B: bool,
 }
 
 #[allow(dead_code)]

--- a/packages/fuels/tests/types/predicates/predicate_tuples/src/main.sw
+++ b/packages/fuels/tests/types/predicates/predicate_tuples/src/main.sw
@@ -7,6 +7,7 @@ struct TestStruct {
 #[allow(dead_code)]
 enum TestEnum {
     Value: u64,
+    OtherValue: u32,
 }
 
 fn main(input_tuple: (u64, TestStruct, TestEnum), number: u64) -> bool {

--- a/packages/fuels/tests/types/predicates/predicate_vectors/src/main.sw
+++ b/packages/fuels/tests/types/predicates/predicate_vectors/src/main.sw
@@ -6,6 +6,7 @@ pub struct SomeStruct<T> {
 
 pub enum SomeEnum<T> {
     A: T,
+    B: bool,
 }
 
 fn main(

--- a/packages/fuels/tests/types/scripts/script_vectors/src/main.sw
+++ b/packages/fuels/tests/types/scripts/script_vectors/src/main.sw
@@ -21,70 +21,70 @@ fn main(
     vec_in_tuple: (Vec<u32>, Vec<u32>),
     vec_in_a_vec_in_a_struct_in_a_vec: Vec<SomeStruct<Vec<Vec<u32>>>>,
 ) -> bool {
-     {
+    {
         let exp_u32_vec = vec_from([0u32, 1u32, 2u32]);
 
         require(u32_vec == exp_u32_vec, "u32_vec_error");
     }
-     {
+    {
         let mut exp_vec_in_vec = Vec::new();
         exp_vec_in_vec.push(vec_from([0u32, 1u32, 2u32]));
         exp_vec_in_vec.push(vec_from([0u32, 1u32, 2u32]));
 
         require(vec_in_vec == exp_vec_in_vec, "vec_in_vec err");
     }
-     {
+    {
         let mut exp_struct_in_vec = Vec::new();
         exp_struct_in_vec.push(SomeStruct { a: 0u32 });
         exp_struct_in_vec.push(SomeStruct { a: 1u32 });
 
         require(struct_in_vec == exp_struct_in_vec, "struct_in_vec err");
     }
-     {
+    {
         let exp_vec_in_struct = SomeStruct {
             a: vec_from([0u32, 1u32, 2u32]),
         };
 
         require(vec_in_struct.a == exp_vec_in_struct.a, "vec_in_struct err");
     }
-     {
+    {
         let mut exp_array_in_vec = Vec::new();
         exp_array_in_vec.push([0, 1]);
         exp_array_in_vec.push([0, 1]);
 
         require(array_in_vec == exp_array_in_vec, "array_in_vec err");
     }
-     {
+    {
         let exp_vec_in_array = [vec_from([0u32, 1u32, 2u32]), vec_from([0u32, 1u32, 2u32])];
 
         require(vec_in_array == exp_vec_in_array, "vec_in_array err");
     }
-     {
+    {
         let exp_u32_vec = vec_from([0u32, 1u32, 2u32]);
         let exp_vec_in_enum = SomeEnum::a(exp_u32_vec);
 
         require(vec_in_enum == exp_vec_in_enum, "vec_in_enum err");
     }
-     {
+    {
         let mut exp_enum_in_vec = Vec::new();
         exp_enum_in_vec.push(SomeEnum::a(0u32));
         exp_enum_in_vec.push(SomeEnum::a(1u32));
 
         require(enum_in_vec == exp_enum_in_vec, "enum_in_vec err");
     }
-     {
+    {
         let mut exp_tuple_in_vec = Vec::new();
         exp_tuple_in_vec.push((0u32, 0u32));
         exp_tuple_in_vec.push((1u32, 1u32));
 
         require(tuple_in_vec == exp_tuple_in_vec, "tuple_in_vec err");
     }
-     {
+    {
         let exp_vec_in_tuple = (vec_from([0u32, 1u32, 2u32]), vec_from([0u32, 1u32, 2u32]));
 
         require(vec_in_tuple == exp_vec_in_tuple, "vec_in_tuple err");
     }
-     {
+    {
         let mut exp_vec_in_a_vec_in_a_struct_in_a_vec = Vec::new();
 
         let mut inner_vec_1 = Vec::new();


### PR DESCRIPTION
I have updated our test projects to work with `forc: 0.45.0` and removed all warnings.
I have also added the ` --error-on-warnings` flag to `forc build` - let me know what you think!

I changed the order of the `increment_from_contract_then_mint` function because of a compiler warning stating that we should first change the balance and then call external contracts.

### Checklist
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
