### PR TITLE
bug: read cargo toml instead of running cargo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ which = { version = "6.0.0", default-features = false }
 zeroize = "1.7.0"
 octocrab = { version = "0.39", default-features = false }
 dotenv = { version = "0.15", default-features = false }
+toml = { version = "0.8", default-features = false }
 
 # Dependencies from the `fuel-core` repository:
 fuel-core = { version = "0.40.0", default-features = false, features = [

--- a/scripts/fuel-core-version/Cargo.toml
+++ b/scripts/fuel-core-version/Cargo.toml
@@ -14,4 +14,4 @@ clap = { version = "4.5.3", features = ["derive"] }
 color-eyre = "0.6.2"
 fuels-accounts = { workspace = true, features = ["std"] }
 semver = { workspace = true }
-versions-replacer = { workspace = true }
+toml = { workspace = true, features = ["parse"] }

--- a/scripts/fuel-core-version/src/main.rs
+++ b/scripts/fuel-core-version/src/main.rs
@@ -1,7 +1,9 @@
+use color_eyre::eyre::OptionExt;
 use std::{
     fs,
     path::{Path, PathBuf},
 };
+use toml::Value;
 
 use clap::{Parser, Subcommand};
 use color_eyre::{
@@ -10,13 +12,6 @@ use color_eyre::{
 };
 use fuels_accounts::provider::SUPPORTED_FUEL_CORE_VERSION;
 use semver::Version;
-use versions_replacer::metadata::collect_versions_from_cargo_toml;
-
-fn get_version_from_toml(manifest_path: impl AsRef<Path>) -> Result<Version> {
-    let versions = collect_versions_from_cargo_toml(manifest_path)?;
-    let version = versions["fuel-core-types"].parse::<Version>()?;
-    Ok(version)
-}
 
 fn write_version_to_file(version: Version, version_file_path: impl AsRef<Path>) -> Result<()> {
     let Version {
@@ -74,11 +69,35 @@ fn main() -> Result<()> {
         command,
         manifest_path,
     } = App::parse();
-    let version = get_version_from_toml(&manifest_path)?;
+    let version = read_fuel_core_version(&manifest_path)?;
     let version_file_path = get_version_file_path(&manifest_path)?;
     match command {
         Command::Write => write_version_to_file(version, version_file_path)?,
         Command::Verify => verify_version_from_file(version)?,
     }
     Ok(())
+}
+
+pub fn read_fuel_core_version(path: impl AsRef<Path>) -> color_eyre::Result<Version> {
+    let cargo_toml: Value = fs::read_to_string(path.as_ref())?.parse::<Value>()?;
+
+    let str_version =
+        find_dependency_version(&cargo_toml).ok_or_eyre("could not find fuel-core version")?;
+
+    Ok(str_version.parse()?)
+}
+
+fn find_dependency_version(toml: &Value) -> Option<String> {
+    match toml
+        .get("workspace")?
+        .get("dependencies")?
+        .get("fuel-core")?
+    {
+        Value::String(version) => Some(version.clone()),
+        Value::Table(table) => table
+            .get("version")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        _ => None,
+    }
 }


### PR DESCRIPTION
- Closes: #1551 

# Summary

Now we read from the `Cargo.toml` and use that for the CI check. More details in the issue.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
