### PR TITLE
feat: expose loader data offset + bump default gas horizon

### DIFF
--- a/e2e/tests/scripts.rs
+++ b/e2e/tests/scripts.rs
@@ -4,6 +4,7 @@ use fuels::{
     core::{
         codec::{DecoderConfig, EncoderConfig},
         traits::Tokenizable,
+        Configurables,
     },
     prelude::*,
     programs::executable::Executable,
@@ -553,6 +554,63 @@ async fn loader_script_calling_loader_proxy() -> Result<()> {
         .await?;
 
     assert!(result.value);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn loader_can_be_presented_as_a_normal_script_with_shifted_configurables() -> Result<()> {
+    abigen!(Script(
+        abi = "e2e/sway/scripts/script_blobs/out/release/script_blobs-abi.json",
+        name = "MyScript"
+    ));
+
+    let binary_path = "./sway/scripts/script_blobs/out/release/script_blobs.bin";
+    let wallet = launch_provider_and_get_wallet().await?;
+    let provider = wallet.try_provider()?.clone();
+
+    // ANCHOR: preload_low_level
+    let regular = Executable::load_from(binary_path)?;
+
+    let configurables = MyScriptConfigurables::default().with_SECRET_NUMBER(10001)?;
+    let loader = regular.clone().convert_to_loader()?;
+
+    // The Blob must be uploaded manually, otherwise the script code will revert.
+    loader.upload_blob(wallet.clone()).await?;
+
+    let encoder = fuels::core::codec::ABIEncoder::default();
+    let token = MyStruct {
+        field_a: MyEnum::B(99),
+        field_b: Bits256([17; 32]),
+    }
+    .into_token();
+    let data = encoder.encode(&[token])?;
+
+    let configurables: Configurables = configurables.into();
+
+    let shifted_configurables = configurables
+        .with_shifted_offsets(-(regular.data_offset_in_code().unwrap() as i64))
+        .unwrap()
+        .with_shifted_offsets(loader.data_offset_in_code() as i64)
+        .unwrap();
+
+    let loader_posing_as_normal_script =
+        Executable::from_bytes(loader.code()).with_configurables(shifted_configurables);
+
+    let mut tb = ScriptTransactionBuilder::default()
+        .with_script(loader_posing_as_normal_script.code())
+        .with_script_data(data);
+
+    wallet.adjust_for_fee(&mut tb, 0).await?;
+
+    wallet.add_witnesses(&mut tb)?;
+
+    let tx = tb.build(&provider).await?;
+
+    let response = provider.send_transaction_and_await_commit(tx).await?;
+
+    response.check(None)?;
+    // ANCHOR_END: preload_low_level
 
     Ok(())
 }

--- a/e2e/tests/scripts.rs
+++ b/e2e/tests/scripts.rs
@@ -569,7 +569,6 @@ async fn loader_can_be_presented_as_a_normal_script_with_shifted_configurables()
     let wallet = launch_provider_and_get_wallet().await?;
     let provider = wallet.try_provider()?.clone();
 
-    // ANCHOR: preload_low_level
     let regular = Executable::load_from(binary_path)?;
 
     let configurables = MyScriptConfigurables::default().with_SECRET_NUMBER(10001)?;
@@ -610,7 +609,6 @@ async fn loader_can_be_presented_as_a_normal_script_with_shifted_configurables()
     let response = provider.send_transaction_and_await_commit(tx).await?;
 
     response.check(None)?;
-    // ANCHOR_END: preload_low_level
 
     Ok(())
 }

--- a/packages/fuels-core/src/lib.rs
+++ b/packages/fuels-core/src/lib.rs
@@ -5,6 +5,8 @@ mod utils;
 
 pub use utils::*;
 
+use crate::types::errors::Result;
+
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Configurables {
     offsets_with_data: Vec<(u64, Vec<u8>)>,
@@ -13,6 +15,25 @@ pub struct Configurables {
 impl Configurables {
     pub fn new(offsets_with_data: Vec<(u64, Vec<u8>)>) -> Self {
         Self { offsets_with_data }
+    }
+
+    // TODO: test
+    pub fn with_shifted_offsets(self, shift: i64) -> Result<Self> {
+        self.offsets_with_data
+            .iter()
+            .map(|(offset, data)| {
+                let offset = offset.checked_add(shift as u64).ok_or_else(|| {
+                    crate::error!(
+                        Other,
+                        "Overflow occurred while shifting offset: {} + {}",
+                        offset,
+                        shift
+                    )
+                })?;
+                Ok((offset, data.clone()))
+            })
+            .collect::<Result<Vec<_>>>()
+            .map(Self::new)
     }
 
     pub fn update_constants_in(&self, binary: &mut [u8]) {

--- a/packages/fuels-core/src/lib.rs
+++ b/packages/fuels-core/src/lib.rs
@@ -19,27 +19,103 @@ impl Configurables {
 
     // TODO: test
     pub fn with_shifted_offsets(self, shift: i64) -> Result<Self> {
-        self.offsets_with_data
-            .iter()
+        let new_offsets_with_data = self
+            .offsets_with_data
+            .into_iter()
             .map(|(offset, data)| {
-                let offset = offset.checked_add(shift as u64).ok_or_else(|| {
+                let new_offset = if shift.is_negative() {
+                    offset.checked_sub(shift.unsigned_abs())
+                } else {
+                    offset.checked_add(shift.unsigned_abs())
+                };
+
+                let new_offset = new_offset.ok_or_else(|| {
                     crate::error!(
                         Other,
-                        "Overflow occurred while shifting offset: {} + {}",
-                        offset,
-                        shift
+                        "Overflow occurred while shifting offset: {offset} + {shift}"
                     )
                 })?;
-                Ok((offset, data.clone()))
+
+                Ok((new_offset, data.clone()))
             })
-            .collect::<Result<Vec<_>>>()
-            .map(Self::new)
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Self {
+            offsets_with_data: new_offsets_with_data,
+        })
     }
 
     pub fn update_constants_in(&self, binary: &mut [u8]) {
         for (offset, data) in &self.offsets_with_data {
             let offset = *offset as usize;
             binary[offset..offset + data.len()].copy_from_slice(data)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_with_shifted_offsets_positive_shift() {
+        let offsets_with_data = vec![(10u64, vec![1, 2, 3])];
+        let configurables = Configurables::new(offsets_with_data.clone());
+        let shifted_configurables = configurables.with_shifted_offsets(5).unwrap();
+        let expected_offsets_with_data = vec![(15u64, vec![1, 2, 3])];
+        assert_eq!(
+            shifted_configurables.offsets_with_data,
+            expected_offsets_with_data
+        );
+    }
+
+    #[test]
+    fn test_with_shifted_offsets_negative_shift() {
+        let offsets_with_data = vec![(10u64, vec![4, 5, 6])];
+        let configurables = Configurables::new(offsets_with_data.clone());
+        let shifted_configurables = configurables.with_shifted_offsets(-5).unwrap();
+        let expected_offsets_with_data = vec![(5u64, vec![4, 5, 6])];
+        assert_eq!(
+            shifted_configurables.offsets_with_data,
+            expected_offsets_with_data
+        );
+    }
+
+    #[test]
+    fn test_with_shifted_offsets_zero_shift() {
+        let offsets_with_data = vec![(20u64, vec![7, 8, 9])];
+        let configurables = Configurables::new(offsets_with_data.clone());
+        let shifted_configurables = configurables.with_shifted_offsets(0).unwrap();
+        let expected_offsets_with_data = offsets_with_data;
+        assert_eq!(
+            shifted_configurables.offsets_with_data,
+            expected_offsets_with_data
+        );
+    }
+
+    #[test]
+    fn test_with_shifted_offsets_overflow() {
+        let offsets_with_data = vec![(u64::MAX - 1, vec![1, 2, 3])];
+        let configurables = Configurables::new(offsets_with_data);
+        let result = configurables.with_shifted_offsets(10);
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(e
+                .to_string()
+                .contains("Overflow occurred while shifting offset"));
+        }
+    }
+
+    #[test]
+    fn test_with_shifted_offsets_underflow() {
+        let offsets_with_data = vec![(5, vec![4, 5, 6])];
+        let configurables = Configurables::new(offsets_with_data);
+        let result = configurables.with_shifted_offsets(-10);
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(e
+                .to_string()
+                .contains("Overflow occurred while shifting offset"));
         }
     }
 }

--- a/packages/fuels-core/src/lib.rs
+++ b/packages/fuels-core/src/lib.rs
@@ -17,7 +17,6 @@ impl Configurables {
         Self { offsets_with_data }
     }
 
-    // TODO: test
     pub fn with_shifted_offsets(self, shift: i64) -> Result<Self> {
         let new_offsets_with_data = self
             .offsets_with_data

--- a/packages/fuels-core/src/types/transaction_builders.rs
+++ b/packages/fuels-core/src/types/transaction_builders.rs
@@ -22,7 +22,7 @@ use itertools::Itertools;
 use script_tx_estimator::ScriptTxEstimator;
 
 use crate::{
-    constants::{SIGNATURE_WITNESS_SIZE, WORD_SIZE},
+    constants::{DEFAULT_GAS_ESTIMATION_BLOCK_HORIZON, SIGNATURE_WITNESS_SIZE, WORD_SIZE},
     traits::Signer,
     types::{
         bech32::Bech32Address,
@@ -45,7 +45,7 @@ mod script_tx_estimator;
 
 pub use blob::*;
 
-const GAS_ESTIMATION_BLOCK_HORIZON: u32 = 1;
+const GAS_ESTIMATION_BLOCK_HORIZON: u32 = DEFAULT_GAS_ESTIMATION_BLOCK_HORIZON;
 
 #[derive(Debug, Clone, Default)]
 struct UnresolvedWitnessIndexes {

--- a/packages/fuels-core/src/utils/constants.rs
+++ b/packages/fuels-core/src/utils/constants.rs
@@ -8,7 +8,7 @@ pub const DEFAULT_CALL_PARAMS_AMOUNT: u64 = 0;
 // ANCHOR_END: default_call_parameters
 
 pub const DEFAULT_GAS_ESTIMATION_TOLERANCE: f64 = 0.2;
-pub const DEFAULT_GAS_ESTIMATION_BLOCK_HORIZON: u32 = 1;
+pub const DEFAULT_GAS_ESTIMATION_BLOCK_HORIZON: u32 = 5;
 
 // The size of a signature inside a transaction `Witness`
 pub const WITNESS_STATIC_SIZE: usize = 8;


### PR DESCRIPTION

# Release notes


In this release, we:

Loader and Regular executables now offer insight into the data section offset within.

Configurables can be shifted by a i64 offset.

Default estimation horizon bumped from 1 to 5.

# Summary

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
