### PR TITLE
chore: add change log script to the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
   "scripts/check-docs",
   "scripts/fuel-core-version",
   "scripts/versions-replacer",
+  "scripts/change-log",
   "wasm-tests",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,8 @@ trybuild = "1.0.85"
 uint = { version = "0.9.5", default-features = false }
 which = { version = "6.0.0", default-features = false }
 zeroize = "1.7.0"
+octocrab = { version = "0.39", default-features = false }
+dotenv = { version = "0.15", default-features = false }
 
 # Dependencies from the `fuel-core` repository:
 fuel-core = { version = "0.35.0", default-features = false, features = [

--- a/scripts/change-log/Cargo.toml
+++ b/scripts/change-log/Cargo.toml
@@ -1,10 +1,16 @@
 [package]
 name = "change-log"
-version = "0.1.0"
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = false
+repository = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 regex = { workspace = true }
-dotenv = "0.15"
-tokio = { workspace = true, features = ["full"] }
-octocrab = "0.39"
+dotenv = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+octocrab = { workspace = true, features = ["default"] }

--- a/scripts/change-log/src/get_latest_release.rs
+++ b/scripts/change-log/src/get_latest_release.rs
@@ -1,5 +1,5 @@
-use octocrab::Octocrab;
 use dotenv::dotenv;
+use octocrab::Octocrab;
 
 pub async fn get_latest_release_tag() -> Result<String, Box<dyn std::error::Error>> {
     dotenv().ok();

--- a/scripts/change-log/src/main.rs
+++ b/scripts/change-log/src/main.rs
@@ -1,22 +1,30 @@
 mod get_full_changelog;
 mod get_latest_release;
 
-use get_full_changelog::{get_changelogs, generate_changelog, write_changelog_to_file};
+use get_full_changelog::{generate_changelog, get_changelogs, write_changelog_to_file};
 use get_latest_release::get_latest_release_tag;
 use octocrab::Octocrab;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv::dotenv().ok();
-    let github_token = std::env::var("GITHUB_TOKEN").expect("GITHUB_TOKEN is not set in the environment");
+    let github_token =
+        std::env::var("GITHUB_TOKEN").expect("GITHUB_TOKEN is not set in the environment");
     let repo_owner = std::env::var("GITHUB_REPOSITORY_OWNER").expect("Repository owner not found");
     let repo_name = std::env::var("GITHUB_REPOSITORY_NAME").expect("Repository name not found");
-    
+
     let octocrab = Octocrab::builder().personal_token(github_token).build()?;
 
     let latest_release_tag = get_latest_release_tag().await?;
 
-    let changelogs = get_changelogs(&octocrab, &repo_owner, &repo_name, &latest_release_tag, "master").await?;
+    let changelogs = get_changelogs(
+        &octocrab,
+        &repo_owner,
+        &repo_name,
+        &latest_release_tag,
+        "master",
+    )
+    .await?;
 
     let full_changelog = generate_changelog(changelogs);
 


### PR DESCRIPTION
# Summary

The crate references the workspace but it is not part of it. In order to run it via `cargo run --bin` (and to silence the cargo warnings) we need to make it part of the workspace like the other scripts.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
