### PR TITLE
refactor: use receipts from `TransactionStatus`

### DIFF
--- a/packages/fuels-accounts/Cargo.toml
+++ b/packages/fuels-accounts/Cargo.toml
@@ -18,7 +18,6 @@ fuel-core-client = { workspace = true, optional = true }
 fuel-crypto = { workspace = true, features = ["random"] }
 fuel-tx = { workspace = true }
 fuel-types = { workspace = true, features = ["random"] }
-fuel-vm = { workspace = true }
 fuels-core = { workspace = true, default-features = false }
 hex = { workspace = true, default-features = false, features = ["std"] }
 rand = { workspace = true, default-features = false }

--- a/packages/fuels-accounts/src/provider.rs
+++ b/packages/fuels-accounts/src/provider.rs
@@ -17,7 +17,6 @@ use fuel_tx::{
     TxId, UtxoId,
 };
 use fuel_types::{Address, Bytes32, ChainId, Nonce};
-use fuel_vm::state::ProgramState;
 #[cfg(feature = "coin-cache")]
 use fuels_core::types::coin_type_id::CoinTypeId;
 use fuels_core::{
@@ -269,41 +268,11 @@ impl Provider {
     }
 
     pub async fn tx_status(&self, tx_id: &TxId) -> ProviderResult<TxStatus> {
-        let fetch_receipts = || async {
-            let receipts = self.client.receipts(tx_id).await?;
-            receipts.ok_or_else(|| ProviderError::ReceiptsNotPropagatedYet)
-        };
-
-        let tx_status = self.client.transaction_status(tx_id).await?;
-        let status = match tx_status {
-            TransactionStatus::Success { .. } => {
-                let receipts = fetch_receipts().await?;
-                TxStatus::Success { receipts }
-            }
-            TransactionStatus::Failure {
-                reason,
-                program_state,
-                ..
-            } => {
-                let receipts = fetch_receipts().await?;
-                let revert_id = program_state
-                    .and_then(|state| match state {
-                        ProgramState::Revert(revert_id) => Some(revert_id),
-                        _ => None,
-                    })
-                    .expect("Transaction failed without a `revert_id`");
-
-                TxStatus::Revert {
-                    receipts,
-                    reason,
-                    revert_id,
-                }
-            }
-            TransactionStatus::Submitted { .. } => TxStatus::Submitted,
-            TransactionStatus::SqueezedOut { reason } => TxStatus::SqueezedOut { reason },
-        };
-
-        Ok(status)
+        self.client
+            .transaction_status(tx_id)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
     pub async fn chain_info(&self) -> ProviderResult<ChainInfo> {

--- a/packages/fuels-accounts/src/provider.rs
+++ b/packages/fuels-accounts/src/provider.rs
@@ -8,9 +8,11 @@ mod supported_versions;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
+#[cfg(feature = "coin-cache")]
+use fuel_core_client::client::types::TransactionStatus;
 use fuel_core_client::client::{
     pagination::{PageDirection, PaginatedResult, PaginationRequest},
-    types::{balance::Balance, contract::ContractBalance, TransactionStatus},
+    types::{balance::Balance, contract::ContractBalance},
 };
 use fuel_tx::{
     AssetId, ConsensusParameters, Receipt, ScriptExecutionResult, Transaction as FuelTransaction,

--- a/packages/fuels-accounts/src/provider/retryable_client.rs
+++ b/packages/fuels-accounts/src/provider/retryable_client.rs
@@ -67,15 +67,6 @@ impl RetryableClient {
         self.our_retry(|| self.client.submit(tx)).await
     }
 
-    pub async fn receipts(&self, id: &TxId) -> io::Result<Option<Vec<Receipt>>> {
-        retry_util::retry(
-            || self.client.receipts(id),
-            &self.retry_config,
-            |result| !matches!(result, Ok(Some(_))),
-        )
-        .await
-    }
-
     pub async fn transaction_status(&self, id: &TxId) -> io::Result<TransactionStatus> {
         self.our_retry(|| self.client.transaction_status(id)).await
     }

--- a/packages/fuels-core/src/types/tx_status.rs
+++ b/packages/fuels-core/src/types/tx_status.rs
@@ -87,15 +87,17 @@ impl TxStatus {
         }
     }
 }
+
 #[cfg(feature = "std")]
 impl From<ClientTransactionStatus> for TxStatus {
     fn from(client_status: ClientTransactionStatus) -> Self {
         match client_status {
             ClientTransactionStatus::Submitted { .. } => TxStatus::Submitted {},
-            ClientTransactionStatus::Success { .. } => TxStatus::Success { receipts: vec![] },
+            ClientTransactionStatus::Success { receipts, .. } => TxStatus::Success { receipts },
             ClientTransactionStatus::Failure {
                 reason,
                 program_state,
+                receipts,
                 ..
             } => {
                 let revert_id = program_state
@@ -105,7 +107,7 @@ impl From<ClientTransactionStatus> for TxStatus {
                     })
                     .expect("Transaction failed without a `revert_id`");
                 TxStatus::Revert {
-                    receipts: vec![],
+                    receipts,
                     reason,
                     revert_id,
                 }


### PR DESCRIPTION
`fuel-core` now provides `receipts` inside the `TransactionStatus`.

### Checklist
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
