### PR TITLE
Revert "fix(ci): ignore testnet_hello_world test"

### DIFF
--- a/packages/fuels/tests/providers.rs
+++ b/packages/fuels/tests/providers.rs
@@ -619,7 +619,6 @@ async fn test_get_gas_used() -> Result<()> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn testnet_hello_world() -> Result<()> {
     // Note that this test might become flaky.
     // This test depends on:


### PR DESCRIPTION
Reverts FuelLabs/fuels-rs#1143. Closes #1144.