### PR TITLE
bug!: accounts now cover max fee increase due to tolerance

### DIFF
--- a/e2e/tests/contracts.rs
+++ b/e2e/tests/contracts.rs
@@ -2,7 +2,7 @@ use fuels::{
     core::codec::{calldata, encode_fn_selector, DecoderConfig, EncoderConfig},
     prelude::*,
     tx::ContractParameters,
-    types::{errors::transaction::Reason, Bits256, Identity},
+    types::{errors::transaction::Reason, input::Input, Bits256, Identity},
 };
 use tokio::time::Instant;
 
@@ -1984,21 +1984,34 @@ async fn contract_call_with_non_zero_base_asset_id_and_tip() -> Result<()> {
 async fn max_fee_estimation_respects_tolerance() -> Result<()> {
     use fuels::prelude::*;
 
+    let mut call_wallet = WalletUnlocked::new_random(None);
+
+    let call_coins = setup_single_asset_coins(call_wallet.address(), AssetId::BASE, 1000, 1);
+
+    let mut deploy_wallet = WalletUnlocked::new_random(None);
+    let deploy_coins =
+        setup_single_asset_coins(deploy_wallet.address(), AssetId::BASE, 1, 1_000_000);
+
+    let provider =
+        setup_test_provider([call_coins, deploy_coins].concat(), vec![], None, None).await?;
+
+    call_wallet.set_provider(provider.clone());
+    deploy_wallet.set_provider(provider.clone());
+
     setup_program_test!(
-        Wallets("wallet"),
         Abigen(Contract(
             name = "MyContract",
             project = "e2e/sway/contracts/contract_test"
         )),
         Deploy(
             name = "contract_instance",
-            wallet = "wallet",
+            wallet = "deploy_wallet",
             contract = "MyContract"
         )
     );
-    let provider = wallet.provider().unwrap();
+    let contract_instance = contract_instance.with_account(call_wallet.clone());
 
-    let calculate_max_fee = |tolerance: f32| {
+    let max_fee_from_tx = |tolerance: f32| {
         let contract_instance = contract_instance.clone();
         let provider = provider.clone();
         async move {
@@ -2024,11 +2037,69 @@ async fn max_fee_estimation_respects_tolerance() -> Result<()> {
         }
     };
 
-    let no_increase_max_fee = calculate_max_fee(0.0).await;
-    let increased_max_fee = calculate_max_fee(2.00).await;
+    let max_fee_from_builder = |tolerance: f32| {
+        let contract_instance = contract_instance.clone();
+        let provider = provider.clone();
+        async move {
+            contract_instance
+                .methods()
+                .initialize_counter(42)
+                .transaction_builder()
+                .await
+                .unwrap()
+                .with_max_fee_estimation_tolerance(tolerance)
+                .estimate_max_fee(&provider)
+                .await
+                .unwrap()
+        }
+    };
+
+    let base_amount_in_inputs = |tolerance: f32| {
+        let contract_instance = contract_instance.clone();
+        let call_wallet = &call_wallet;
+        async move {
+            let mut tb = contract_instance
+                .methods()
+                .initialize_counter(42)
+                .transaction_builder()
+                .await
+                .unwrap()
+                .with_max_fee_estimation_tolerance(tolerance);
+
+            call_wallet.adjust_for_fee(&mut tb, 0).await.unwrap();
+            tb.inputs
+                .iter()
+                .filter_map(|input: &Input| match input {
+                    Input::ResourceSigned { resource }
+                        if resource.coin_asset_id().unwrap() == AssetId::BASE =>
+                    {
+                        Some(resource.amount())
+                    }
+                    _ => None,
+                })
+                .sum::<u64>()
+        }
+    };
+
+    let no_increase_max_fee = max_fee_from_tx(0.0).await;
+    let increased_max_fee = max_fee_from_tx(2.00).await;
 
     assert_eq!(
         increased_max_fee as f64 / no_increase_max_fee as f64,
+        1.00 + 2.00
+    );
+
+    let no_increase_max_fee = max_fee_from_builder(0.0).await;
+    let increased_max_fee = max_fee_from_builder(2.00).await;
+    assert_eq!(
+        increased_max_fee as f64 / no_increase_max_fee as f64,
+        1.00 + 2.00
+    );
+
+    let normal_base_asset = base_amount_in_inputs(0.0).await;
+    let more_base_asset_due_to_bigger_tolerance = base_amount_in_inputs(2.00).await;
+    assert_eq!(
+        more_base_asset_due_to_bigger_tolerance as f64 / normal_base_asset as f64,
         1.00 + 2.00
     );
 

--- a/packages/fuels-accounts/src/accounts_utils.rs
+++ b/packages/fuels-accounts/src/accounts_utils.rs
@@ -5,7 +5,7 @@ use fuels_core::types::{
     coin::Coin,
     coin_type::CoinType,
     coin_type_id::CoinTypeId,
-    errors::{error, error_transaction, Error, Result},
+    errors::{error, Error, Result},
     input::Input,
     transaction_builders::TransactionBuilder,
 };
@@ -23,15 +23,9 @@ pub async fn calculate_missing_base_amount(
     reserved_base_amount: u64,
     provider: &Provider,
 ) -> Result<u64> {
-    let transaction_fee = tb
-        .fee_checked_from_tx(provider)
-        .await?
-        .ok_or(error_transaction!(
-            Other,
-            "error calculating `TransactionFee`"
-        ))?;
+    let max_fee = tb.estimate_max_fee(provider).await?;
 
-    let total_used = transaction_fee.max_fee() + reserved_base_amount;
+    let total_used = max_fee + reserved_base_amount;
     let missing_amount = if total_used > available_base_amount {
         total_used - available_base_amount
     } else if !is_consuming_utxos(tb) {

--- a/packages/fuels-accounts/src/provider.rs
+++ b/packages/fuels-accounts/src/provider.rs
@@ -55,7 +55,7 @@ use tokio::sync::Mutex;
 use crate::coin_cache::CoinsCache;
 use crate::provider::retryable_client::RetryableClient;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 // ANCHOR: transaction_cost
 pub struct TransactionCost {
     pub gas_price: u64,


### PR DESCRIPTION
closes: #1463 

### Breaking changes
* `fee_checked_from_tx` is removed from all transaction builders. max fee can now be estimated using the new method `estimate_max_fee` which takes into account the max fee estimation tolerance set on the builders.

### Checklist

- [x] I have linked to any relevant issues.
- [ ] I have updated the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
