### PR TITLE
chore(deps): remove unused deps, add corresponding CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,8 @@ jobs:
             install_fuel_core: true
           - cargo_command: test
             args: --doc --workspace
+          - cargo_command: machete
+            args: --skip-target-dir
           - command: test_wasm
             args:
           - command: check_doc_anchors_valid
@@ -214,6 +216,10 @@ jobs:
       - name: Install nextest
         if: ${{ matrix.cargo_command == 'nextest' }}
         uses: taiki-e/install-action@nextest
+
+      - name: Install cargo-machete
+        if: ${{ matrix.cargo_command == 'machete' }}
+        uses: taiki-e/install-action@cargo-machete
 
       - name: Cargo (workspace-level)
         if: ${{ matrix.cargo_command && !matrix.package }}

--- a/packages/fuels-accounts/Cargo.toml
+++ b/packages/fuels-accounts/Cargo.toml
@@ -11,7 +11,6 @@ description = "Fuel Rust SDK accounts."
 
 [dependencies]
 async-trait = { workspace = true, default-features = false }
-bytes = { workspace = true, features = ["serde"] }
 chrono = { workspace = true }
 elliptic-curve = { workspace = true, default-features = false }
 eth-keystore =  { workspace = true }
@@ -23,10 +22,7 @@ fuel-types = { workspace = true, features = ["random"] }
 fuel-vm = { workspace = true }
 fuels-core = { workspace = true }
 hex = { workspace = true, default-features = false, features = ["std"] }
-itertools = { workspace = true }
 rand = { workspace = true, default-features = false }
-serde = { workspace = true, default-features = true, features = ["derive"] }
-sha2 = { workspace = true, default-features = false }
 tai64 = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true, default-features = false }
 tokio = { workspace = true, features = ["full"] }

--- a/packages/fuels-code-gen/Cargo.toml
+++ b/packages/fuels-code-gen/Cargo.toml
@@ -18,3 +18,6 @@ quote = { workspace = true }
 regex = { workspace = true }
 serde_json = { workspace = true }
 syn = { workspace = true }
+
+[package.metadata.cargo-machete]
+ignored = ["Inflector"]

--- a/packages/fuels-core/Cargo.toml
+++ b/packages/fuels-core/Cargo.toml
@@ -14,7 +14,6 @@ bech32 = { workspace = true }
 chrono = { workspace = true }
 fuel-abi-types = { workspace = true }
 fuel-asm = { workspace = true }
-fuel-core = { workspace = true, default-features = false, optional = true }
 fuel-core-chain-config = { workspace = true }
 fuel-core-client = { workspace = true, optional = true }
 fuel-crypto = { workspace = true }
@@ -24,8 +23,6 @@ fuel-vm = { workspace = true }
 fuels-macros = { workspace = true }
 hex = { workspace = true, features = ["std"] }
 itertools = { workspace = true }
-proc-macro2 = { workspace = true }
-regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, default-features = true }
 sha2 = { workspace = true }

--- a/packages/fuels-macros/Cargo.toml
+++ b/packages/fuels-macros/Cargo.toml
@@ -13,15 +13,11 @@ description = "Fuel Rust SDK marcros to generate types from ABI."
 proc-macro = true
 
 [dependencies]
-Inflector = { workspace = true }
-fuel-abi-types = { workspace = true }
 fuels-code-gen = { workspace = true }
 itertools = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 rand = { workspace = true }
-regex = { workspace = true }
-serde_json = { workspace = true }
 syn = { workspace = true, features = ["extra-traits"] }
 
 [dev-dependencies]

--- a/packages/fuels-programs/Cargo.toml
+++ b/packages/fuels-programs/Cargo.toml
@@ -18,15 +18,9 @@ fuel-tx = { workspace = true }
 fuel-types = { workspace = true, features = ["default"] }
 fuels-accounts = { workspace = true }
 fuels-core = { workspace = true }
-hex = { workspace = true, default-features = false, features = ["std"] }
 itertools = { workspace = true }
-proc-macro2 = { workspace = true }
 rand = { workspace = true }
-regex = { workspace = true }
-serde = { workspace = true, default-features = false, features = ["derive"] }
 serde_json = { workspace = true }
-sha2 = { workspace = true }
-thiserror = { workspace = true, default-features = false }
 tokio = { workspace = true }
 
 [dev-dependencies]

--- a/packages/fuels-test-helpers/Cargo.toml
+++ b/packages/fuels-test-helpers/Cargo.toml
@@ -13,7 +13,6 @@ description = "Fuel Rust SDK test helpers."
 fuel-core = { workspace = true, default-features = false, optional = true }
 fuel-core-chain-config = { workspace = true }
 fuel-core-client = { workspace = true }
-fuel-core-types = { workspace = true }
 fuel-tx = { workspace = true }
 fuel-types = { workspace = true, features = ["random"] }
 fuels-accounts = { workspace = true, optional = true }


### PR DESCRIPTION
No relevant issue - just tech debt.

Removes dependencies unused by our crates, and adds a step to `ci.yml` to report them in the future.

This is accomplished with [`cargo-machete`](https://github.com/bnjbvr/cargo-machete), which reported only a single false positive - a crate called `Inflector` (titlecase), but used in code as `inflector` (lowercase); I added a corresponding exception.

### Checklist
- [ ] I have linked to any relevant issues.
- [ ] I have updated the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
