### PR TITLE
fix: string slice decoding

### DIFF
--- a/packages/fuels-core/src/codec/abi_decoder/bounded_decoder.rs
+++ b/packages/fuels-core/src/codec/abi_decoder/bounded_decoder.rs
@@ -210,12 +210,14 @@ impl BoundedDecoder {
 
     fn decode_string_slice(bytes: &[u8]) -> Result<Decoded> {
         let length = peek_length(bytes)?;
-        let bytes = peek(skip(bytes, LENGTH_BYTES_SIZE)?, length)?;
-        let decoded = str::from_utf8(bytes)?.to_string();
+        // skipping over the previously read length
+        let content_bytes = skip(bytes, LENGTH_BYTES_SIZE)?;
+        let string_bytes = peek(content_bytes, length)?;
+        let decoded = str::from_utf8(string_bytes)?.to_string();
 
         Ok(Decoded {
             token: Token::StringSlice(StaticStringToken::new(decoded, None)),
-            bytes_read: bytes.len(),
+            bytes_read: string_bytes.len() + LENGTH_BYTES_SIZE,
         })
     }
 


### PR DESCRIPTION
closes: #1482 

The decoder didn't report the correct number of bytes read when decoding a string slice. 

### Checklist

- [x] I have linked to any relevant issues.
- [] I have updated the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary labels.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
