### PR TITLE
Implement conversion between Address/ContractId types and Identity

### DIFF
--- a/packages/fuels-core/src/types/core/identity.rs
+++ b/packages/fuels-core/src/types/core/identity.rs
@@ -1,3 +1,4 @@
+use crate::types::bech32::{Bech32Address, Bech32ContractId};
 use fuel_tx::{Address, ContractId};
 use fuels_macros::{Parameterize, Tokenizable, TryFrom};
 use serde::{Deserialize, Serialize};
@@ -24,5 +25,80 @@ impl AsRef<[u8]> for Identity {
             Identity::Address(address) => address.as_ref(),
             Identity::ContractId(contract_id) => contract_id.as_ref(),
         }
+    }
+}
+
+impl From<&Address> for Identity {
+    fn from(address: &Address) -> Self {
+        Self::Address(address.clone())
+    }
+}
+impl From<Address> for Identity {
+    fn from(address: Address) -> Self {
+        Self::Address(address)
+    }
+}
+
+impl From<&ContractId> for Identity {
+    fn from(contract_id: &ContractId) -> Self {
+        Self::ContractId(contract_id.clone())
+    }
+}
+impl From<ContractId> for Identity {
+    fn from(contract_id: ContractId) -> Self {
+        Self::ContractId(contract_id)
+    }
+}
+
+impl From<&Bech32Address> for Identity {
+    fn from(data: &Bech32Address) -> Self {
+        Self::Address(data.into())
+    }
+}
+impl From<Bech32Address> for Identity {
+    fn from(data: Bech32Address) -> Self {
+        Self::Address(data.into())
+    }
+}
+
+impl From<&Bech32ContractId> for Identity {
+    fn from(data: &Bech32ContractId) -> Self {
+        Self::ContractId(data.into())
+    }
+}
+impl From<Bech32ContractId> for Identity {
+    fn from(data: Bech32ContractId) -> Self {
+        Self::ContractId(data.into())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_bech32() {
+        let b32_str = "fuel1dved7k25uxadatl7l5kql309jnw07dcn4t3a6x9hm9nxyjcpqqns50p7n2";
+        let bech32_contract_id = Bech32ContractId::from_str(b32_str).unwrap();
+
+        let bech32_contract_id_borrowed = &bech32_contract_id.clone();
+        let identity: Identity = bech32_contract_id_borrowed.into();
+        assert_eq!(
+            identity,
+            Identity::ContractId(bech32_contract_id.clone().into())
+        );
+
+        let identity: Identity = bech32_contract_id.clone().into();
+        assert_eq!(identity, Identity::ContractId(bech32_contract_id.into()));
+
+        let bech32_address = Bech32Address::from_str(b32_str).unwrap();
+
+        let bech32_address_borrowed = &bech32_address.clone();
+        let identity: Identity = bech32_address_borrowed.into();
+        assert_eq!(identity, Identity::Address(bech32_address.clone().into()));
+
+        let identity: Identity = bech32_address.clone().into();
+        assert_eq!(identity, Identity::Address(bech32_address.clone().into()));
     }
 }


### PR DESCRIPTION
Convert from `Address`/`Bech32Address`/`ContractId`/`Bech32ContractId` to `Identity` easily

### Checklist
- [ ] I have linked to any relevant issues.
- [ ] I have updated the documentation.
- [ x] I have added tests that prove my fix is effective or that my feature works.
- [ x] I have added necessary labels.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
