### PR TITLE
Change publish action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
 
       - name: Publish crate check
-        uses: katyo/publish-crates@v2
+        uses: xgreenx/publish-crates@v1
         with:
           dry-run: true
           check-repo: false
@@ -279,7 +279,7 @@ jobs:
           mv ./dasel /usr/local/bin/dasel
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} Cargo.toml
       - name: Publish crate
-        uses: katyo/publish-crates@v2
+        uses: xgreenx/publish-crates@v1
         with:
           publish-delay: 30000
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Due to recent changes in the action used to publish our crates, cyclic dependencies were being poorly handled, resulting in our CI failing to publish the `0.55` version. This PR changes the action, replacing the original one with the one forked and maintained by @xgreenx (thanks, green!). 