### PR TITLE
fix: broken docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ See [the `fuels-rs` book](https://fuellabs.github.io/fuels-rs/latest/)
 
 ### What dependencies do I need?
 
-- [The latest `stable` Rust toolchain](https://fuellabs.github.io/sway/master/book/introduction/installation.html);
-- [`forc` and `fuel-core` binaries](https://fuellabs.github.io/sway/master/book/introduction/installation.html#installing-from-cargo).
+- [The latest `stable` Rust toolchain](https://docs.fuel.network/guides/installation/#installing-rust);
+- [`forc` and `fuel-core` binaries](https://docs.fuel.network/guides/installation/#installing-the-fuel-toolchain-using-fuelup).
 
 ### How can I run the SDK tests?
 

--- a/docs/src/abigen/the-json-abi-file.md
+++ b/docs/src/abigen/the-json-abi-file.md
@@ -2,7 +2,7 @@
 
 <!-- This section should talk about the importance of the ABI -->
 <!-- abi:example:start -->
-Whether you want to deploy or connect to a pre-existing smart contract, the JSON ABI file is extremely important: it's what tells the SDK about the [ABI methods](https://fuellabs.github.io/sway/master/book/introduction/sway_quickstart.html#abi) in your smart contracts.
+Whether you want to deploy or connect to a pre-existing smart contract, the JSON ABI file is extremely important: it's what tells the SDK about the [ABI methods](https://docs.fuel.network/guides/quickstart/building-a-smart-contract/#abi) in your smart contracts.
 <!-- abi:example:end -->
 
 For the same example Sway code as above:

--- a/docs/src/deploying/index.md
+++ b/docs/src/deploying/index.md
@@ -8,7 +8,7 @@ There are two main ways of working with contracts in the SDK: deploying a contra
 <!-- build:example:start -->
 Once you've written a contract in Sway and compiled it with `forc build`, you'll have in your hands two important artifacts: the compiled binary file and the JSON ABI file.
 <!-- build:example:end -->
-> Note: Read [here](https://fuellabs.github.io/sway/master/book/introduction/sway_quickstart.html) for more on how to work with Sway.
+> Note: Read [here](https://docs.fuel.network/guides/quickstart/) for more on how to work with Sway.
 
 Below is how you can deploy your contracts using the SDK. For more details about each component in this process, read [The abigen macro](../abigen/the-abigen-macro.md), [The FuelVM binary file](./the-fuelvm-binary-file.md), and [The JSON ABI file](../abigen/the-json-abi-file.md).
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -6,7 +6,7 @@
 <!-- rs_dependencies:example:start -->
 The dependencies for using the Fuel Rust SDK are:
 
-- [The latest `stable` Rust toolchain](https://fuellabs.github.io/sway/master/book/introduction/installation.html);
+- [The latest `stable` Rust toolchain](https://docs.fuel.network/guides/installation/);
 - [`forc` and `fuel-core` binaries](https://fuellabs.github.io/sway/master/book/introduction/installation.html#installing-from-cargo).
 <!-- rs_dependencies:example:end -->
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -6,8 +6,8 @@
 <!-- rs_dependencies:example:start -->
 The dependencies for using the Fuel Rust SDK are:
 
-- [The latest `stable` Rust toolchain](https://docs.fuel.network/guides/installation/);
-- [`forc` and `fuel-core` binaries](https://fuellabs.github.io/sway/master/book/introduction/installation.html#installing-from-cargo).
+-- [The latest `stable` Rust toolchain](https://docs.fuel.network/guides/installation/#installing-rust);
+-- [`forc` and `fuel-core` binaries](https://docs.fuel.network/guides/installation/#installing-the-fuel-toolchain-using-fuelup).
 <!-- rs_dependencies:example:end -->
 
 `forc` is Sway equivalent of Rust's `cargo`. `fuel-core` is a Fuel full node implementation.


### PR DESCRIPTION
CI  is failing because of broken links.

cc @cold-briu 

### Checklist
- [x] I have updated the documentation.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
