### PR TITLE
chore: bump `dasel` and deps versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,10 +119,10 @@ jobs:
       - run: |
           curl -sSLf "$DASEL_VERSION" -L -o dasel && chmod +x dasel
           mv ./dasel /usr/local/bin/dasel
-          MIN_VERSION=$(cat Cargo.toml | dasel -r toml 'workspace.package.rust-version')
+          MIN_VERSION=$(cat Cargo.toml | dasel -r toml 'workspace.package.rust-version' -w plain)
           RUST_VERSION="${{ env.RUST_VERSION }}"
           echo "Comparing minimum supported toolchain ($MIN_VERSION) with ci toolchain (RUST_VERSION)"
-          test "$MIN_VERSION" == "'$RUST_VERSION'"
+          test "$MIN_VERSION" == "$RUST_VERSION"
 
   # Ensure workspace is publishable
   publish-crates-check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
           MIN_VERSION=$(cat Cargo.toml | dasel -r toml 'workspace.package.rust-version')
           RUST_VERSION="${{ env.RUST_VERSION }}"
           echo "Comparing minimum supported toolchain ($MIN_VERSION) with ci toolchain (RUST_VERSION)"
-          test "'$MIN_VERSION'" == "$RUST_VERSION"
+          test "$MIN_VERSION" == "'$RUST_VERSION'"
 
   # Ensure workspace is publishable
   publish-crates-check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
+  DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v2.3.6/dasel_linux_amd64
   RUSTFLAGS: "-D warnings"
   FUEL_CORE_VERSION: 0.20.6
-  RUST_VERSION: 1.73.0
+  RUST_VERSION: 1.72.1
   FORC_VERSION: 0.46.0
   FORC_PATCH_BRANCH: ""
   FORC_PATCH_REVISION: ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ env:
   CARGO_TERM_COLOR: always
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
   RUSTFLAGS: "-D warnings"
-  FUEL_CORE_VERSION: 0.20.4
-  RUST_VERSION: 1.72.0
+  FUEL_CORE_VERSION: 0.20.6
+  RUST_VERSION: 1.73.0
   FORC_VERSION: 0.46.0
   FORC_PATCH_BRANCH: ""
   FORC_PATCH_REVISION: ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
           MIN_VERSION=$(cat Cargo.toml | dasel -r toml 'workspace.package.rust-version')
           RUST_VERSION="${{ env.RUST_VERSION }}"
           echo "Comparing minimum supported toolchain ($MIN_VERSION) with ci toolchain (RUST_VERSION)"
-          test "$MIN_VERSION" == "$RUST_VERSION"
+          test "'$MIN_VERSION'" == "$RUST_VERSION"
 
   # Ensure workspace is publishable
   publish-crates-check:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ homepage = "https://fuel.network/"
 readme = "README.md"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuels-rs"
-rust-version = "1.73.0"
+rust-version = "1.72.1"
 version = "0.48.0"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,9 @@ version = "0.48.0"
 Inflector = "0.11.4"
 async-trait = { version = "0.1.73", default-features = false }
 bech32 = "0.9.1"
-bytes = { version = "1.4.0", default-features = false }
-chrono = "0.4.27"
-elliptic-curve = { version = "0.13.5", default-features = false }
+bytes = { version = "1.5.0", default-features = false }
+chrono = "0.4.31"
+elliptic-curve = { version = "0.13.6", default-features = false }
 eth-keystore = "0.5.0"
 fuel-abi-types = "0.3.0"
 futures = "0.3.28"
@@ -52,38 +52,36 @@ hex = { version = "0.4.3", default-features = false }
 itertools = "0.11.0"
 portpicker = "0.1.1"
 proc-macro2 = "1.0.66"
