### PR TITLE
feat: generate full predicate abigen code in wasm

### DIFF
--- a/packages/fuels-code-gen/src/program_bindings/abigen/bindings/predicate.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/bindings/predicate.rs
@@ -19,10 +19,6 @@ pub(crate) fn predicate_bindings(
     abi: FullProgramABI,
     no_std: bool,
 ) -> Result<GeneratedCode> {
-    if no_std {
-        return Ok(GeneratedCode::default());
-    }
-
     let encode_function = expand_fn(&abi)?;
     let encoder_struct_name = ident(&format!("{name}Encoder"));
 


### PR DESCRIPTION
As the `Predicates` code is wasm compatible ([1667](https://github.com/FuelLabs/fuels-rs/pull/1167)), we can also expose the structs for encoding and configurables from abigen.

- I have updated the predicate wasm test to include the abigen code.

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
