### PR TITLE
chore: update `forc build` path in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See [the `fuels-rs` book](https://fuellabs.github.io/fuels-rs/latest/)
 First, build the test projects using `forc`:
 
 ```shell
-forc build --release --path packages/fuels
+forc build --release --path e2e
 ```
 
 Then you can run the SDK tests with:
@@ -73,7 +73,7 @@ Before doing anything else, try all these commands:
 ```shell
 cargo clean
 rm Cargo.lock
-forc build --release --path packages/fuels
+forc build --release --path e2e
 cargo test
 ```
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -101,7 +101,7 @@ Another way to experience the SDK is to look at the source code. The `e2e/tests/
 > To build these tests, run the following command:
 
 ```shell
-forc build --release --path packages/fuels
+forc build --release --path e2e
 ```
 
 > `forc` can also be used to clean and format the test projects. Check the `help` output for more info.


### PR DESCRIPTION
Updating `forc build --path` usages in docs based on the update in #1374.

### Checklist
- [ ] I have linked to any relevant issues.
- [x] I have updated the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
