### PR TITLE
feat!: improve transaction builders wrt `TxPolicies`

### DIFF
--- a/docs/src/calling-contracts/tx-policies.md
+++ b/docs/src/calling-contracts/tx-policies.md
@@ -18,11 +18,7 @@ Where:
 
 When the **Script Gas Limit** is not set, the Rust SDK will estimate the consumed gas in the background and set it as the limit. Similarly, if no **Gas Price** is defined, the Rust SDK defaults to the network's minimum gas price.
 
-**Witness Limit** makes use of the following default values for script and create transactions:
-
-```rust,ignore
-{{#include ../../../packages/fuels-core/src/utils/constants.rs:witness_default}}
-```
+If the **Witness Limit** is not set, the SDK will set it to the size of all witnesses and signatures defined in the transaction builder.
 
 You can configure these parameters by creating an instance of `TxPolicies` and passing it to a chain method called `with_tx_policies`:
 <!-- tx_policies:example:end-->

--- a/packages/fuels-accounts/src/account.rs
+++ b/packages/fuels-accounts/src/account.rs
@@ -444,7 +444,7 @@ mod tests {
         assert_eq!(signature, tx_signature);
 
         // Check if the signature is what we expect it to be
-        assert_eq!(signature, Signature::from_str("ffd15da2db6668e95e3056c5526aaa37f582e2e5e55927879bf896e813d7f57f14398297ada9205847d16a8e3bcc299a372c9a69c4cf91c4ce2c3804dc900e96")?);
+        assert_eq!(signature, Signature::from_str("a7446cb9703d3bc9e68677715fc7ef6ed72ff4eeac0c67bdb0d9b9c8ba38048e078e38fdd85bf988cefd3737005f1be97ed8b9662f002b0480d4404ebb397fed")?);
 
         // Recover the address that signed the transaction
         let recovered_address = signature.recover(&message)?;

--- a/packages/fuels-core/src/types/transaction_builders.rs
+++ b/packages/fuels-core/src/types/transaction_builders.rs
@@ -248,11 +248,11 @@ macro_rules! impl_tx_trait {
             }
 
             fn calculate_witnesses_size(&self) -> Option<u64> {
-                let witnesse_size = calculate_witnesses_size(&self.witnesses);
+                let witnesses_size = calculate_witnesses_size(&self.witnesses);
                 let signature_size =
                     SIGNATURE_WITNESS_SIZE * self.unresolved_signatures.secret_keys.len();
 
-                Some(padded_len_usize(witnesse_size + signature_size) as u64)
+                Some(padded_len_usize(witnesses_size + signature_size) as u64)
             }
         }
     };

