### PR TITLE
chore: propagate `test-helpers` feature flag to `fuels-accounts` from `fuels`

### DIFF
--- a/packages/fuels/Cargo.toml
+++ b/packages/fuels/Cargo.toml
@@ -26,6 +26,7 @@ fuels-test-helpers = { workspace = true, optional = true }
 [features]
 default = ["std", "fuels-test-helpers?/fuels-accounts", "coin-cache"]
 coin-cache = ["fuels-accounts/coin-cache"]
+test-helpers = ["dep:fuels-test-helpers", "fuels-accounts/test-helpers"]
 
 # The crates enabled via `dep:` below are not currently wasm compatible, as
 # such they are only available if `std` is enabled. The `dep:` syntax was


### PR DESCRIPTION
- Closes: #1559 

# Summary

Added a feature flag on `fuels` that will enable `test-helpers` on `fuels-accounts` when it itself is enabled.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
