### PR TITLE
feat: `extract_contract_call_data` function pub modifier

### DIFF
--- a/packages/fuels-programs/src/calls/receipt_parser.rs
+++ b/packages/fuels-programs/src/calls/receipt_parser.rs
@@ -59,7 +59,7 @@ impl ReceiptParser {
         )
     }
 
-    fn extract_contract_call_data(&mut self, target_contract: ContractId) -> Option<Vec<u8>> {
+    pub fn extract_contract_call_data(&mut self, target_contract: ContractId) -> Option<Vec<u8>> {
         // If the script contains nested calls, we need to extract the data of the top-level call
         let mut nested_calls_stack = vec![];
 


### PR DESCRIPTION
# Summary

Made the `extract_contract_call_data` function public in the `ReceiptParser` struct to allow external access to the function.
This is required to construct low-level calls if you dont want to use `CallHandler` and instead want to manually deal with the low-level bytes (`Vec<u8>`) data.

# Checklist

- [ ] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
