### PR TITLE
feat: add setup_test_provider_with_relayer

### DIFF
--- a/packages/fuels-test-helpers/src/service.rs
+++ b/packages/fuels-test-helpers/src/service.rs
@@ -43,6 +43,29 @@ impl FuelService {
         })
     }
 
+    #[cfg(not(feature = "fuel-core-lib"))]
+    pub async fn start_with_relayer(
+        node_config: NodeConfig,
+        chain_config: ChainConfig,
+        state_config: StateConfig,
+        relayer_config: RelayerConfig,
+    ) -> Result<Self> {
+        let service = BinFuelService::new_node_with_relayer(
+            node_config,
+            chain_config,
+            state_config,
+            Some(relayer_config),
+        )
+        .await?;
+
+        let bound_address = service.bound_address;
+
+        Ok(FuelService {
+            service,
+            bound_address,
+        })
+    }
+
     pub async fn stop(&self) -> Result<State> {
         #[cfg(feature = "fuel-core-lib")]
         let result = self.service.send_stop_signal_and_await_shutdown().await;


### PR DESCRIPTION
Closes #1513 

# Summary

Added a fuel-test-helpers method `setup_test_provider_with_relayer` that allows to hook the provider to an Ethereum endpoint for message generation.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [ ] All **changes** are **documented** (or not applicable)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