-quote = "1.0.32"
-rand = { version = "0.8.5", default-features = false, features = [
-  "std_rng",
-  "getrandom",
-] }
-regex = "1.9.3"
-serde = { version = "1.0.183", default-features = false }
-serde_json = "1.0.104"
-serde_with = { version = "3.2.0", default-features = false }
-sha2 = { version = "0.10.7", default-features = false }
-syn = "2.0.28"
+quote = "1.0.33"
+rand = { version = "0.8.5", default-features = false, features = ["std_rng", "getrandom"] }
+regex = "1.10.0"
+serde = { version = "1.0.188", default-features = false }
+serde_json = "1.0.107"
+serde_with = { version = "3.3.0", default-features = false }
+sha2 = { version = "0.10.8", default-features = false }
+syn = "2.0.38"
 tai64 = { version = "4.0.0", default-features = false }
-tempfile = { version = "3.7.1", default-features = false }
-thiserror = { version = "1.0.47", default-features = false }
-tokio = { version = "1.31.0", default-features = false }
-trybuild = "1.0.82"
-which = { version = "4.4.0", default-features = false }
+tempfile = { version = "3.8.0", default-features = false }
+thiserror = { version = "1.0.49", default-features = false }
+tokio = { version = "1.33.0", default-features = false }
+trybuild = "1.0.85"
+uint = { version = "0.9.5", default-features = false }
+which = { version = "4.4.2", default-features = false }
 
 # Dependencies from the `fuel-core` repository:
-fuel-core = { version = "0.20.4", default-features = false }
-fuel-core-chain-config = { version = "0.20.4", default-features = false }
-fuel-core-client = { version = "0.20.4", default-features = false }
-fuel-core-types = { version = "0.20.4", default-features = false }
+fuel-core = { version = "0.20.6", default-features = false }
+fuel-core-chain-config = { version = "0.20.6", default-features = false }
+fuel-core-client = { version = "0.20.6", default-features = false }
+fuel-core-types = { version = "0.20.6", default-features = false }
 
 # Dependencies from the `fuel-vm` repository:
