### PR TITLE
fix: fix ci about replacing all references to {{versions.<package>}}

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           mdbook-version: "0.4.15"
 
+      - run: cargo run --package versions-replacer -- ./docs --manifest-path ./Cargo.toml --filename-regex "\.md$"
       - run: mdbook build docs
 
       - name: Deploy master


### PR DESCRIPTION
At present, references to {{versions.<package>}} in docs/*.md aren't replaced by specific value. For example:
1. https://rust.fuel.network/v0.50.1/types/bytes32.html#:~:text=fuel%2Dtypes%20documentation
2. https://rust.fuel.network/v0.50.1/getting-started.html#:~:text=fuels%20%3D%20%22%7B%7Bversions.fuels%7D%7D%22
