### PR TITLE
chore: bump fuel-core to 0.38.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v2.3.6/dasel_linux_amd64
   RUSTFLAGS: "-D warnings"
-  FUEL_CORE_VERSION: 0.37.0
+  FUEL_CORE_VERSION: 0.38.0
   FUEL_CORE_PATCH_BRANCH: ""
   FUEL_CORE_PATCH_REVISION: ""
   RUST_VERSION: 1.79.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,14 +85,14 @@ octocrab = { version = "0.39", default-features = false }
 dotenv = { version = "0.15", default-features = false }
 
 # Dependencies from the `fuel-core` repository:
-fuel-core = { version = "0.37.0", default-features = false, features = [
+fuel-core = { version = "0.38.0", default-features = false, features = [
   "wasm-executor",
 ] }
-fuel-core-chain-config = { version = "0.37.0", default-features = false }
-fuel-core-client = { version = "0.37.0", default-features = false }
-fuel-core-poa = { version = "0.37.0", default-features = false }
-fuel-core-services = { version = "0.37.0", default-features = false }
-fuel-core-types = { version = "0.37.0", default-features = false }
+fuel-core-chain-config = { version = "0.38.0", default-features = false }
+fuel-core-client = { version = "0.38.0", default-features = false }
+fuel-core-poa = { version = "0.38.0", default-features = false }
+fuel-core-services = { version = "0.38.0", default-features = false }
+fuel-core-types = { version = "0.38.0", default-features = false }
 
 # Dependencies from the `fuel-vm` repository:
 fuel-asm = { version = "0.58.0" }

--- a/packages/fuels-accounts/src/provider/supported_fuel_core_version.rs
+++ b/packages/fuels-accounts/src/provider/supported_fuel_core_version.rs
@@ -1,1 +1,1 @@
-pub const SUPPORTED_FUEL_CORE_VERSION: semver::Version = semver::Version::new(0, 37, 0);
+pub const SUPPORTED_FUEL_CORE_VERSION: semver::Version = semver::Version::new(0, 38, 0);

--- a/packages/fuels-test-helpers/src/service.rs
+++ b/packages/fuels-test-helpers/src/service.rs
@@ -94,6 +94,7 @@ impl FuelService {
                 max_queries_complexity: 80000,
                 max_queries_recursive_depth: 16,
                 max_queries_directives: 10,
+                max_concurrent_queries: 1024,
                 request_body_bytes_limit: 16 * 1024 * 1024,
                 query_log_threshold_time: Duration::from_secs(2),
                 api_request_timeout: Duration::from_secs(60),


### PR DESCRIPTION
<!--
List the issues this PR closes (if any) in a bullet list format, e.g.:
- Closes #ABCD
- Closes #EFGH
-->

# Release notes

<!--
Use this only if this PR requires a mention in the Release
Notes Summary. Valuable features and critical fixes are good
examples. For everything else, please delete the whole section.
-->

In this release, we:

- Updated fuel-core to `0.38.0`

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
