### PR TITLE
chore: replace deprecated `chrono` functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ Inflector = "0.11.4"
 async-trait = { version = "0.1.73", default-features = false }
 bech32 = "0.9.1"
 bytes = { version = "1.4.0", default-features = false }
-chrono = "0.4.26"
+chrono = "0.4.27"
 elliptic-curve = { version = "0.13.5", default-features = false }
 eth-keystore = "0.5.0"
 fuel-abi-types = "0.3.0"

--- a/packages/fuels-core/Cargo.toml
+++ b/packages/fuels-core/Cargo.toml
@@ -10,8 +10,8 @@ rust-version = { workspace = true }
 description = "Fuel Rust SDK core."
 
 [dependencies]
-bech32 = "0.9.0"
-chrono = "0.4.2"
+bech32 = { workspace = true }
+chrono = { workspace = true }
 fuel-abi-types = { workspace = true }
 fuel-asm = { workspace = true }
 fuel-core = { workspace = true, default-features = false, optional = true }

--- a/packages/fuels-core/src/types/wrappers/block.rs
+++ b/packages/fuels-core/src/types/wrappers/block.rs
@@ -23,7 +23,7 @@ pub struct Header {
 impl From<ClientHeader> for Header {
     fn from(client_header: ClientHeader) -> Self {
         let naive = NaiveDateTime::from_timestamp_opt(client_header.time.to_unix(), 0);
-        let time = naive.map(|time| DateTime::<Utc>::from_utc(time, Utc));
+        let time = naive.map(|time| DateTime::<Utc>::from_naive_utc_and_offset(time, Utc));
 
         Self {
             id: client_header.id,

--- a/packages/fuels-core/src/types/wrappers/transaction_response.rs
+++ b/packages/fuels-core/src/types/wrappers/transaction_response.rs
@@ -45,7 +45,7 @@ impl From<ClientTransactionResponse> for TransactionResponse {
             ClientTransactionStatus::Success { time, .. }
             | ClientTransactionStatus::Failure { time, .. } => {
                 let native = NaiveDateTime::from_timestamp_opt(time.to_unix(), 0);
-                native.map(|time| DateTime::<Utc>::from_utc(time, Utc))
+                native.map(|time| DateTime::<Utc>::from_naive_utc_and_offset(time, Utc))
             }
         };
 

--- a/packages/fuels/tests/providers.rs
+++ b/packages/fuels/tests/providers.rs
@@ -749,7 +749,10 @@ fn given_a_message(address: Bech32Address, message_amount: u64) -> Message {
 
 fn convert_to_datetime(timestamp: u64) -> DateTime<Utc> {
     let unix = Tai64(timestamp).to_unix();
-    DateTime::from_local(NaiveDateTime::from_timestamp_opt(unix, 0).unwrap(), Utc)
+    NaiveDateTime::from_timestamp_opt(unix, 0)
+        .unwrap()
+        .and_local_timezone(Utc)
+        .unwrap()
 }
 
 /// This test is here in addition to `can_set_custom_block_time` because even though this test


### PR DESCRIPTION
Our CI is failing because a warning caused by deprecated functions.

### Checklist
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
