### PR TITLE
refactor: use `TxStatus` to map revert errors

### DIFF
--- a/packages/fuels-accounts/src/provider.rs
+++ b/packages/fuels-accounts/src/provider.rs
@@ -282,32 +282,27 @@ impl Provider {
         Ok(self.client.node_info().await?.into())
     }
 
-    pub async fn checked_dry_run<T: Transaction>(&self, tx: T) -> Result<Vec<Receipt>> {
+    pub async fn checked_dry_run<T: Transaction>(&self, tx: T) -> Result<TxStatus> {
         let receipts = self.dry_run(tx).await?;
-        Self::has_script_succeeded(&receipts)?;
-
-        Ok(receipts)
+        Ok(Self::tx_status_from_receipts(receipts))
     }
 
-    fn has_script_succeeded(receipts: &[Receipt]) -> Result<()> {
-        receipts
-            .iter()
-            .find_map(|receipt| match receipt {
-                Receipt::ScriptResult { result, .. }
-                    if *result != ScriptExecutionResult::Success =>
-                {
-                    Some(format!("{result:?}"))
-                }
-                _ => None,
-            })
-            .map(|error_message| {
-                Err(Error::RevertTransactionError {
-                    reason: error_message,
-                    revert_id: 0,
-                    receipts: receipts.to_owned(),
-                })
-            })
-            .unwrap_or(Ok(()))
+    fn tx_status_from_receipts(receipts: Vec<Receipt>) -> TxStatus {
+        let revert_reason = receipts.iter().find_map(|receipt| match receipt {
+            Receipt::ScriptResult { result, .. } if *result != ScriptExecutionResult::Success => {
+                Some(format!("{result:?}"))
+            }
+            _ => None,
+        });
+
+        match revert_reason {
+            Some(reason) => TxStatus::Revert {
+                receipts,
+                reason,
+                id: 0,
+            },
+            None => TxStatus::Success { receipts },
+        }
     }
 
     pub async fn dry_run<T: Transaction>(&self, tx: T) -> Result<Vec<Receipt>> {

--- a/packages/fuels-programs/src/contract.rs
+++ b/packages/fuels-programs/src/contract.rs
@@ -11,7 +11,7 @@ use fuel_tx::{
 };
 use fuels_accounts::{provider::TransactionCost, Account};
 use fuels_core::{
-    codec::{map_revert_error, ABIEncoder, DecoderConfig, LogDecoder},
+    codec::{ABIEncoder, DecoderConfig, LogDecoder},
     constants::{BASE_ASSET_ID, DEFAULT_CALL_PARAMS_AMOUNT},
     traits::{Parameterize, Tokenizable},
     types::{
@@ -576,9 +576,7 @@ where
 
     /// Call a contract's method on the node, in a state-modifying manner.
     pub async fn call(mut self) -> Result<FuelCallResponse<D>> {
-        self.call_or_simulate(false)
-            .await
-            .map_err(|err| map_revert_error(err, &self.log_decoder))
+        self.call_or_simulate(false).await
     }
 
     pub async fn submit(mut self) -> Result<SubmitResponse<T, D>> {
@@ -607,9 +605,7 @@ where
     /// blockchain is *not* modified but simulated.
     ///
     pub async fn simulate(&mut self) -> Result<FuelCallResponse<D>> {
-        self.call_or_simulate(true)
-            .await
-            .map_err(|err| map_revert_error(err, &self.log_decoder))
+        self.call_or_simulate(true).await
     }
 
     async fn call_or_simulate(&mut self, simulate: bool) -> Result<FuelCallResponse<D>> {
@@ -618,15 +614,13 @@ where
 
         self.cached_tx_id = Some(tx.id(provider.chain_id()));
 
-        let receipts = if simulate {
+        let tx_status = if simulate {
             provider.checked_dry_run(tx).await?
         } else {
             let tx_id = provider.send_transaction_and_await_commit(tx).await?;
-            provider
-                .tx_status(&tx_id)
-                .await?
-                .take_receipts_checked(Some(&self.log_decoder))?
+            provider.tx_status(&tx_id).await?
         };
+        let receipts = tx_status.take_receipts_checked(Some(&self.log_decoder))?;
 
         self.get_response(receipts)
     }
@@ -864,9 +858,7 @@ impl<T: Account> MultiContractCallHandler<T> {
 
     /// Call contract methods on the node, in a state-modifying manner.
     pub async fn call<D: Tokenizable + Debug>(&mut self) -> Result<FuelCallResponse<D>> {
-        self.call_or_simulate(false)
-            .await
-            .map_err(|err| map_revert_error(err, &self.log_decoder))
+        self.call_or_simulate(false).await
     }
 
     pub async fn submit(mut self) -> Result<SubmitResponseMultiple<T>> {
@@ -897,9 +889,7 @@ impl<T: Account> MultiContractCallHandler<T> {
     ///
     /// [call]: Self::call
     pub async fn simulate<D: Tokenizable + Debug>(&mut self) -> Result<FuelCallResponse<D>> {
-        self.call_or_simulate(true)
-            .await
-            .map_err(|err| map_revert_error(err, &self.log_decoder))
+        self.call_or_simulate(true).await
     }
 
     async fn call_or_simulate<D: Tokenizable + Debug>(
@@ -911,15 +901,13 @@ impl<T: Account> MultiContractCallHandler<T> {
 
         self.cached_tx_id = Some(tx.id(provider.chain_id()));
 
-        let receipts = if simulate {
+        let tx_status = if simulate {
             provider.checked_dry_run(tx).await?
         } else {
             let tx_id = provider.send_transaction_and_await_commit(tx).await?;
-            provider
-                .tx_status(&tx_id)
-                .await?
-                .take_receipts_checked(Some(&self.log_decoder))?
+            provider.tx_status(&tx_id).await?
         };
+        let receipts = tx_status.take_receipts_checked(Some(&self.log_decoder))?;
 
         self.get_response(receipts)
     }
@@ -929,7 +917,7 @@ impl<T: Account> MultiContractCallHandler<T> {
         let provider = self.account.try_provider()?;
         let tx = self.build_tx().await?;
 
-        provider.checked_dry_run(tx).await?;
+        provider.checked_dry_run(tx).await?.check(None)?;
 
         Ok(())
     }

--- a/packages/fuels-programs/src/script_calls.rs
+++ b/packages/fuels-programs/src/script_calls.rs
@@ -7,7 +7,7 @@ use fuels_accounts::{
     Account,
 };
 use fuels_core::{
-    codec::{map_revert_error, DecoderConfig, LogDecoder},
+    codec::{DecoderConfig, LogDecoder},
     constants::BASE_ASSET_ID,
     offsets::base_offset_script,
     traits::{Parameterize, Tokenizable},
@@ -234,24 +234,20 @@ where
         let tx = self.build_tx().await?;
         self.cached_tx_id = Some(tx.id(self.provider.chain_id()));
 
-        let receipts = if simulate {
+        let tx_status = if simulate {
             self.provider.checked_dry_run(tx).await?
         } else {
             let tx_id = self.provider.send_transaction_and_await_commit(tx).await?;
-            self.provider
-                .tx_status(&tx_id)
-                .await?
-                .take_receipts_checked(Some(&self.log_decoder))?
+            self.provider.tx_status(&tx_id).await?
         };
+        let receipts = tx_status.take_receipts_checked(Some(&self.log_decoder))?;
 
         self.get_response(receipts)
     }
 
     /// Call a script on the node, in a state-modifying manner.
     pub async fn call(mut self) -> Result<FuelCallResponse<D>> {
-        self.call_or_simulate(false)
-            .await
-            .map_err(|err| map_revert_error(err, &self.log_decoder))
+        self.call_or_simulate(false).await
     }
 
     pub async fn submit(mut self) -> Result<SubmitResponse<T, D>> {
@@ -280,9 +276,7 @@ where
     ///
     /// [`call`]: Self::call
     pub async fn simulate(&mut self) -> Result<FuelCallResponse<D>> {
-        self.call_or_simulate(true)
-            .await
-            .map_err(|err| map_revert_error(err, &self.log_decoder))
+        self.call_or_simulate(true).await
     }
 
     /// Get a scripts's estimated cost

--- a/packages/fuels/tests/providers.rs
+++ b/packages/fuels/tests/providers.rs
@@ -62,9 +62,9 @@ async fn test_provider_launch_and_connect() -> Result<()> {
     Ok(())
 }
 
+// Ignored until https://github.com/FuelLabs/fuel-core/issues/1384 is resolved
 #[tokio::test]
 #[ignore]
-// Ignored until https://github.com/FuelLabs/fuel-core/issues/1384 is resolved
 async fn test_network_error() -> Result<()> {
     abigen!(Contract(
         name = "MyContract",

--- a/packages/fuels/tests/providers.rs
+++ b/packages/fuels/tests/providers.rs
@@ -63,6 +63,8 @@ async fn test_provider_launch_and_connect() -> Result<()> {
 }
 
 #[tokio::test]
+#[ignore]
+// Ignored until https://github.com/FuelLabs/fuel-core/issues/1384 is resolved
 async fn test_network_error() -> Result<()> {
     abigen!(Contract(
         name = "MyContract",


### PR DESCRIPTION
While working on an other issue, I have seen that we have some duplicated code for revert error mapping. I have refactored the code a bit so that we can remove the `map_revert_error` function and use the logic inside `TxStatus`

### Checklist
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
