### PR TITLE
chore: fixing broken links

### DIFF
--- a/docs/src/types/address.md
+++ b/docs/src/types/address.md
@@ -1,6 +1,6 @@
 # `Address`
 
-Like `Bytes32`, `Address` is a wrapper on `[u8; 32]` with similar methods and implements the same traits (see [fuel-types documentation](https://docs.rs/fuel-types/{{versions.fuel-types}}/fuel_types/struct.Address.html)).
+Like `Bytes32`, `Address` is a wrapper on `[u8; 32]` with similar methods and implements the same traits (see [fuel-types documentation](https://docs.rs/fuel-types/latest/fuel_types/struct.Address.html)).
 
 These are the main ways of creating an `Address`:
 

--- a/docs/src/types/bytes32.md
+++ b/docs/src/types/bytes32.md
@@ -14,6 +14,6 @@ These are the main ways of creating a `Bytes32`:
 {{#include ../../../examples/types/src/lib.rs:bytes32_format}}
 ```
 
-For a full list of implemented methods and traits, see the [fuel-types documentation](https://docs.rs/fuel-types/{{versions.fuel-types}}/fuel_types/struct.Bytes32.html).
+For a full list of implemented methods and traits, see the [fuel-types documentation](https://docs.rs/fuel-types/latest/fuel_types/struct.Bytes32.html).
 
 > **Note:** In Fuel, there's a special type called `b256`, which is similar to `Bytes32`; also used to represent hashes, and it holds a 256-bit value. In Rust, through the SDK, this is represented as `Bits256(value)` where `value` is a `[u8; 32]`. If your contract method takes a `b256` as input, all you need to do is pass a `Bits256([u8; 32])` when calling it from the SDK.


### PR DESCRIPTION
Came across two dead links while reading the docs.
{{versions.fuel-types}} doesn't work anymore and leads to this : 
<img width="1115" alt="Capture d’écran 2024-01-13 à 05 05 07" src="https://github.com/FuelLabs/fuels-rs/assets/153332328/a296cf23-8aa4-42f7-b63b-668f914f42ef">

"latest" works fine.
Hope I can help a bit, have a nice week-end