### PR TITLE
bug: await tx committal

### DIFF
--- a/e2e/tests/providers.rs
+++ b/e2e/tests/providers.rs
@@ -995,11 +995,8 @@ async fn can_upload_executor_and_trigger_upgrade() -> Result<()> {
         wallet.adjust_for_fee(&mut builder, 0).await?;
         let tx = builder.build(&provider).await?;
 
-        provider.send_transaction(tx).await?;
+        provider.send_transaction_and_await_commit(tx).await?;
     }
-
-    // Otherwise we occasionally get `UnknownStateTransactionBytecodeRoot` in CI runs
-    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
     let mut builder =
         UpgradeTransactionBuilder::prepare_state_transition_upgrade(root, TxPolicies::default());


### PR DESCRIPTION
The test just submitted transactions without awaiting their commitment, causing CI to sometimes complain about transactions being processed out of place... :facepalm: 

related: #1382 

### Checklist
- [ ] I have linked to any relevant issues.
- [ ] I have updated the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
