### PR TITLE
Move health check after error collection

### DIFF
--- a/packages/fuels-test-helpers/src/fuel_bin_service.rs
+++ b/packages/fuels-test-helpers/src/fuel_bin_service.rs
@@ -136,7 +136,9 @@ impl FuelService {
             config_file: NamedTempFile::new()?,
         };
 
+        let addr = extended_config.config.addr;
         let handle = run_node(extended_config).await?;
+        server_health_check(addr).await?;
 
         Ok(FuelService {
             bound_address,
@@ -150,7 +152,9 @@ impl FuelService {
     }
 }
 
-async fn server_health_check(client: &FuelClient) -> FuelResult<()> {
+async fn server_health_check(address: SocketAddr) -> FuelResult<()> {
+    let client = FuelClient::from(address);
+
     let mut attempts = 5;
     let mut healthy = client.health().await.unwrap_or(false);
     let between_attempts = Duration::from_millis(300);
@@ -204,10 +208,6 @@ async fn run_node(mut extended_config: ExtendedConfig) -> FuelResult<JoinHandle<
 
     let mut command = Command::new(path);
     let running_node = command.args(args).kill_on_drop(true).output();
-
-    let address = extended_config.config.addr;
-    let client = FuelClient::from(address);
-    server_health_check(&client).await?;
 
     let join_handle = spawn(async move {
         let result = running_node

--- a/packages/fuels-test-helpers/src/fuel_bin_service.rs
+++ b/packages/fuels-test-helpers/src/fuel_bin_service.rs
@@ -210,6 +210,8 @@ async fn run_node(mut extended_config: ExtendedConfig) -> FuelResult<JoinHandle<
     let running_node = command.args(args).kill_on_drop(true).output();
 
     let join_handle = spawn(async move {
+        // ensure drop is not called on the tmp file and it lives throughout the lifetime of the node
+        let _unused = extended_config;
         let result = running_node
             .await
             .expect("error: Couldn't find fuel-core in PATH.");


### PR DESCRIPTION
#1132

Moves the server health check to take place after the thread for collecting command output is spawned.

It seems like the the previous spot at which we did the health check was hiding a bug. The `NamedTmpFile` get's dropped with no guarantee that it was read during node startup. The health check bought just enough time for it it to succeed. It

Thanks to @segfault-magnet for explaining what the cause was and suggesting a quick fix.

### Checklist
- [x] I have linked to any relevant issues.
- [ ] I have updated the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
