### PR TITLE
refactor: remove `provider` from `ScriptCallHandler`

### DIFF
--- a/packages/fuels-code-gen/src/program_bindings/abigen/bindings/script.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/bindings/script.rs
@@ -192,13 +192,10 @@ mod tests {
             pub fn main(&self, bimbam: ::core::primitive::bool) -> ::fuels::programs::script_calls::ScriptCallHandler<T, ()> {
                 let encoded_args=::fuels::core::codec::ABIEncoder::new(self.encoder_config)
                     .encode(&[::fuels::core::traits::Tokenizable::into_token(bimbam)]);
-                 let provider = ::fuels::accounts::ViewOnlyAccount::try_provider(&self.account)
-                     .expect("Provider not set up").clone();
                  ::fuels::programs::script_calls::ScriptCallHandler::new(
                     self.binary.clone(),
                     encoded_args,
                     self.account.clone(),
-                    provider,
                     self.log_decoder.clone()
                 )
             }

--- a/packages/fuels-code-gen/src/program_bindings/abigen/bindings/script.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/bindings/script.rs
@@ -110,13 +110,10 @@ fn expand_fn(abi: &FullProgramABI) -> Result<TokenStream> {
     let arg_tokens = generator.tokenized_args();
     let body = quote! {
             let encoded_args = ::fuels::core::codec::ABIEncoder::new(self.encoder_config).encode(&#arg_tokens);
-            let provider = ::fuels::accounts::ViewOnlyAccount::try_provider(&self.account).expect("Provider not set up")
-                .clone();
             ::fuels::programs::script_calls::ScriptCallHandler::new(
                 self.binary.clone(),
                 encoded_args,
                 self.account.clone(),
-                provider,
                 self.log_decoder.clone()
             )
     };

--- a/packages/fuels-programs/src/contract.rs
+++ b/packages/fuels-programs/src/contract.rs
@@ -644,10 +644,8 @@ where
 
     /// Create a [`FuelCallResponse`] from call receipts
     pub fn get_response(&self, receipts: Vec<Receipt>) -> Result<FuelCallResponse<D>> {
-        let token = ReceiptParser::new(&receipts, self.decoder_config).parse_call(
-            &self.contract_call.contract_id,
-            &self.contract_call.output_param,
-        )?;
+        let token = ReceiptParser::new(&receipts, self.decoder_config)
+            .parse_call(&self.contract_call.contract_id, &D::param_type())?;
 
         Ok(FuelCallResponse::new(
             D::from_token(token)?,

--- a/packages/fuels-programs/src/submit_response.rs
+++ b/packages/fuels-programs/src/submit_response.rs
@@ -39,6 +39,7 @@ pub struct SubmitResponse<T: Account, D> {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum CallHandler<T: Account, D> {
     Contract(ContractCallHandler<T, D>),
     Script(ScriptCallHandler<T, D>),


### PR DESCRIPTION
Removed `provider` from `ScriptCallHandler`. The `provider` can be accessed from the `account` the same way we do in `ContractCallHandlers`. 

Another benefit is that we will not panic when initializing a new script instance if the provider is not set up.

### Checklist
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
