### PR TITLE
feat: return `str` from contracts

### DIFF
--- a/packages/fuels-core/src/codec/abi_decoder/bounded_decoder.rs
+++ b/packages/fuels-core/src/codec/abi_decoder/bounded_decoder.rs
@@ -303,10 +303,12 @@ impl BoundedDecoder {
         let selected_variant = variants.param_type_of_variant(discriminant)?;
         let skip_extra = variants
             .heap_type_variant()
-            .is_some_and(|(heap_discriminant, _)| heap_discriminant == discriminant)
-            .then_some(3);
-        let words_to_skip =
-            enum_width - selected_variant.compute_encoding_width() + skip_extra.unwrap_or_default();
+            .and_then(|(heap_discriminant, heap_type)| {
+                (heap_discriminant == discriminant).then_some(heap_type.compute_encoding_width())
+            })
+            .unwrap_or_default();
+
+        let words_to_skip = enum_width - selected_variant.compute_encoding_width() + skip_extra;
         let enum_content_bytes = skip(bytes, words_to_skip * WORD_SIZE)?;
         let result = self.decode_token_in_enum(enum_content_bytes, variants, selected_variant)?;
 

--- a/packages/fuels-core/src/codec/abi_encoder.rs
+++ b/packages/fuels-core/src/codec/abi_encoder.rs
@@ -154,16 +154,17 @@ impl ABIEncoder {
             .collect::<Vec<_>>();
 
         let num_bytes = data.len() * WORD_SIZE;
-
         let len = Self::encode_u64(num_bytes as u64);
+
         Ok(vec![Data::Dynamic(encoded_data), len])
     }
 
     fn encode_string_slice(arg_string: &StaticStringToken) -> Result<Vec<Data>> {
-        let encoded_data = Data::Inline(arg_string.get_encodable_str()?.as_bytes().to_vec());
+        let encodable_str = arg_string.get_encodable_str()?;
 
-        let num_bytes = arg_string.get_encodable_str()?.len();
-        let len = Self::encode_u64(num_bytes as u64);
+        let encoded_data = Data::Inline(encodable_str.as_bytes().to_vec());
+        let len = Self::encode_u64(encodable_str.len() as u64);
+
         Ok(vec![Data::Dynamic(vec![encoded_data]), len])
     }
 

--- a/packages/fuels-core/src/types/param_types.rs
+++ b/packages/fuels-core/src/types/param_types.rs
@@ -151,7 +151,7 @@ impl ParamType {
             ParamType::Tuple(elements) => elements
                 .iter()
                 .any(|param_type| param_type.is_extra_receipt_needed(false)),
-            ParamType::RawSlice => !top_level_type,
+            ParamType::RawSlice | ParamType::StringSlice => !top_level_type,
             _ => false,
         }
     }
@@ -165,6 +165,7 @@ impl ParamType {
             // `Bytes` type is byte-packed in the VM, so it's the size of an u8
             ParamType::Bytes | ParamType::String => Some(std::mem::size_of::<u8>()),
             ParamType::RawSlice if !top_level_type => Some(ParamType::U64.compute_encoding_width()),
+            ParamType::StringSlice if !top_level_type => Some(std::mem::size_of::<u8>()),
             _ => None,
         }
     }

--- a/packages/fuels-programs/src/call_utils.rs
+++ b/packages/fuels-programs/src/call_utils.rs
@@ -361,7 +361,8 @@ fn extract_heap_data(param_type: &ParamType) -> Vec<fuel_asm::Instruction> {
                 return vec![];
             };
 
