### PR TITLE
bug: e2e build script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ version = "0.62.0"
 
 [workspace.dependencies]
 Inflector = "0.11.4"
+anyhow = { version = "1.0", default-features = false }
 async-trait = { version = "0.1.74", default-features = false }
 bech32 = "0.9.1"
 bytes = { version = "1.5.0", default-features = false }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -24,6 +24,7 @@ tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 
 [build-dependencies]
+anyhow = { workspace = true, features = ["std"] }
 flate2 = { workspace = true, features = ["zlib"] }
 reqwest = { workspace = true, features = ["blocking", "default-tls"] }
 semver = { workspace = true }

--- a/e2e/build.rs
+++ b/e2e/build.rs
@@ -1,64 +1,107 @@
 use flate2::read::GzDecoder;
 use semver::Version;
-use std::{io::Cursor, path::Path};
+use std::{
+    io::Cursor,
+    path::{Path, PathBuf},
+};
 use tar::Archive;
 
-const CORE_VERSION: semver::Version = include!("../scripts/fuel-core-version/version.rs");
-const EXECUTOR_FILE_NAME: &str = "fuel-core-wasm-executor.wasm";
+struct Downloader {
+    dir: PathBuf,
+}
+
+impl Downloader {
+    const EXECUTOR_FILE_NAME: &'static str = "fuel-core-wasm-executor.wasm";
+    const CORRECT_VERSION_CONTENTS: &'static str =
+        include_str!("../scripts/fuel-core-version/version.rs");
+
+    pub fn new() -> Self {
+        let env = std::env::var("OUT_DIR").unwrap();
+        let out_dir = Path::new(&env);
+        Self {
+            dir: out_dir.to_path_buf(),
+        }
+    }
+
+    pub fn should_download(&self) -> anyhow::Result<bool> {
+        if !self.executor_path().exists() {
+            return Ok(true);
+        }
+
+        if !self.version_path().exists() {
+            return Ok(true);
+        }
+
+        let saved_version = std::fs::read_to_string(self.version_path())?;
+        if saved_version != Self::CORRECT_VERSION_CONTENTS {
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
+    pub fn download(&self) -> anyhow::Result<()> {
+        std::fs::create_dir_all(&self.dir)?;
+
+        const LINK_TEMPLATE: &str = "https://github.com/FuelLabs/fuel-core/releases/download/vVERSION/fuel-core-VERSION-x86_64-unknown-linux-gnu.tar.gz";
+        const CORE_VERSION: semver::Version = include!("../scripts/fuel-core-version/version.rs");
+        let link = LINK_TEMPLATE.replace("VERSION", &CORE_VERSION.to_string());
+
+        let response = reqwest::blocking::get(link)?;
+        assert!(
+            response.status().is_success(),
+            "Failed to download wasm executor"
+        );
+
+        let mut content = Cursor::new(response.bytes()?);
+
+        let mut archive = Archive::new(GzDecoder::new(&mut content));
+
+        let mut extracted = false;
+        let executor_in_tar = Path::new(&format!(
+            "fuel-core-{CORE_VERSION}-x86_64-unknown-linux-gnu"
+        ))
+        .join(Self::EXECUTOR_FILE_NAME);
+
+        for entry in archive.entries()? {
+            let mut entry = entry?;
+
+            if entry.path()? == executor_in_tar {
+                entry.unpack(self.executor_path())?;
+                std::fs::write(self.version_path(), Self::CORRECT_VERSION_CONTENTS)?;
+
+                extracted = true;
+                break;
+            }
+        }
+        if !extracted {
+            anyhow::bail!("Failed to extract wasm executor from the archive");
+        }
+
+        Ok(())
+    }
+
+    fn executor_path(&self) -> PathBuf {
+        self.dir.join(Self::EXECUTOR_FILE_NAME)
+    }
+
+    fn version_path(&self) -> PathBuf {
+        self.dir.join("version.rs")
+    }
+}
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
-    let core_version_file =
-        Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/fuel-core-version/version.rs");
-    println!("cargo:rerun-if-changed={}", core_version_file.display());
+    let downloader = Downloader::new();
 
-    let executor = expected_executor_location();
-    if !executor.exists() {
-        download_executor(&executor);
+    let executor_path = downloader.executor_path();
+    println!("cargo:rerun-if-changed={}", executor_path.display());
+
+    let version_path = downloader.version_path();
+    println!("cargo:rerun-if-changed={}", version_path.display());
+
+    if downloader.should_download().unwrap() {
+        downloader.download().unwrap();
     }
-}
-
-fn expected_executor_location() -> std::path::PathBuf {
-    let env = std::env::var("OUT_DIR").unwrap();
-    let out_dir = Path::new(&env);
-
-    std::fs::create_dir_all(out_dir).unwrap();
-
-    out_dir.join(EXECUTOR_FILE_NAME)
-}
-
-fn download_executor(path: &Path) {
-    const LINK_TEMPLATE: &str = "https://github.com/FuelLabs/fuel-core/releases/download/vVERSION/fuel-core-VERSION-x86_64-unknown-linux-gnu.tar.gz";
-    let link = LINK_TEMPLATE.replace("VERSION", &CORE_VERSION.to_string());
-
-    let response = reqwest::blocking::get(link).unwrap();
-    assert!(
-        response.status().is_success(),
-        "Failed to download wasm executor"
-    );
-
-    let mut content = Cursor::new(response.bytes().unwrap());
-
-    let mut archive = Archive::new(GzDecoder::new(&mut content));
-
-    let mut extracted = false;
-    let executor = Path::new(&format!(
-        "fuel-core-{CORE_VERSION}-x86_64-unknown-linux-gnu"
-    ))
-    .join(EXECUTOR_FILE_NAME);
-
-    for entry in archive.entries().unwrap() {
-        let mut entry = entry.unwrap();
-
-        if entry.path().unwrap() == executor {
-            entry.unpack(path).unwrap();
-            extracted = true;
-            break;
-        }
-    }
-    assert!(
-        extracted,
-        "Failed to extract wasm executor from the archive"
-    );
 }

--- a/e2e/build.rs
+++ b/e2e/build.rs
@@ -48,10 +48,9 @@ impl Downloader {
         let link = LINK_TEMPLATE.replace("VERSION", &CORE_VERSION.to_string());
 
         let response = reqwest::blocking::get(link)?;
-        assert!(
-            response.status().is_success(),
-            "Failed to download wasm executor"
-        );
+        if !response.status().is_success() {
+            anyhow::bail!("Failed to download wasm executor: {}", response.status());
+        }
 
         let mut content = Cursor::new(response.bytes()?);
 

--- a/e2e/build.rs
+++ b/e2e/build.rs
@@ -80,6 +80,14 @@ impl Downloader {
         Ok(())
     }
 
+    fn make_cargo_watch_downloaded_files(&self) {
+        let executor_path = self.executor_path();
+        println!("cargo:rerun-if-changed={}", executor_path.display());
+
+        let version_path = self.version_path();
+        println!("cargo:rerun-if-changed={}", version_path.display());
+    }
+
     fn executor_path(&self) -> PathBuf {
         self.dir.join(Self::EXECUTOR_FILE_NAME)
     }
@@ -93,12 +101,7 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     let downloader = Downloader::new();
-
-    let executor_path = downloader.executor_path();
-    println!("cargo:rerun-if-changed={}", executor_path.display());
-
-    let version_path = downloader.version_path();
-    println!("cargo:rerun-if-changed={}", version_path.display());
+    downloader.make_cargo_watch_downloaded_files();
 
     if downloader.should_download().unwrap() {
         downloader.download().unwrap();


### PR DESCRIPTION
closes: #1397

The `build.rs` will now check:
* Whether the `version.rs` is updated
* Whether the executor is downloaded
* If downloaded, is it the same version as can be found in our `version.rs`
* cleanup if any step fails

### Checklist
- [x] I have linked to any relevant issues.
- [x] I have updated the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
