### PR TITLE
freeze gql version to 7.0.11 due to MSRV incompatibility of 7.0.12>=

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,8 @@ zeroize = "1.7.0"
 octocrab = { version = "0.39", default-features = false }
 dotenv = { version = "0.15", default-features = false }
 toml = { version = "0.8", default-features = false }
+async-graphql = { version = "=7.0.11", default-features = false }
+async-graphql-derive = { version = "=7.0.11", default-features = false }
 
 # Dependencies from the `fuel-core` repository:
 fuel-core = { version = "0.40.1", default-features = false, features = [

--- a/packages/fuels-test-helpers/Cargo.toml
+++ b/packages/fuels-test-helpers/Cargo.toml
@@ -9,6 +9,9 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 description = "Fuel Rust SDK test helpers."
 
+[package.metadata.cargo-machete]
+ignored = ["async-graphql", "async-graphql-derive"]
+
 [dependencies]
 fuel-core = { workspace = true, default-features = false, features = [
   "test-helpers",

--- a/packages/fuels-test-helpers/Cargo.toml
+++ b/packages/fuels-test-helpers/Cargo.toml
@@ -30,9 +30,20 @@ rand = { workspace = true, default-features = false }
 tempfile = { workspace = true, default-features = false }
 tokio = { workspace = true, default-features = false }
 which = { workspace = true, default-features = false }
+# fuel-core uses these deps. We need to list them here so that we can pin them
+# to =7.0.11 even though fuel-core can accepts 7.0.11 onwards. 7.0.12 bumped the
+# MSRV and broke the sdk build for users using anything less than Rust 1.81.
+#
+# Until the SDK MSRV reaches 1.81 we need to freeze these packages to 7.0.11
+async-graphql = { workspace = true, optional = true }
+async-graphql-derive = { workspace = true, optional = true }
 
 [features]
 default = ["fuels-accounts", "std"]
 std = ["fuels-accounts?/std", "fuels-core/std", "fuel-core-chain-config/std"]
-fuel-core-lib = ["dep:fuel-core"]
+fuel-core-lib = [
+  "dep:fuel-core",
+  "dep:async-graphql",
+  "dep:async-graphql-derive",
+]
 rocksdb = ["fuel-core?/rocksdb"]


### PR DESCRIPTION
Closes: #1556 

# Release notes

In this release, we:

- froze async-graphql to `7.0.11` until the SDK MSRV moves to 1.81 needed for `7.0.12` onwards.

# Summary

If you build the SDK with the `fuel-core-lib` feature *and* have a dep on `async-graphql` you'll only be able to use the version `7.0.11` until the SDK moves its MSRV to 1.81.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
