### PR TITLE
chore: refactor `fuel_types` imports

### DIFF
--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -110,10 +110,7 @@ mod tests {
 
     #[tokio::test]
     async fn deploy_with_parameters() -> std::result::Result<(), Box<dyn std::error::Error>> {
-        use fuels::{
-            prelude::*,
-            tx::{Bytes32, StorageSlot},
-        };
+        use fuels::{prelude::*, tx::StorageSlot, types::Bytes32};
         use rand::prelude::{Rng, SeedableRng, StdRng};
 
         let wallet = launch_provider_and_get_wallet().await?;

--- a/examples/types/src/lib.rs
+++ b/examples/types/src/lib.rs
@@ -11,7 +11,7 @@ mod tests {
         // ANCHOR: bytes32
         use std::str::FromStr;
 
-        use fuels::tx::Bytes32;
+        use fuels::types::Bytes32;
 
         // Zeroed Bytes32
         let b256 = Bytes32::zeroed();
@@ -70,7 +70,7 @@ mod tests {
     #[tokio::test]
     async fn bech32() -> Result<()> {
         // ANCHOR: bech32
-        use fuels::{prelude::Bech32Address, tx::Bytes32, types::Address};
+        use fuels::types::{bech32::Bech32Address, Address, Bytes32};
 
         // New from HRP string and a hash
         let hrp = "fuel";

--- a/packages/fuels-core/src/types.rs
+++ b/packages/fuels-core/src/types.rs
@@ -1,8 +1,10 @@
 use std::fmt;
 
-pub use fuel_tx::{Address, AssetId, ContractId, TxPointer, UtxoId};
 use fuel_types::bytes::padded_len;
-pub use fuel_types::{ChainId, MessageId, Nonce};
+pub use fuel_types::{
+    Address, AssetId, Bytes32, Bytes4, Bytes64, Bytes8, ChainId, ContractId, MessageId, Nonce,
+    Salt, Word,
+};
 
 pub use crate::types::{core::*, wrappers::*};
 use crate::types::{

--- a/packages/fuels/src/lib.rs
+++ b/packages/fuels/src/lib.rs
@@ -16,7 +16,7 @@ pub mod tx {
     pub use fuel_tx::{
         field, ConsensusParameters, ContractIdExt, ContractParameters, FeeParameters, GasCosts,
         PredicateParameters, Receipt, ScriptExecutionResult, ScriptParameters, StorageSlot,
-        Transaction as FuelTransaction, TxId, TxParameters, Witness,
+        Transaction as FuelTransaction, TxId, TxParameters, TxPointer, UtxoId, Witness,
     };
 }
 

--- a/packages/fuels/src/lib.rs
+++ b/packages/fuels/src/lib.rs
@@ -14,9 +14,9 @@
 
 pub mod tx {
     pub use fuel_tx::{
-        field, AssetId, Bytes32, ConsensusParameters, ContractIdExt, ContractParameters,
-        FeeParameters, GasCosts, PredicateParameters, Receipt, Salt, ScriptExecutionResult,
-        ScriptParameters, StorageSlot, Transaction as FuelTransaction, TxId, TxParameters, Witness,
+        field, ConsensusParameters, ContractIdExt, ContractParameters, FeeParameters, GasCosts,
+        PredicateParameters, Receipt, ScriptExecutionResult, ScriptParameters, StorageSlot,
+        Transaction as FuelTransaction, TxId, TxParameters, Witness,
     };
 }
 
@@ -93,12 +93,11 @@ pub mod prelude {
     pub use super::{
         core::constants::*,
         macros::{abigen, setup_program_test},
-        tx::Salt,
         types::{
             bech32::{Bech32Address, Bech32ContractId},
             errors::{Error, Result},
             transaction::*,
-            Address, AssetId, Bytes, ContractId, RawSlice,
+            Address, AssetId, Bytes, ContractId, RawSlice, Salt,
         },
     };
 }

--- a/packages/fuels/tests/storage.rs
+++ b/packages/fuels/tests/storage.rs
@@ -2,8 +2,8 @@ use std::str::FromStr;
 
 use fuels::{
     prelude::*,
-    tx::{Bytes32, StorageSlot},
-    types::Bits256,
+    tx::StorageSlot,
+    types::{Bits256, Bytes32},
 };
 
 #[tokio::test]


### PR DESCRIPTION
`AssetId` was exported two times. Once through `fuels::tx::AssetId` and once through `fuels::types::AssetId`.
In addition, we were exposing `fuel_types` through `fuel_tx` and `fuels::tx`.

This PR exposes all `fuel_types` directly through `fuels::types` and leaves `fuel_tx` relevant exports to `fuels::tx`.

BREAKING CHANGE: 
- `Bytes32` and `Salt` are accessed through `fuels::types`
- `UtxoId` and `TxPointer` are accessed through `fuels::tx`

### Checklist
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
