### PR TITLE
fix: encode contract arguments with `gas_forwarded`

### DIFF
--- a/packages/fuels-programs/src/call_utils.rs
+++ b/packages/fuels-programs/src/call_utils.rs
@@ -228,9 +228,9 @@ pub(crate) fn get_instructions(
 /// Returns script data, consisting of the following items in the given order:
 /// 1. Amount to be forwarded `(1 * `[`WORD_SIZE`]`)`
 /// 2. Asset ID to be forwarded ([`AssetId::LEN`])
-/// 3. Contract ID ([`ContractId::LEN`]);
-/// 4. Function selector `(1 * `[`WORD_SIZE`]`)`
-/// 5. Gas to be forwarded `(1 * `[`WORD_SIZE`]`)`
+/// 3. Gas to be forwarded `(1 * `[`WORD_SIZE`]`)` - Optional
+/// 4. Contract ID ([`ContractId::LEN`]);
+/// 5. Function selector `(1 * `[`WORD_SIZE`]`)`
 /// 6. Calldata offset (optional) `(1 * `[`WORD_SIZE`]`)`
 /// 7. Encoded arguments (optional) (variable length)
 pub(crate) fn build_script_data_from_contract_calls(
@@ -246,27 +246,27 @@ pub(crate) fn build_script_data_from_contract_calls(
     for call in calls {
         let gas_forwarded = call.call_parameters.gas_forwarded();
 
-        let call_param_offsets = CallOpcodeParamsOffset {
-            amount_offset: segment_offset,
-            asset_id_offset: segment_offset + WORD_SIZE,
-            call_data_offset: segment_offset + WORD_SIZE + AssetId::LEN,
-            gas_forwarded_offset: gas_forwarded
-                .map(|_| segment_offset + WORD_SIZE + AssetId::LEN + ContractId::LEN + WORD_SIZE),
-        };
-        param_offsets.push(call_param_offsets);
-
         script_data.extend(call.call_parameters.amount().to_be_bytes());
         script_data.extend(call.call_parameters.asset_id().iter());
-        script_data.extend(call.contract_id.hash().as_ref());
-        script_data.extend(call.encoded_selector);
 
         let gas_forwarded_size = gas_forwarded
             .map(|gf| {
-                script_data.extend(gf.to_be_bytes());
+                script_data.extend((gf as Word).to_be_bytes());
 
                 WORD_SIZE
             })
             .unwrap_or_default();
+
+        script_data.extend(call.contract_id.hash().as_ref());
+        script_data.extend(call.encoded_selector);
+
+        let call_param_offsets = CallOpcodeParamsOffset {
+            amount_offset: segment_offset,
+            asset_id_offset: segment_offset + WORD_SIZE,
+            gas_forwarded_offset: gas_forwarded.map(|_| segment_offset + WORD_SIZE + AssetId::LEN),
+            call_data_offset: segment_offset + WORD_SIZE + AssetId::LEN + gas_forwarded_size,
+        };
+        param_offsets.push(call_param_offsets);
 
         // If the method call takes custom inputs or has more than
         // one argument, we need to calculate the `call_data_offset`,
@@ -278,9 +278,9 @@ pub(crate) fn build_script_data_from_contract_calls(
             let custom_input_offset = segment_offset
                 + WORD_SIZE // amount size
                 + AssetId::LEN
+                + gas_forwarded_size
                 + ContractId::LEN
                 + WORD_SIZE // encoded_selector size
-                + gas_forwarded_size
                 + WORD_SIZE; // custom_input_offset size
             script_data.extend((custom_input_offset as Word).to_be_bytes());
 
@@ -289,7 +289,7 @@ pub(crate) fn build_script_data_from_contract_calls(
             segment_offset
         };
 
-        let bytes = call.encoded_args.resolve(encoded_args_start_offset as u64);
+        let bytes = call.encoded_args.resolve(encoded_args_start_offset as Word);
         script_data.extend(bytes);
 
         // the data segment that holds the parameters for the next call
@@ -609,7 +609,6 @@ mod test {
     async fn test_script_data() {
         // Arrange
         const SELECTOR_LEN: usize = WORD_SIZE;
-        const GAS_FORWARDED_SIZE: usize = WORD_SIZE;
         const NUM_CALLS: usize = 3;
 
         let contract_ids = vec![
@@ -678,19 +677,16 @@ mod test {
         }
 
         // Calls 1 and 3 have their input arguments after the selector
-        let call_1_arg_offset =
-            param_offsets[0].call_data_offset + ContractId::LEN + SELECTOR_LEN + GAS_FORWARDED_SIZE;
+        let call_1_arg_offset = param_offsets[0].call_data_offset + ContractId::LEN + SELECTOR_LEN;
         let call_1_arg = script_data[call_1_arg_offset..call_1_arg_offset + WORD_SIZE].to_vec();
         assert_eq!(call_1_arg, args[0].resolve(0));
 
-        let call_3_arg_offset =
-            param_offsets[2].call_data_offset + ContractId::LEN + SELECTOR_LEN + GAS_FORWARDED_SIZE;
+        let call_3_arg_offset = param_offsets[2].call_data_offset + ContractId::LEN + SELECTOR_LEN;
         let call_3_arg = script_data[call_3_arg_offset..call_3_arg_offset + WORD_SIZE].to_vec();
         assert_eq!(call_3_arg, args[2].resolve(0));
 
         // Call 2 has custom inputs and custom_input_offset
-        let call_2_arg_offset =
-            param_offsets[1].call_data_offset + ContractId::LEN + SELECTOR_LEN + GAS_FORWARDED_SIZE;
+        let call_2_arg_offset = param_offsets[1].call_data_offset + ContractId::LEN + SELECTOR_LEN;
         let custom_input_offset =
             script_data[call_2_arg_offset..call_2_arg_offset + WORD_SIZE].to_vec();
         assert_eq!(
@@ -698,11 +694,8 @@ mod test {
             (call_2_arg_offset + WORD_SIZE).to_be_bytes()
         );
 
-        let custom_input_offset = param_offsets[1].call_data_offset
-            + ContractId::LEN
-            + SELECTOR_LEN
-            + GAS_FORWARDED_SIZE
-            + WORD_SIZE;
+        let custom_input_offset =
+            param_offsets[1].call_data_offset + ContractId::LEN + SELECTOR_LEN + WORD_SIZE;
         let custom_input =
             script_data[custom_input_offset..custom_input_offset + WORD_SIZE].to_vec();
         assert_eq!(custom_input, args[1].resolve(0));


### PR DESCRIPTION
In [1122](https://github.com/FuelLabs/fuels-rs/pull/1122) I introduced a bug where contract arguments are not put at the right location in the script data. We did not catch this because we did not have a test that has arguments and uses `gas_forwarded`. I have fixed the issue and added a test to cover this use-case.

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
