### PR TITLE
chore: update `wallet.rs` in-line BIP doc

### DIFF
--- a/packages/fuels-accounts/src/wallet.rs
+++ b/packages/fuels-accounts/src/wallet.rs
@@ -125,7 +125,7 @@ impl WalletUnlocked {
     }
 
     /// Creates a new wallet from a mnemonic phrase.
-    /// It takes a path to a BIP32 derivation path.
+    /// It takes a path to a BIP32/BIP44 derivation path.
     pub fn new_from_mnemonic_phrase_with_path(
         phrase: &str,
         provider: Option<Provider>,

--- a/packages/fuels-accounts/src/wallet.rs
+++ b/packages/fuels-accounts/src/wallet.rs
@@ -125,7 +125,7 @@ impl WalletUnlocked {
     }
 
     /// Creates a new wallet from a mnemonic phrase.
-    /// It takes a path to a BIP32/BIP44 derivation path.
+    /// It takes a derivation path such as BIP32 or BIP44.
     pub fn new_from_mnemonic_phrase_with_path(
         phrase: &str,
         provider: Option<Provider>,


### PR DESCRIPTION
This PR makes a small addition to the in-line docs of `new_from_mnemonic_phrase_with_path ` to clarify that it is not restricted to BIP32 derivation paths only.


### Checklist
- [x] I have linked to any relevant issues.
- [x] I have updated the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.

Closes #1369 