-            let ptr_offset = (param_type.compute_encoding_width() - 3) as u16;
+            let ptr_offset =
+                (param_type.compute_encoding_width() - heap_type.compute_encoding_width()) as u16;
 
             [
                 vec![
@@ -397,9 +398,10 @@ fn extract_data_receipt(
     };
 
     let len_offset = match (top_level_type, param_type) {
-        // A nested RawSlice shows up as ptr,len
+        // Nested `RawSlice` or `str` show up as ptr, len
         (false, ParamType::RawSlice) => 1,
-        // Every other heap type (currently) shows up as ptr,cap,len
+        (false, ParamType::StringSlice) => 1,
+        // Every other heap type (currently) shows up as ptr, cap, len
         _ => 2,
     };
 

--- a/packages/fuels/Forc.toml
+++ b/packages/fuels/Forc.toml
@@ -67,6 +67,7 @@ members = [
   'tests/types/contracts/results',
   'tests/types/contracts/std_lib_string',
   'tests/types/contracts/str_in_array',
+  'tests/types/contracts/string_slice',
   'tests/types/contracts/tuples',
   'tests/types/contracts/two_structs',
   'tests/types/contracts/type_inside_enum',

--- a/packages/fuels/tests/types/contracts/heap_type_in_enums/src/main.sw
+++ b/packages/fuels/tests/types/contracts/heap_type_in_enums/src/main.sw
@@ -16,9 +16,11 @@ abi MyContract {
     fn returns_bytes_result(return_ok: bool) -> Result<Bytes, TestError>;
     fn returns_vec_result(return_ok: bool) -> Result<Vec<u64>, TestError>;
     fn returns_string_result(return_ok: bool) -> Result<String, TestError>;
+    fn returns_str_result(return_ok: bool) -> Result<str, TestError>;
     fn returns_bytes_option(return_some: bool) -> Option<Bytes>;
     fn returns_vec_option(return_some: bool) -> Option<Vec<u64>>;
     fn returns_string_option(return_some: bool) -> Option<String>;
+    fn returns_str_option(return_some: bool) -> Option<str>;
     fn would_raise_a_memory_overflow() -> Result<Bytes, b256>;
     fn returns_a_heap_type_too_deep() -> Result<Bimbam, u64>;
 }
@@ -60,6 +62,14 @@ impl MyContract for Contract {
         }
     }
 
+    fn returns_str_result(return_ok: bool) -> Result<str, TestError> {
+        return if return_ok {
+            Result::Ok("Hello World")
+        } else {
+            Result::Err(TestError::Else(3333))
+        }
+    }
+
     fn returns_bytes_option(return_some: bool) -> Option<Bytes> {
         return if return_some {
             let mut b = Bytes::new();
@@ -91,6 +101,14 @@ impl MyContract for Contract {
         return if return_some {
             let s = String::from_ascii_str("Hello World");
             Option::Some(s)
+        } else {
+            None
+        }
+    }
+
+    fn returns_str_option(return_some: bool) -> Option<str> {
+        return if return_some {
+            Option::Some("Hello World")
         } else {
             None
         }

--- a/packages/fuels/tests/types/contracts/string_slice/Forc.toml
+++ b/packages/fuels/tests/types/contracts/string_slice/Forc.toml
@@ -1,0 +1,5 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "string_slice"

--- a/packages/fuels/tests/types/contracts/string_slice/src/main.sw
+++ b/packages/fuels/tests/types/contracts/string_slice/src/main.sw
@@ -1,0 +1,11 @@
+contract;
+
+abi RawSliceContract {
+    fn return_str() -> str;
+}
+
+impl RawSliceContract for Contract {
+    fn return_str() -> str {
+        "contract-return"
+    }
+}

--- a/packages/fuels/tests/types_contracts.rs
+++ b/packages/fuels/tests/types_contracts.rs
@@ -1967,6 +1967,31 @@ async fn test_contract_raw_slice() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_contract_returning_string_slice() -> Result<()> {
+    let wallet = launch_provider_and_get_wallet().await;
+    setup_program_test!(
+        Abigen(Contract(
+            name = "StringSliceContract",
+            project = "packages/fuels/tests/types/contracts/string_slice"
+        )),
+        Deploy(
+            name = "contract_instance",
+            contract = "StringSliceContract",
+            wallet = "wallet"
+        ),
+    );
+
+    let contract_methods = contract_instance.methods();
+
+    {
+        let response = contract_methods.return_str().call().await?;
+        assert_eq!(response.value, "contract-return");
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_contract_std_lib_string() -> Result<()> {
     let wallet = launch_provider_and_get_wallet().await;
     setup_program_test!(
@@ -2033,6 +2058,13 @@ async fn test_heap_type_in_enums() -> Result<()> {
     let expected = Err(TestError::Else(3333));
     assert_eq!(resp.value, expected);
 
+    let resp = contract_methods.returns_str_result(true).call().await?;
+    let expected = Ok("Hello World".try_into()?);
+    assert_eq!(resp.value, expected);
+    let resp = contract_methods.returns_string_result(false).call().await?;
+    let expected = Err(TestError::Else(3333));
+    assert_eq!(resp.value, expected);
+
     let resp = contract_methods.returns_bytes_option(true).call().await?;
     let expected = Some(Bytes(vec![1, 1, 1, 1]));
     assert_eq!(resp.value, expected);
@@ -2047,6 +2079,12 @@ async fn test_heap_type_in_enums() -> Result<()> {
 
     let resp = contract_methods.returns_string_option(true).call().await?;
     let expected = Some("Hello World".to_string());
+    assert_eq!(resp.value, expected);
+    let resp = contract_methods.returns_string_option(false).call().await?;
+    assert!(resp.value.is_none());
+
+    let resp = contract_methods.returns_str_option(true).call().await?;
+    let expected = Some("Hello World".try_into()?);
     assert_eq!(resp.value, expected);
     let resp = contract_methods.returns_string_option(false).call().await?;
     assert!(resp.value.is_none());


### PR DESCRIPTION
This PR adds support for `str` returned from contract calls (either directly, or inside `enums`)

Full support will be added once `sway` is ready. Issue to track: https://github.com/FuelLabs/fuels-rs/issues/1158

### Checklist
- [x] I have linked to any relevant issues.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