-fuel-asm = "0.35.3"
-fuel-crypto = "0.35.3"
-fuel-merkle = "0.35.3"
-fuel-storage = "0.35.3"
-fuel-tx = "0.35.3"
-fuel-types = { version = "0.35.3", default-features = false }
-fuel-vm = "0.35.3"
+fuel-asm = "0.35.4"
+fuel-crypto = "0.35.4"
+fuel-merkle = "0.35.4"
+fuel-storage = "0.35.4"
+fuel-tx = "0.35.4"
+fuel-types = { version = "0.35.4", default-features = false }
+fuel-vm = "0.35.4"
 
 # Workspace projects
 fuels = { version = "0.48.0", path = "./packages/fuels" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ homepage = "https://fuel.network/"
 readme = "README.md"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuels-rs"
-rust-version = "1.72.0"
+rust-version = "1.73.0"
 version = "0.48.0"
 
 [workspace.dependencies]

--- a/packages/fuels-code-gen/src/program_bindings/utils.rs
+++ b/packages/fuels-code-gen/src/program_bindings/utils.rs
@@ -66,57 +66,6 @@ pub(crate) fn single_param_type_call(field_type: &ResolvedType) -> TokenStream {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use fuel_abi_types::abi::full_program::FullTypeDeclaration;
-
-    use super::*;
-
-    #[test]
-    fn respects_snake_case_flag() -> Result<()> {
-        let type_application = type_application_named("WasNotSnakeCased");
-
-        let sut = Component::new(&type_application, true, TypePath::default())?;
-
-        assert_eq!(sut.field_name, "was_not_snake_cased");
-
-        Ok(())
-    }
-
-    #[test]
-    fn avoids_collisions_with_reserved_keywords() -> Result<()> {
-        {
-            let type_application = type_application_named("if");
-
-            let sut = Component::new(&type_application, false, TypePath::default())?;
-
-            assert_eq!(sut.field_name, "if_");
-        }
-
-        {
-            let type_application = type_application_named("let");
-
-            let sut = Component::new(&type_application, false, TypePath::default())?;
-
-            assert_eq!(sut.field_name, "let_");
-        }
-
-        Ok(())
-    }
-
-    fn type_application_named(name: &str) -> FullTypeApplication {
-        FullTypeApplication {
-            name: name.to_string(),
-            type_decl: FullTypeDeclaration {
-                type_field: "u64".to_string(),
-                components: vec![],
-                type_parameters: vec![],
-            },
-            type_arguments: vec![],
-        }
-    }
-}
-
 pub(crate) fn sdk_provided_custom_types_lookup() -> HashMap<TypePath, TypePath> {
     [
         ("std::address::Address", "::fuels::types::Address"),
@@ -165,5 +114,56 @@ pub(crate) fn get_equivalent_bech32_type(ttype: &str) -> Option<TokenStream> {
             Some(quote! {::fuels::types::bech32::Bech32ContractId})
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fuel_abi_types::abi::full_program::FullTypeDeclaration;
+
+    use super::*;
+
+    #[test]
+    fn respects_snake_case_flag() -> Result<()> {
+        let type_application = type_application_named("WasNotSnakeCased");
+
+        let sut = Component::new(&type_application, true, TypePath::default())?;
+
+        assert_eq!(sut.field_name, "was_not_snake_cased");
+
+        Ok(())
+    }
+
+    #[test]
+    fn avoids_collisions_with_reserved_keywords() -> Result<()> {
+        {
+            let type_application = type_application_named("if");
+
+            let sut = Component::new(&type_application, false, TypePath::default())?;
+
+            assert_eq!(sut.field_name, "if_");
+        }
+
+        {
+            let type_application = type_application_named("let");
+
+            let sut = Component::new(&type_application, false, TypePath::default())?;
+
+            assert_eq!(sut.field_name, "let_");
+        }
+
+        Ok(())
+    }
+
+    fn type_application_named(name: &str) -> FullTypeApplication {
+        FullTypeApplication {
+            name: name.to_string(),
+            type_decl: FullTypeDeclaration {
+                type_field: "u64".to_string(),
+                components: vec![],
+                type_parameters: vec![],
+            },
+            type_arguments: vec![],
+        }
     }
 }

--- a/packages/fuels-core/Cargo.toml
+++ b/packages/fuels-core/Cargo.toml
@@ -27,7 +27,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, default-features = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true, default-features = false }
-uint = { version = "0.9.5", default-features = false }
+uint = { workspace = true, default-features = false }
 
 [dev-dependencies]
 fuels-macros = { workspace = true }

--- a/packages/wasm-tests/Cargo.toml
+++ b/packages/wasm-tests/Cargo.toml
@@ -18,5 +18,5 @@ crate-type = ['cdylib']
 # that our examples don't inherit `fuels` with disabled features).
 # Cargo wouldn't respect any attempts here to disable them again.
 fuels = { path = "../fuels", default-features = false }
-getrandom = { version = "0.2", features = ["js"] }
-wasm-bindgen-test = "0.3.34"
+getrandom = { version = "0.2.10", features = ["js"] }
+wasm-bindgen-test = "0.3.37"

--- a/scripts/check-docs/Cargo.toml
+++ b/scripts/check-docs/Cargo.toml
@@ -5,6 +5,6 @@ edition = { workspace = true }
 publish = false
 
 [dependencies]
-anyhow = "1.0.62"
-itertools = "0.10.3"
-regex = "1.6.0"
+anyhow = "1.0.75"
+itertools = { workspace = true }
+regex = { workspace = true }

--- a/scripts/versions-replacer/Cargo.toml
+++ b/scripts/versions-replacer/Cargo.toml
@@ -12,9 +12,9 @@ version.workspace = true
 
 [dependencies]
 argh = "0.1.12"
-cargo_metadata = "0.17.0"
+cargo_metadata = "0.18.0"
 color-eyre = "0.6.2"
 once_cell = "1.18.0"
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-walkdir = "2.3.3"
+walkdir = "2.4.0"


### PR DESCRIPTION
Bump `dasel` and dependencies versions. Fixed a `clippy` nightly warning that we should not have functions after a test mod.

### Checklist
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
