### PR TITLE
Update main.sw

### DIFF
--- a/e2e/sway/types/contracts/b512/src/main.sw
+++ b/e2e/sway/types/contracts/b512/src/main.sw
@@ -2,9 +2,9 @@ contract;
 
 use std::b512::B512;
 
-const HI_BITS = 0xbd0c9b8792876713afa8bff383eebf31c43437823ed761cc3600d0016de5110c;
-const LO_BITS = 0x44ac566bd156b4fc71a4a4cb2655d3dd360c695edb17dc3b64d611e122fea23d;
-const LO_BITS2 = 0x54ac566bd156b4fc71a4a4cb2655d3dd360c695edb17dc3b64d611e122fea23d;
+const HI_BITS: u64 = 0xbd0c9b8792876713afa8bff383eebf31c43437823ed761cc3600d0016de5110c;
+const LO_BITS: u64 = 0x44ac566bd156b4fc71a4a4cb2655d3dd360c695edb17dc3b64d611e122fea23d;
+const LO_BITS2: u64 = 0x54ac566bd156b4fc71a4a4cb2655d3dd360c695edb17dc3b64d611e122fea23d;
 
 abi MyContract {
     fn b512_as_output() -> B512;
@@ -18,7 +18,6 @@ impl MyContract for Contract {
 
     fn b512_as_input(b512: B512) -> bool {
         let expected_b512 = B512::from((HI_BITS, LO_BITS2));
-
         b512 == expected_b512
     }
 }


### PR DESCRIPTION
Updated documentation for B512

- Renamed `Bits512` to `B512` to better align with the wider ecosystem.
- Added documentation on how to form a B512 from two B256.
- Improved examples to reflect more complex use cases.

- Closes #3241

# Release notes

In this release, we:

- Updated the documentation for B512 to enhance clarity and usability.

# Summary

This PR updates the documentation for B512 to improve understanding and usability. The changes include renaming `Bits512` to `B512`, adding missing information on how to form a B512 from two B256, and enhancing examples to illustrate more complex use cases.

# Breaking Changes

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)

<!--
List the issues this PR closes (if any) in a bullet list format, e.g.:
- Closes #ABCD
- Closes #EFGH
-->

# Release notes

<!--
Use this only if this PR requires a mention in the Release
Notes Summary. Valuable features and critical fixes are good
examples. For everything else, please delete the whole section.
-->

In this release, we:

- Did this and that <!-- edit this text only -->

# Summary

<!--
Please write a summary of your changes and why you made them.
Not all PRs will be complex or substantial enough to require this
section, so you can remove it if you think it's unnecessary.
-->

# Breaking Changes

<!--
If the PR has breaking changes, please detail them in this section
and remove this comment.

Remove this section if there are no breaking changes.
-->

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
