### PR TITLE
Predicate estimation fallback to API

### DIFF
--- a/packages/fuels-accounts/src/provider.rs
+++ b/packages/fuels-accounts/src/provider.rs
@@ -256,6 +256,10 @@ impl Provider {
         Ok(self.client.estimate_gas_price(block_horizon).await?)
     }
 
+    pub async fn estimate_predicates(&self, tx: impl Transaction) -> Result<()> {
+        Ok(self.client.estimate_predicates(&mut tx.into()).await?)
+    }
+
     pub async fn dry_run(&self, tx: impl Transaction) -> Result<TxStatus> {
         let [tx_status] = self
             .client

--- a/packages/fuels-accounts/src/provider/retryable_client.rs
+++ b/packages/fuels-accounts/src/provider/retryable_client.rs
@@ -150,12 +150,13 @@ impl RetryableClient {
             .map(Into::into)
     }
 
-    pub async fn estimate_predicates(&self, tx: &mut Transaction) -> RequestResult<()> {
+    pub async fn estimate_predicates(&self, mut tx: Transaction) -> RequestResult<Transaction> {
         // TODO(oleksii): use &mut Transaction in RetryableClient::wrap
         self.client
-            .estimate_predicates(tx)
+            .estimate_predicates(&mut tx)
             .await
-            .map_err(|e| RequestError::IO(e.to_string()))
+            .map_err(|e| RequestError::IO(e.to_string()))?;
+        Ok(tx)
     }
 
     pub async fn dry_run(

--- a/packages/fuels-accounts/src/provider/retryable_client.rs
+++ b/packages/fuels-accounts/src/provider/retryable_client.rs
@@ -88,7 +88,7 @@ impl RetryableClient {
         self.retry_config = retry_config;
     }
 
-    async fn wrap<T, Fut>(&self, action: impl Fn() -> Fut) -> RequestResult<T>
+    async fn wrap<T, Fut>(&self, action: impl FnMut() -> Fut) -> RequestResult<T>
     where
         Fut: Future<Output = io::Result<T>>,
     {
@@ -148,6 +148,14 @@ impl RetryableClient {
         self.wrap(|| self.client.estimate_gas_price(block_horizon))
             .await
             .map(Into::into)
+    }
+
+    pub async fn estimate_predicates(&self, tx: &mut Transaction) -> RequestResult<()> {
+        // TODO(oleksii): use &mut Transaction in RetryableClient::wrap
+        self.client
+            .estimate_predicates(tx)
+            .await
+            .map_err(|e| RequestError::IO(e.to_string()))
     }
 
     pub async fn dry_run(

--- a/packages/fuels-core/src/types/wrappers/transaction.rs
+++ b/packages/fuels-core/src/types/wrappers/transaction.rs
@@ -343,6 +343,17 @@ macro_rules! impl_tx_wrapper {
             }
         }
 
+        impl EstimablePredicates for $wrapper {
+            fn estimate_predicates(
+                &mut self,
+                consensus_parameters: &ConsensusParameters,
+            ) -> Result<()> {
+                self.tx.estimate_predicates(&consensus_parameters.into())?;
+
+                Ok(())
+            }
+        }
+
         impl ValidatablePredicates for $wrapper {
             fn validate_predicates(
                 self,
@@ -496,30 +507,6 @@ impl_tx_wrapper!(CreateTransaction, Create);
 impl_tx_wrapper!(UploadTransaction, Upload);
 impl_tx_wrapper!(UpgradeTransaction, Upgrade);
 
-impl EstimablePredicates for UploadTransaction {
-    fn estimate_predicates(&mut self, consensus_parameters: &ConsensusParameters) -> Result<()> {
-        self.tx.estimate_predicates(&consensus_parameters.into())?;
-
-        Ok(())
-    }
-}
-
-impl EstimablePredicates for UpgradeTransaction {
-    fn estimate_predicates(&mut self, consensus_parameters: &ConsensusParameters) -> Result<()> {
-        self.tx.estimate_predicates(&consensus_parameters.into())?;
-
-        Ok(())
-    }
-}
-
-impl EstimablePredicates for CreateTransaction {
-    fn estimate_predicates(&mut self, consensus_parameters: &ConsensusParameters) -> Result<()> {
-        self.tx.estimate_predicates(&consensus_parameters.into())?;
-
-        Ok(())
-    }
-}
-
 impl CreateTransaction {
     pub fn salt(&self) -> &FuelSalt {
         self.tx.salt()
@@ -531,14 +518,6 @@ impl CreateTransaction {
 
     pub fn storage_slots(&self) -> &Vec<StorageSlot> {
         self.tx.storage_slots()
-    }
-}
-
-impl EstimablePredicates for ScriptTransaction {
-    fn estimate_predicates(&mut self, consensus_parameters: &ConsensusParameters) -> Result<()> {
-        self.tx.estimate_predicates(&consensus_parameters.into())?;
-
-        Ok(())
     }
 }
 

--- a/packages/fuels-core/src/types/wrappers/transaction.rs
+++ b/packages/fuels-core/src/types/wrappers/transaction.rs
@@ -27,7 +27,7 @@ use crate::{
     traits::Signer,
     types::{
         bech32::Bech32Address,
-        errors::{error, error_transaction, Result},
+        errors::{error, error_transaction, Error, Result},
     },
     utils::{calculate_witnesses_size, sealed},
 };
@@ -213,7 +213,8 @@ pub trait ValidatablePredicates: sealed::Sealed {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait Transaction:
-    Into<FuelTransaction>
+    TryFrom<FuelTransaction, Error = Error>
+    + Into<FuelTransaction>
     + EstimablePredicates
     + ValidatablePredicates
     + GasValidation
@@ -322,6 +323,20 @@ macro_rules! impl_tx_wrapper {
         impl From<$wrapper> for FuelTransaction {
             fn from(tx: $wrapper) -> Self {
                 tx.tx.into()
+            }
+        }
+
+        impl TryFrom<FuelTransaction> for $wrapper {
+            type Error = Error;
+
+            fn try_from(tx: FuelTransaction) -> Result<Self> {
+                match tx {
+                    FuelTransaction::$wrapped(tx) => Ok(tx.into()),
+                    _ => Err(error!(
+                        Other,
+                        "couldn't convert Transaction into a wrapper of type $wrapper"
+                    )),
+                }
             }
         }
 


### PR DESCRIPTION
Close #1409.

This is very janky, I'm open to any and all ideas of improvement.
I'm going to collect any ideas in a short period, open issue(s) for them, and remove the TODO comments afterward.

Points of special jank:
- `estimate_predicates_with_node_fallback` (name suggestions welcome) calls node for `chain_info` to get the executor version every time a transaction is estimated. A much better approach (suggested by @segfault-magnet) would be to cache the on-chain executor version (or the whole `chain_info`) and only update it periodically.
- had to `impl TryFrom<FuelTransaction> for Transaction`, where logic depends on the enum variant being named exactly the same as the transaction type being wrapped, e.g. `FuelTransaction::Script(tx: Script)`
- in the `TryFrom` impl itself, `Err(error!(Other, "...")` feels wrong and too vague
- `RetryableClient::wrap` only supports immutable references in `self.client` calls, which is impossible with `self.client.estimate_predicates(&mut tx)`. `RetryableClient` could be refactored, but for now I opted to just forward the call to the client without applying retry logic

### Checklist
- [x] I have linked to any relevant issues.
- [ ] I have updated the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
