### PR TITLE
chore!: remove unused `response` method

### DIFF
--- a/packages/fuels-programs/src/contract.rs
+++ b/packages/fuels-programs/src/contract.rs
@@ -613,11 +613,11 @@ where
         let tx = self.build_tx().await?;
         let provider = self.account.try_provider()?;
 
+        self.cached_tx_id = Some(tx.id(provider.chain_id()));
+
         let tx_status = if simulate {
             provider.checked_dry_run(tx).await?
         } else {
-            self.cached_tx_id = Some(tx.id(provider.chain_id()));
-
             provider.send_transaction_and_await_commit(tx).await?
         };
         let receipts = tx_status.take_receipts_checked(Some(&self.log_decoder))?;
@@ -905,11 +905,11 @@ impl<T: Account> MultiContractCallHandler<T> {
         let tx = self.build_tx().await?;
         let provider = self.account.try_provider()?;
 
+        self.cached_tx_id = Some(tx.id(provider.chain_id()));
+
         let tx_status = if simulate {
             provider.checked_dry_run(tx).await?
         } else {
-            self.cached_tx_id = Some(tx.id(provider.chain_id()));
-
             provider.send_transaction_and_await_commit(tx).await?
         };
         let receipts = tx_status.take_receipts_checked(Some(&self.log_decoder))?;

--- a/packages/fuels-programs/src/script_calls.rs
+++ b/packages/fuels-programs/src/script_calls.rs
@@ -228,11 +228,11 @@ where
     async fn call_or_simulate(&mut self, simulate: bool) -> Result<FuelCallResponse<D>> {
         let tx = self.build_tx().await?;
 
+        self.cached_tx_id = Some(tx.id(self.provider.chain_id()));
+
         let tx_status = if simulate {
             self.provider.checked_dry_run(tx).await?
         } else {
-            self.cached_tx_id = Some(tx.id(self.provider.chain_id()));
-
             self.provider.send_transaction_and_await_commit(tx).await?
         };
         let receipts = tx_status.take_receipts_checked(Some(&self.log_decoder))?;


### PR DESCRIPTION
The `response` method from `ScriptCallHandler`, `ContractCallHandler` and `MultiContractCallHandler` was unreachable because of:
```rust
let tx_id = self.cached_tx_id.expect("Cached tx_id is missing");
```
Which means that if there is no cached `tx_id` this method will panic. The only way to get a `tx_id` is by calling `call`, `simulate` or `submit` and these methods return other types that handle the response.

Even though this method was never used, I will mark the PR as breaking as the method was `pub`.

BREAKING CHANGE: remove `response` method from `ScriptCallHandler`, `ContractCallHandler` and `MultiContractCallHandler`.

### Checklist
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
