### PR TITLE
chore: remove syntax highlighting of Sway files as Rust

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# Syntax highlighting of sway files as rust
-*.sw linguist-language=Rust


### PR DESCRIPTION
Github recognizes Sway files and does not need them to be marked as Rust anymore. 

### Checklist
- [ ] I have linked to any relevant issues.
- [ ] I have updated the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