--- a/packages/fuels-core/src/types/transaction_builders.rs
+++ b/packages/fuels-core/src/types/transaction_builders.rs
@@ -380,9 +380,12 @@ impl ScriptTransactionBuilder {
             .dry_run_and_get_used_gas(tx.clone().into(), tolerance)
             .await?;
 
-        // Remove dry_run input
+        // Remove dry-run input. We do not need to remove the witnesses
+        // as we are using temporary values that will be overwritten.
+        // However, we need to readjust the `witness_limit`.
         if no_input_for_fee {
             tx.inputs_mut().pop();
+            tx.set_witness_limit(tx.witness_limit() - WITNESS_STATIC_SIZE as u64);
         }
 
         Ok(gas_used)

--- a/packages/fuels-core/src/types/transaction_builders.rs
+++ b/packages/fuels-core/src/types/transaction_builders.rs
@@ -1,12 +1,12 @@
 #![cfg(feature = "std")]
 
-use std::{cmp::max, collections::HashMap, iter::repeat_with};
+use std::{collections::HashMap, iter::repeat_with};
 
 use async_trait::async_trait;
 use fuel_asm::{op, GTFArgs, RegId};
 use fuel_crypto::{Message as CryptoMessage, SecretKey, Signature};
 use fuel_tx::{
-    field::{Inputs, Witnesses},
+    field::{Inputs, WitnessLimit, Witnesses},
     policies::{Policies, PolicyType},
     Buildable, Chargeable, ConsensusParameters, Create, Input as FuelInput, Output, Script,
     StorageSlot, Transaction as FuelTransaction, TransactionFee, TxPointer, UniqueIdentifier,
@@ -16,9 +16,7 @@ use fuel_types::{bytes::padded_len_usize, canonical::Serialize, Bytes32, ChainId
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{
-    constants::{
-        BASE_ASSET_ID, DEFAULT_CREATE_WITNESS_LIMIT, DEFAULT_SCRIPT_WITNESS_LIMIT, WORD_SIZE,
-    },
+    constants::{BASE_ASSET_ID, SIGNATURE_WITNESS_SIZE, WITNESS_STATIC_SIZE, WORD_SIZE},
     offsets,
     types::{
         bech32::Bech32Address,
@@ -35,6 +33,7 @@ use crate::{
         unresolved_bytes::UnresolvedBytes,
         Address, AssetId, ContractId,
     },
+    utils::calculate_witnesses_size,
 };
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -115,8 +114,6 @@ pub trait TransactionBuilder: BuildableTransaction + Send + Clone {
     fn add_unresolved_signature(&mut self, owner: Bech32Address, secret_key: SecretKey);
     async fn fee_checked_from_tx(&self, provider: impl DryRunner)
         -> Result<Option<TransactionFee>>;
-    fn with_maturity(self, maturity: u32) -> Self;
-    fn with_gas_price(self, gas_price: u64) -> Self;
     fn with_tx_policies(self, tx_policies: TxPolicies) -> Self;
     fn with_inputs(self, inputs: Vec<Input>) -> Self;
     fn with_outputs(self, outputs: Vec<Output>) -> Self;
@@ -159,16 +156,6 @@ macro_rules! impl_tx_trait {
                     &self.consensus_parameters().fee_params,
                     &tx.tx,
                 ))
-            }
-
-            fn with_maturity(mut self, maturity: u32) -> Self {
-                self.maturity = maturity.into();
-                self
-            }
-
-            fn with_gas_price(mut self, gas_price: u64) -> Self {
-                self.gas_price = Some(gas_price);
-                self
             }
 
             fn with_tx_policies(self, tx_policies: TxPolicies) -> Self {
@@ -220,15 +207,22 @@ macro_rules! impl_tx_trait {
         }
 
         impl $ty {
-            fn generate_shared_fuel_policies(&self) -> Policies {
+            fn generate_fuel_policies(&self) -> Policies {
                 let mut policies = Policies::default();
+                policies.set(PolicyType::MaxFee, self.tx_policies.max_fee());
+                policies.set(PolicyType::Maturity, self.tx_policies.maturity());
 
-                policies.set(PolicyType::MaxFee, self.max_fee);
-                policies.set(PolicyType::Maturity, Some(self.maturity as u64));
+                let witness_limit = self
+                    .tx_policies
+                    .witness_limit()
+                    .or_else(|| self.calculate_witnesses_size());
+                policies.set(PolicyType::WitnessLimit, witness_limit);
 
                 policies.set(
                     PolicyType::GasPrice,
-                    self.gas_price.or(Some(self.network_info.min_gas_price)),
+                    self.tx_policies
+                        .gas_price()
+                        .or(Some(self.network_info.min_gas_price)),
                 );
 
                 policies
@@ -252,22 +246,26 @@ macro_rules! impl_tx_trait {
 
                 Ok(num_witnesses as u8)
             }
+
+            fn calculate_witnesses_size(&self) -> Option<u64> {
+                let witnesse_size = calculate_witnesses_size(&self.witnesses);
+                let signature_size =
+                    SIGNATURE_WITNESS_SIZE * self.unresolved_signatures.secret_keys.len();
+
+                Some(padded_len_usize(witnesse_size + signature_size) as u64)
+            }
         }
     };
 }
 
 #[derive(Debug, Clone)]
 pub struct ScriptTransactionBuilder {
-    pub gas_price: Option<u64>,
-    pub gas_limit: Option<u64>,
-    pub witness_limit: Option<u64>,
-    pub max_fee: Option<u64>,
-    pub maturity: u32,
     pub script: Vec<u8>,
     pub script_data: Vec<u8>,
     pub inputs: Vec<Input>,
     pub outputs: Vec<Output>,
     pub witnesses: Vec<Witness>,
+    pub tx_policies: TxPolicies,
     pub gas_estimation_tolerance: f32,
     pub(crate) network_info: NetworkInfo,
     unresolved_signatures: UnresolvedSignatures,
@@ -275,16 +273,13 @@ pub struct ScriptTransactionBuilder {
 
 #[derive(Debug, Clone)]
 pub struct CreateTransactionBuilder {
-    pub gas_price: Option<u64>,
-    pub maturity: u32,
-    pub witness_limit: Option<u64>,
-    pub max_fee: Option<u64>,
     pub bytecode_length: u64,
     pub bytecode_witness_index: u8,
     pub storage_slots: Vec<StorageSlot>,
     pub inputs: Vec<Input>,
     pub outputs: Vec<Output>,
     pub witnesses: Vec<Witness>,
+    pub tx_policies: TxPolicies,
     pub salt: Salt,
     pub(crate) network_info: NetworkInfo,
     unresolved_signatures: UnresolvedSignatures,
@@ -296,16 +291,12 @@ impl_tx_trait!(CreateTransactionBuilder, CreateTransaction);
 impl ScriptTransactionBuilder {
     pub fn new(network_info: NetworkInfo) -> ScriptTransactionBuilder {
         ScriptTransactionBuilder {
-            gas_price: None,
-            gas_limit: None,
-            witness_limit: None,
-            max_fee: None,
-            maturity: 0,
             script: vec![],
             script_data: vec![],
             inputs: vec![],
             outputs: vec![],
             witnesses: vec![],
+            tx_policies: TxPolicies::default(),
             network_info,
             gas_estimation_tolerance: 0.05,
             unresolved_signatures: Default::default(),
@@ -337,48 +328,64 @@ impl ScriptTransactionBuilder {
     fn create_dry_run_witnesses(&self, num_witnesses: u8) -> Vec<Witness> {
         let unresolved_witnesses_len = self.unresolved_signatures.addr_idx_offset_map.len();
         repeat_with(Default::default)
-            // Add one in case there is no witnesses at all
-            .take(max(num_witnesses as usize + unresolved_witnesses_len, 1))
+            .take(num_witnesses as usize + unresolved_witnesses_len)
             .collect()
     }
 
-    // When the `script_gas_limit` was not set by the user, `dry_run` the tx
-    // and set the `script_gas_limit` to the actual `gas_used`
-    async fn set_script_gas_limit_to_gas_used(
+    fn no_input_to_pay_for_fee<'a, I: IntoIterator<Item = &'a FuelInput>>(inputs: I) -> bool {
+        !inputs.into_iter().any(|i| {
+            matches!(
+                i,
+                FuelInput::CoinSigned(_)
+                    | FuelInput::CoinPredicate(_)
+                    | FuelInput::MessageCoinSigned(_)
+                    | FuelInput::MessageCoinPredicate(_)
+            )
+        })
+    }
+
+    async fn gas_used(
         tx: &mut Script,
         provider: &impl DryRunner,
         network_info: &NetworkInfo,
         tolerance: f32,
-    ) -> Result<()> {
+    ) -> Result<u64> {
         let consensus_params = &network_info.consensus_parameters;
-        // Add `1` because of rounding
-        let max_gas = tx.max_gas(consensus_params.gas_costs(), consensus_params.fee_params()) + 1;
-
-        // TODO: @xgreenx why do I need to / 2
-        tx.set_script_gas_limit((network_info.max_gas_per_tx() / 2) - max_gas);
 
         // The `dry_run` validation will check if there is an input present that can cover
         // the tx fees. If we are estimating without inputs we have to add a temporary one
-        tx.inputs_mut().push(FuelInput::coin_signed(
-            Default::default(),
-            Default::default(),
-            1_000_000_000,
-            Default::default(),
-            TxPointer::default(),
-            0,
-            0u32.into(),
-        ));
+        let no_input_for_fee = Self::no_input_to_pay_for_fee(tx.inputs());
+        if no_input_for_fee {
+            tx.inputs_mut().push(FuelInput::coin_signed(
+                Default::default(),
+                Default::default(),
+                1_000_000_000,
+                Default::default(),
+                TxPointer::default(),
+                0,
+                0u32.into(),
+            ));
+
+            // Add an empty `Witness` for the `coin_signed` we just added
+            // and increase the witness limit
+            tx.witnesses_mut().push(Default::default());
+            tx.set_witness_limit(tx.witness_limit() + WITNESS_STATIC_SIZE as u64);
+        }
+
+        // Add `1` because of rounding
+        let max_gas = tx.max_gas(consensus_params.gas_costs(), consensus_params.fee_params()) + 1;
+        tx.set_script_gas_limit(network_info.max_gas_per_tx() - max_gas);
 
         let gas_used = provider
             .dry_run_and_get_used_gas(tx.clone().into(), tolerance)
             .await?;
 
-        // Remove the temporary coin
-        tx.inputs_mut().pop();
+        // Remove dry_run input
+        if no_input_for_fee {
+            tx.inputs_mut().pop();
+        }
 
-        tx.set_script_gas_limit(gas_used);
-
-        Ok(())
+        Ok(gas_used)
     }
 
     async fn resolve_fuel_tx_provider(
@@ -387,11 +394,7 @@ impl ScriptTransactionBuilder {
         num_witnesses: u8,
         provider: &impl DryRunner,
     ) -> Result<Script> {
-        let mut policies = self.generate_shared_fuel_policies();
-        policies.set(
-            PolicyType::WitnessLimit,
-            self.witness_limit.or(Some(DEFAULT_SCRIPT_WITNESS_LIMIT)),
-        );
+        let policies = self.generate_fuel_policies();
 
         let has_no_code = self.script.is_empty();
         let dry_run_witnesses = self.create_dry_run_witnesses(num_witnesses);
@@ -410,20 +413,24 @@ impl ScriptTransactionBuilder {
             dry_run_witnesses,
         );
 
-        if has_no_code {
-            tx.set_script_gas_limit(0);
+        let gas_limit = if has_no_code {
+            0
         // Use the user defined value even if it makes the tx revert
-        } else if let Some(gas_limit) = self.gas_limit {
-            tx.set_script_gas_limit(gas_limit);
+        } else if let Some(gas_limit) = self.tx_policies.script_gas_limit() {
+            gas_limit
+
+        // If the `script_gas_limit` was not set by the user,
+        // `dry_run` the tx to get the `gas_used`
         } else {
-            Self::set_script_gas_limit_to_gas_used(
+            Self::gas_used(
                 &mut tx,
                 provider,
                 &self.network_info,
                 self.gas_estimation_tolerance,
             )
-            .await?;
-        }
+            .await?
+        };
+        tx.set_script_gas_limit(gas_limit);
 
         let missing_witnesses = generate_missing_witnesses(
             tx.id(&self.network_info.chain_id()),
@@ -549,17 +556,8 @@ impl ScriptTransactionBuilder {
             .with_outputs(outputs)
     }
 
-    pub fn with_gas_limit(mut self, gas_limit: u64) -> Self {
-        self.gas_limit = Some(gas_limit);
-        self
-    }
-
     fn with_tx_policies(mut self, tx_policies: TxPolicies) -> Self {
-        self.gas_limit = tx_policies.script_gas_limit();
-        self.gas_price = tx_policies.gas_price();
-        self.witness_limit = tx_policies.witness_limit();
-        self.max_fee = tx_policies.max_fee();
-        self.maturity = tx_policies.maturity();
+        self.tx_policies = tx_policies;
 
         self
     }
@@ -568,10 +566,6 @@ impl ScriptTransactionBuilder {
 impl CreateTransactionBuilder {
     fn new(network_info: NetworkInfo) -> CreateTransactionBuilder {
         CreateTransactionBuilder {
-            gas_price: None,
-            witness_limit: None,
-            max_fee: None,
-            maturity: 0,
             bytecode_length: 0,
             bytecode_witness_index: 0,
             storage_slots: vec![],
@@ -579,6 +573,7 @@ impl CreateTransactionBuilder {
             inputs: vec![],
             outputs: vec![],
             witnesses: vec![],
+            tx_policies: TxPolicies::default(),
             network_info,
             unresolved_signatures: Default::default(),
         }
@@ -602,11 +597,7 @@ impl CreateTransactionBuilder {
     }
 
     fn resolve_fuel_tx(self, mut base_offset: usize, num_witnesses: u8) -> Result<Create> {
-        let mut policies = self.generate_shared_fuel_policies();
-        policies.set(
-            PolicyType::WitnessLimit,
-            self.witness_limit.or(Some(DEFAULT_CREATE_WITNESS_LIMIT)),
-        );
+        let policies = self.generate_fuel_policies();
 
         let storage_slots_offset = self.storage_slots.len() * StorageSlot::SLOT_SIZE;
         base_offset += storage_slots_offset + policies.size_dynamic();
@@ -685,10 +676,7 @@ impl CreateTransactionBuilder {
     }
 
     fn with_tx_policies(mut self, tx_policies: TxPolicies) -> Self {
-        self.gas_price = tx_policies.gas_price();
-        self.witness_limit = tx_policies.witness_limit();
-        self.max_fee = tx_policies.max_fee();
-        self.maturity = tx_policies.maturity();
+        self.tx_policies = tx_policies;
 
         self
     }

--- a/packages/fuels-core/src/utils.rs
+++ b/packages/fuels-core/src/utils.rs
@@ -1,7 +1,18 @@
 pub mod constants;
 pub mod offsets;
 
-use constants::WORD_SIZE;
+use constants::{WITNESS_STATIC_SIZE, WORD_SIZE};
+use fuel_tx::Witness;
+
 pub const fn round_up_to_word_alignment(bytes_len: usize) -> usize {
     (bytes_len + (WORD_SIZE - 1)) - ((bytes_len + (WORD_SIZE - 1)) % WORD_SIZE)
+}
+
+pub(crate) fn calculate_witnesses_size<'a, I: IntoIterator<Item = &'a Witness>>(
+    witnesses: I,
+) -> usize {
+    witnesses
+        .into_iter()
+        .map(|w| w.as_ref().len() + WITNESS_STATIC_SIZE)
+        .sum()
 }

--- a/packages/fuels-core/src/utils/constants.rs
+++ b/packages/fuels-core/src/utils/constants.rs
@@ -12,9 +12,7 @@ pub const BASE_ASSET_ID: AssetId = AssetId::BASE;
 
 pub const DEFAULT_GAS_ESTIMATION_TOLERANCE: f64 = 0.2;
 
-//ANCHOR: witness_default
-// Supports 10 signatures
-pub const DEFAULT_SCRIPT_WITNESS_LIMIT: u64 = 720;
-
-pub const DEFAULT_CREATE_WITNESS_LIMIT: u64 = 20_000;
-//ANCHOR_END: witness_default
+// The size of a signature inside a transaction `Witness`
+pub const WITNESS_STATIC_SIZE: usize = 8;
+const SIGNATURE_SIZE: usize = 64;
+pub const SIGNATURE_WITNESS_SIZE: usize = WITNESS_STATIC_SIZE + SIGNATURE_SIZE;

--- a/packages/fuels/tests/contracts.rs
+++ b/packages/fuels/tests/contracts.rs
@@ -282,8 +282,8 @@ async fn test_contract_call_fee_estimation() -> Result<()> {
 
     let expected_min_gas_price = 0; // This is the default min_gas_price from the ConsensusParameters
     let expected_gas_used = 688;
-    let expected_metered_bytes_size = 800;
-    let expected_total_fee = 1160;
+    let expected_metered_bytes_size = 792;
+    let expected_total_fee = 898;
 
     let estimated_transaction_cost = contract_instance
         .methods()
@@ -402,9 +402,9 @@ async fn contract_method_call_respects_maturity() -> Result<()> {
             .with_tx_policies(TxPolicies::default().with_maturity(maturity))
     };
 
-    call_w_maturity(1u32).call().await.expect("Should have passed since we're calling with a maturity that is less or equal to the current block height");
+    call_w_maturity(1).call().await.expect("Should have passed since we're calling with a maturity that is less or equal to the current block height");
 
-    call_w_maturity(3u32).call().await.expect_err("Should have failed since we're calling with a maturity that is greater than the current block height");
+    call_w_maturity(3).call().await.expect_err("Should have failed since we're calling with a maturity that is greater than the current block height");
     Ok(())
 }
 

--- a/packages/fuels/tests/logs.rs
+++ b/packages/fuels/tests/logs.rs
@@ -1298,7 +1298,7 @@ async fn test_log_results() -> Result<()> {
     let succeeded = log.filter_succeeded();
     let failed = log.filter_failed();
     assert_eq!(succeeded, vec!["123".to_string()]);
-    assert_eq!(failed.get(0).unwrap().to_string(), expected_err);
+    assert_eq!(failed.first().unwrap().to_string(), expected_err);
 
     Ok(())
 }
@@ -1478,7 +1478,7 @@ async fn test_string_slice_log() -> Result<()> {
         "Invalid data: String slices can not be decoded from logs. Convert the slice to `str[N]` with `__to_str_array`".to_string();
 
     let failed = log.filter_failed();
-    assert_eq!(failed.get(0).unwrap().to_string(), expected_err);
+    assert_eq!(failed.first().unwrap().to_string(), expected_err);
 
     Ok(())
 }

--- a/packages/fuels/tests/predicates.rs
+++ b/packages/fuels/tests/predicates.rs
@@ -802,7 +802,7 @@ async fn predicate_can_access_manually_added_witnesses() -> Result<()> {
     let mut tx = ScriptTransactionBuilder::prepare_transfer(
         inputs,
         outputs,
-        TxPolicies::default(),
+        TxPolicies::default().with_witness_limit(32),
         network_info.clone(),
     )
     .build(&provider)
@@ -811,8 +811,8 @@ async fn predicate_can_access_manually_added_witnesses() -> Result<()> {
     let witness = ABIEncoder::encode(&[64u8.into_token()])?.resolve(0);
     let witness2 = ABIEncoder::encode(&[4096u64.into_token()])?.resolve(0);
 
-    tx.append_witness(witness.into());
-    tx.append_witness(witness2.into());
+    tx.append_witness(witness.into())?;
+    tx.append_witness(witness2.into())?;
 
     provider.send_transaction_and_await_commit(tx).await?;
 
@@ -870,7 +870,7 @@ async fn tx_id_not_changed_after_adding_witnesses() -> Result<()> {
     let mut tx = ScriptTransactionBuilder::prepare_transfer(
         inputs,
         outputs,
-        TxPolicies::default(),
+        TxPolicies::default().with_witness_limit(32),
         network_info.clone(),
     )
     .build(&provider)
@@ -881,8 +881,8 @@ async fn tx_id_not_changed_after_adding_witnesses() -> Result<()> {
     let witness = ABIEncoder::encode(&[64u8.into_token()])?.resolve(0);
     let witness2 = ABIEncoder::encode(&[4096u64.into_token()])?.resolve(0);
 
-    tx.append_witness(witness.into());
-    tx.append_witness(witness2.into());
+    tx.append_witness(witness.into())?;
+    tx.append_witness(witness2.into())?;
     let tx_id_after_witnesses = tx.id(network_info.chain_id());
 
     let tx_id_from_provider = provider.send_transaction_and_await_commit(tx).await?;

--- a/packages/fuels/tests/providers.rs
+++ b/packages/fuels/tests/providers.rs
@@ -290,7 +290,7 @@ async fn contract_deployment_respects_maturity() -> Result<()> {
         })
     };
 
-    let err = deploy_w_maturity(1u32)?.await.expect_err(
+    let err = deploy_w_maturity(1)?.await.expect_err(
         "Should not deploy contract since block height (0) is less than the requested maturity (1)",
     );
 
@@ -300,7 +300,7 @@ async fn contract_deployment_respects_maturity() -> Result<()> {
     assert_eq!(s, "TransactionMaturity");
 
     provider.produce_blocks(1, None).await?;
-    deploy_w_maturity(1u32)?
+    deploy_w_maturity(1)?
         .await
         .expect("Should deploy contract since maturity (1) is <= than the block height (1)");
 

--- a/packages/fuels/tests/types_contracts.rs
+++ b/packages/fuels/tests/types_contracts.rs
@@ -2074,7 +2074,6 @@ async fn test_heap_type_in_enums() -> Result<()> {
     let contract_methods = contract_instance.methods();
 
     let resp = contract_methods.returns_bytes_result(true).call().await?;
-    dbg!(&resp);
     let expected = Ok(Bytes(vec![1, 1, 1, 1]));
     assert_eq!(resp.value, expected);
 

--- a/packages/fuels/tests/wallets.rs
+++ b/packages/fuels/tests/wallets.rs
@@ -266,7 +266,7 @@ async fn send_transfer_transactions() -> Result<()> {
     let gas_price = 1;
     let script_gas_limit = 500_000;
     let expected_script_gas_limit = 0;
-    let maturity = 0u32;
+    let maturity = 0;
 
     let tx_policies = TxPolicies::default()
         .with_gas_price(gas_price)
@@ -293,7 +293,7 @@ async fn send_transfer_transactions() -> Result<()> {
     // Transfer scripts have `script_gas_limit` set to `0`
     assert_eq!(script.gas_limit(), expected_script_gas_limit);
     assert_eq!(script.gas_price(), gas_price);
-    assert_eq!(script.maturity(), maturity);
+    assert_eq!(script.maturity(), maturity as u32);
 
     let wallet_1_spendable_resources = wallet_1.get_spendable_resources(BASE_ASSET_ID, 1).await?;
     let wallet_2_spendable_resources = wallet_2.get_spendable_resources(BASE_ASSET_ID, 1).await?;


### PR DESCRIPTION
This PR improves the usage of `TxPolicies` and fixes some of the issues that remained after their were introduced.

BREAKING CHANGE:
- `ScriptTransactionBuilder` and `CreateTransactionBuilder` do not have `with_maturity` and `with_gas_price`, (`with_gas_limit`). They are set through the `with_tx_policies` method.
- `Maturity` is not set to `0` by default - instead we use an `Option<u64>` and `None` if it was not set. This saves bytes as it is not serialized if `None`
- `WitnessLimit` is set to the size of all witnesses in the builder. If the user uses `append_witnesses` after finalizing the transaction a new error will be returned that helps the user set the witness limit manually.

### Checklist
- [x] I have updated the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
