### PR TITLE
chore: update `fuel-core` to `0.36.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v2.3.6/dasel_linux_amd64
   RUSTFLAGS: "-D warnings"
-  FUEL_CORE_VERSION: 0.35.0
+  FUEL_CORE_VERSION: 0.36.0
   FUEL_CORE_PATCH_BRANCH:
   RUST_VERSION: 1.79.0
   FORC_VERSION: 0.63.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,23 +85,23 @@ octocrab = { version = "0.39", default-features = false }
 dotenv = { version = "0.15", default-features = false }
 
 # Dependencies from the `fuel-core` repository:
-fuel-core = { version = "0.35.0", default-features = false, features = [
+fuel-core = { version = "0.36.0", default-features = false, features = [
   "wasm-executor",
 ] }
-fuel-core-chain-config = { version = "0.35.0", default-features = false }
-fuel-core-client = { version = "0.35.0", default-features = false }
-fuel-core-poa = { version = "0.35.0", default-features = false }
-fuel-core-services = { version = "0.35.0", default-features = false }
-fuel-core-types = { version = "0.35.0", default-features = false }
+fuel-core-chain-config = { version = "0.36.0", default-features = false }
+fuel-core-client = { version = "0.36.0", default-features = false }
+fuel-core-poa = { version = "0.36.0", default-features = false }
+fuel-core-services = { version = "0.36.0", default-features = false }
+fuel-core-types = { version = "0.36.0", default-features = false }
 
 # Dependencies from the `fuel-vm` repository:
-fuel-asm = { version = "0.56.0" }
-fuel-crypto = { version = "0.56.0" }
-fuel-merkle = { version = "0.56.0" }
-fuel-storage = { version = "0.56.0" }
-fuel-tx = { version = "0.56.0" }
-fuel-types = { version = "0.56.0" }
-fuel-vm = { version = "0.56.0" }
+fuel-asm = { version = "0.57.0" }
+fuel-crypto = { version = "0.57.0" }
+fuel-merkle = { version = "0.57.0" }
+fuel-storage = { version = "0.57.0" }
+fuel-tx = { version = "0.57.0" }
+fuel-types = { version = "0.57.0" }
+fuel-vm = { version = "0.57.0" }
 
 # Workspace projects
 fuels = { version = "0.66.4", path = "./packages/fuels", default-features = false }

--- a/packages/fuels-accounts/src/provider/supported_fuel_core_version.rs
+++ b/packages/fuels-accounts/src/provider/supported_fuel_core_version.rs
@@ -1,1 +1,1 @@
-pub const SUPPORTED_FUEL_CORE_VERSION: semver::Version = semver::Version::new(0, 35, 0);
+pub const SUPPORTED_FUEL_CORE_VERSION: semver::Version = semver::Version::new(0, 36, 0);


### PR DESCRIPTION
# Release notes
Updated `fuel-core` to `0.36.0`

