### PR TITLE
feat: use doc strings from the `abi` in `abigen`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,3 +102,7 @@ fuels-macros = { version = "0.62.0", path = "./packages/fuels-macros", default-f
 fuels-programs = { version = "0.62.0", path = "./packages/fuels-programs", default-features = false }
 fuels-test-helpers = { version = "0.62.0", path = "./packages/fuels-test-helpers", default-features = false }
 versions-replacer = { version = "0.62.0", path = "./scripts/versions-replacer", default-features = false }
+
+
+[patch.crates-io]
+fuel-abi-types = { git = "https://github.com/FuelLabs/fuel-abi-types", branch = "hal3e/docstrings-getter" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ bytes = { version = "1.5.0", default-features = false }
 chrono = "0.4.31"
 elliptic-curve = { version = "0.13.8", default-features = false }
 eth-keystore = "0.5.0"
-fuel-abi-types = "0.5.0"
+fuel-abi-types = "0.5.2"
 futures = "0.3.29"
 hex = { version = "0.4.3", default-features = false }
 itertools = "0.12.0"
@@ -102,7 +102,3 @@ fuels-macros = { version = "0.62.0", path = "./packages/fuels-macros", default-f
 fuels-programs = { version = "0.62.0", path = "./packages/fuels-programs", default-features = false }
 fuels-test-helpers = { version = "0.62.0", path = "./packages/fuels-test-helpers", default-features = false }
 versions-replacer = { version = "0.62.0", path = "./scripts/versions-replacer", default-features = false }
-
-
-[patch.crates-io]
-fuel-abi-types = { git = "https://github.com/FuelLabs/fuel-abi-types", branch = "hal3e/docstrings-getter" }

--- a/e2e/sway/contracts/contract_test/src/main.sw
+++ b/e2e/sway/contracts/contract_test/src/main.sw
@@ -74,6 +74,8 @@ impl TestContract for Contract {
         value
     }
 
+    /// This method will read the counter from storage, increment it
+    /// and write the incremented value to storage
     #[storage(read, write)]
     fn increment_counter(value: u64) -> u64 {
         let new_value = read::<u64>(COUNTER_KEY, 0).unwrap_or(0) + value;

--- a/e2e/sway/scripts/basic_script/src/main.sw
+++ b/e2e/sway/scripts/basic_script/src/main.sw
@@ -1,5 +1,6 @@
 script;
 
+/// Compares a to b and returns a `str[5]`
 fn main(a: u64, b: u32) -> str[5] {
     if a < b.as_u64() {
         let my_string: str[5] = __to_str_array("hello");

--- a/packages/fuels-code-gen/src/program_bindings/abigen/bindings/contract.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/bindings/contract.rs
@@ -454,10 +454,16 @@ mod tests {
                 type_id: 1,
                 ..Default::default()
             },
-            attributes: Some(vec![Attribute {
-                name: "doc-comment".to_string(),
-                arguments: vec!["This is a doc string".to_string()],
-            }]),
+            attributes: Some(vec![
+                Attribute {
+                    name: "doc-comment".to_string(),
+                    arguments: vec!["This is a doc string".to_string()],
+                },
+                Attribute {
+                    name: "doc-comment".to_string(),
+                    arguments: vec!["This is another doc string".to_string()],
+                },
+            ]),
         };
         let types = [
             (
@@ -528,6 +534,7 @@ mod tests {
         // Some more editing was required because it is not rustfmt-compatible (adding/removing parentheses or commas)
         let expected = quote! {
             #[doc = "This is a doc string"]
+            #[doc = "This is another doc string"]
             pub fn hello_world(
                 &self,
                 the_only_allowed_input: self::SomeWeirdFrenchCuisine

--- a/packages/fuels-code-gen/src/program_bindings/abigen/bindings/contract.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/bindings/contract.rs
@@ -154,10 +154,7 @@ fn expand_functions(functions: &[FullABIFunction]) -> Result<TokenStream> {
 pub(crate) fn expand_fn(abi_fun: &FullABIFunction) -> Result<TokenStream> {
     let mut generator = FunctionGenerator::new(abi_fun)?;
 
-    generator.set_doc(format!(
-        "Calls the contract's `{}` function",
-        abi_fun.name(),
-    ));
+    generator.set_docs(abi_fun.doc_strings()?);
 
     let original_output = generator.output_type();
     generator.set_output_type(
@@ -189,7 +186,7 @@ mod tests {
 
     use fuel_abi_types::abi::{
         full_program::FullABIFunction,
-        program::{ABIFunction, ProgramABI, TypeApplication, TypeDeclaration},
+        program::{ABIFunction, Attribute, ProgramABI, TypeApplication, TypeDeclaration},
     };
     use pretty_assertions::assert_eq;
     use quote::quote;
@@ -197,7 +194,7 @@ mod tests {
     use crate::{error::Result, program_bindings::abigen::bindings::contract::expand_fn};
 
     #[test]
-    fn test_expand_fn_simple_abi() -> Result<()> {
+    fn expand_contract_method_simple_abi() -> Result<()> {
         let s = r#"
             {
                 "types": [
@@ -332,7 +329,15 @@ mod tests {
                       "name": "",
                       "type": 26,
                       "typeArguments": []
-                    }
+                    },
+                    "attributes": [
+                      {
+                        "name": "doc-comment",
+                        "arguments": [
+                          "This is a doc string"
+                        ]
+                      }
+                    ]
                   }
                 ]
               }
@@ -351,7 +356,7 @@ mod tests {
         )?)?;
 
         let expected = quote! {
-            #[doc = "Calls the contract's `some_abi_funct` function"]
+            #[doc = "This is a doc string"]
             pub fn some_abi_funct(
                 &self,
                 s_1: self::MyStruct1,
@@ -378,7 +383,7 @@ mod tests {
     }
 
     #[test]
-    fn test_expand_fn_simple() -> Result<()> {
+    fn expand_contract_method_simple() -> Result<()> {
         let the_function = ABIFunction {
             inputs: vec![TypeApplication {
                 name: String::from("bimbam"),
@@ -386,6 +391,10 @@ mod tests {
                 ..Default::default()
             }],
             name: "HelloWorld".to_string(),
+            attributes: Some(vec![Attribute {
+                name: "doc-comment".to_string(),
+                arguments: vec!["This is a doc string".to_string()],
+            }]),
             ..Default::default()
         };
         let types = [
@@ -411,7 +420,7 @@ mod tests {
         let result = expand_fn(&FullABIFunction::from_counterpart(&the_function, &types)?);
 
         let expected = quote! {
-            #[doc = "Calls the contract's `HelloWorld` function"]
+            #[doc = "This is a doc string"]
             pub fn HelloWorld(&self, bimbam: ::core::primitive::bool) -> ::fuels::programs::contract::ContractCallHandler<T, ()> {
                 ::fuels::programs::contract::method_hash(
                     self.contract_id.clone(),
@@ -431,7 +440,7 @@ mod tests {
     }
 
     #[test]
-    fn test_expand_fn_complex() -> Result<()> {
+    fn expand_contract_method_complex() -> Result<()> {
         // given
         let the_function = ABIFunction {
             inputs: vec![TypeApplication {
@@ -445,7 +454,10 @@ mod tests {
                 type_id: 1,
                 ..Default::default()
             },
-            ..Default::default()
+            attributes: Some(vec![Attribute {
+                name: "doc-comment".to_string(),
+                arguments: vec!["This is a doc string".to_string()],
+            }]),
         };
         let types = [
             (
@@ -515,7 +527,7 @@ mod tests {
 
         // Some more editing was required because it is not rustfmt-compatible (adding/removing parentheses or commas)
         let expected = quote! {
-            #[doc = "Calls the contract's `hello_world` function"]
+            #[doc = "This is a doc string"]
             pub fn hello_world(
                 &self,
                 the_only_allowed_input: self::SomeWeirdFrenchCuisine


### PR DESCRIPTION
closes: https://github.com/FuelLabs/fuels-rs/issues/1335

Adds ABI doc strings to contract methods and script's main function.

### Checklist
- [x] I have linked to any relevant issues.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
