### PR TITLE
feat: use `String` directly in `assert_eq`

### DIFF
--- a/packages/fuels/tests/types/contracts/std_lib_string/src/main.sw
+++ b/packages/fuels/tests/types/contracts/std_lib_string/src/main.sw
@@ -9,16 +9,12 @@ abi MyContract {
     fn accepts_dynamic_string(s: String);
 }
 
-fn validate_string(string: String) {
-    assert_eq(string, String::from_ascii_str("Hello World"));
-}
-
 impl MyContract for Contract {
     fn return_dynamic_string() -> String {
         String::from_ascii_str("Hello World")
     }
 
     fn accepts_dynamic_string(string: String) {
-        validate_string(string);
+        assert_eq(string, String::from_ascii_str("Hello World"));
     }
 }

--- a/packages/fuels/tests/types/contracts/std_lib_string/src/main.sw
+++ b/packages/fuels/tests/types/contracts/std_lib_string/src/main.sw
@@ -9,21 +9,8 @@ abi MyContract {
     fn accepts_dynamic_string(s: String);
 }
 
-fn validate_string(arg: String) {
-    // to be replaced with a simpler assert_eq once
-    // https://github.com/FuelLabs/sway/issues/4868 is done
-    let bytes = arg.as_bytes();
-
-    let inner = String::from_ascii_str("Hello World");
-    let expected_bytes = inner.as_bytes();
-
-    assert_eq(expected_bytes.len(), bytes.len());
-
-    let mut i = 0;
-    while i < bytes.len() {
-        assert(expected_bytes.get(i).unwrap() == bytes.get(i).unwrap());
-        i += 1;
-    }
+fn validate_string(string: String) {
+    assert_eq(string, String::from_ascii_str("Hello World"));
 }
 
 impl MyContract for Contract {
@@ -31,7 +18,7 @@ impl MyContract for Contract {
         String::from_ascii_str("Hello World")
     }
 
-    fn accepts_dynamic_string(s: String) {
-        validate_string(s);
+    fn accepts_dynamic_string(string: String) {
+        validate_string(string);
     }
 }

--- a/packages/fuels/tests/types/predicates/predicate_std_lib_string/src/main.sw
+++ b/packages/fuels/tests/types/predicates/predicate_std_lib_string/src/main.sw
@@ -2,10 +2,6 @@ predicate;
 
 use std::string::String;
 
-fn validate_string(string: String) -> bool {
-    string == String::from_ascii_str("Hello World")
-}
-
 fn main(_arg_0: u64, _arg_1: u64, string: String) -> bool {
-    validate_string(string)
+    string == String::from_ascii_str("Hello World")
 }

--- a/packages/fuels/tests/types/predicates/predicate_std_lib_string/src/main.sw
+++ b/packages/fuels/tests/types/predicates/predicate_std_lib_string/src/main.sw
@@ -2,29 +2,10 @@ predicate;
 
 use std::string::String;
 
-fn validate_string(arg: String) -> bool {
-    // to be replaced with a simpler assert_eq once
-    // https://github.com/FuelLabs/sway/issues/4868 is done
-    let bytes = arg.as_bytes();
-
-    let inner = String::from_ascii_str("Hello World");
-    let expected_bytes = inner.as_bytes();
-
-    if expected_bytes.len() != bytes.len() {
-        return false;
-    }
-
-    let mut i = 0;
-    while i < bytes.len() {
-        if expected_bytes.get(i).unwrap() != bytes.get(i).unwrap() {
-            return false;
-        }
-        i += 1;
-    }
-
-    true
+fn validate_string(string: String) -> bool {
+    string == String::from_ascii_str("Hello World")
 }
 
-fn main(_arg_0: u64, _arg_1: u64, arg_2: String) -> bool {
-    validate_string(arg_2)
+fn main(_arg_0: u64, _arg_1: u64, string: String) -> bool {
+    validate_string(string)
 }

--- a/packages/fuels/tests/types/scripts/script_std_lib_string/src/main.sw
+++ b/packages/fuels/tests/types/scripts/script_std_lib_string/src/main.sw
@@ -2,23 +2,6 @@ script;
 
 use std::string::String;
 
-fn validate_string(arg: String) {
-    // to be replaced with a simpler assert_eq once
-    // https://github.com/FuelLabs/sway/issues/4868 is done
-    let bytes = arg.as_bytes();
-
-    let inner = String::from_ascii_str("Hello World");
-    let expected_bytes = inner.as_bytes();
-
-    assert_eq(expected_bytes.len(), bytes.len());
-
-    let mut i = 0;
-    while i < bytes.len() {
-        assert(expected_bytes.get(i).unwrap() == bytes.get(i).unwrap());
-        i += 1;
-    }
-}
-
-fn main(arg: String) {
-    validate_string(arg);
+fn main(string: String) {
+    assert_eq(string, String::from_ascii_str("Hello World"));
 }


### PR DESCRIPTION
closes: https://github.com/FuelLabs/fuels-rs/issues/1064

`Sway` has got a new `Eq` implementation for `String` so we can use it it directly. https://github.com/FuelLabs/sway/pull/5055

### Checklist
- [x] I have linked to any relevant issues.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
