### PR TITLE
`WalletUnlocked` function to expose `SecretKey` under `test-helpers` feature-flag

### DIFF
--- a/packages/fuels-accounts/Cargo.toml
+++ b/packages/fuels-accounts/Cargo.toml
@@ -44,3 +44,4 @@ std = [
   "dep:eth-keystore",
   "dep:cynic",
 ]
+test-helpers = []

--- a/packages/fuels-accounts/src/wallet.rs
+++ b/packages/fuels-accounts/src/wallet.rs
@@ -188,6 +188,12 @@ impl WalletUnlocked {
     pub fn address(&self) -> &Bech32Address {
         &self.address
     }
+
+    /// Returns the private key of the wallet. This method is only available when the 'test-helpers' feature is enabled.
+    #[cfg(feature = "test-helpers")]
+    pub fn secret_key(&self) -> &SecretKey {
+        &self.private_key
+    }
 }
 
 impl ViewOnlyAccount for WalletUnlocked {


### PR DESCRIPTION
# Release notes

- `WalletUnlocked` exposes `secret_key()` function under `test-helpers` feature-flag.

# Summary

When testing, it is useful to retrieve the secret-key of a wallet (to be used in other functions) - especially in other repos.
This PR introduces the `secret_key()` function on the `WalletUnlocked` which is only enabled under the `test-helpers` feature flag.

# Checklist

- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
