### PR TITLE
bug!: updating consensus parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ zeroize = "1.7.0"
 octocrab = { version = "0.39", default-features = false }
 dotenv = { version = "0.15", default-features = false }
 toml = { version = "0.8", default-features = false }
+mockall = { version = "0.13", default-features = false }
 
 # Dependencies from the `fuel-core` repository:
 fuel-core = { version = "0.40.1", default-features = false, features = [

--- a/e2e/tests/contracts.rs
+++ b/e2e/tests/contracts.rs
@@ -1701,11 +1701,6 @@ async fn contract_custom_call_no_signatures_strategy() -> Result<()> {
         ),
     );
     let provider = wallet.try_provider()?;
-    let mut provider = provider.clone();
-    provider.set_cache_ttl(TtlConfig {
-        consensus_parameters: Duration::from_secs(5),
-    });
-    provider.clear_cache().await;
 
     let counter = 42;
     let call_handler = contract_instance.methods().initialize_counter(counter);

--- a/e2e/tests/contracts.rs
+++ b/e2e/tests/contracts.rs
@@ -1701,6 +1701,11 @@ async fn contract_custom_call_no_signatures_strategy() -> Result<()> {
         ),
     );
     let provider = wallet.try_provider()?;
+    let mut provider = provider.clone();
+    provider.set_cache_ttl(TtlConfig {
+        consensus_parameters: Duration::from_secs(5),
+    });
+    provider.clear_cache().await;
 
     let counter = 42;
     let call_handler = contract_instance.methods().initialize_counter(counter);

--- a/e2e/tests/predicates.rs
+++ b/e2e/tests/predicates.rs
@@ -240,9 +240,10 @@ async fn pay_with_predicate() -> Result<()> {
 
     // TODO: https://github.com/FuelLabs/fuels-rs/issues/1394
     let expected_fee = 1;
+    let consensus_parameters = provider.consensus_parameters().await?;
     assert_eq!(
         predicate
-            .get_asset_balance(provider.base_asset_id())
+            .get_asset_balance(consensus_parameters.base_asset_id())
             .await?,
         192 - expected_fee
     );
@@ -258,7 +259,7 @@ async fn pay_with_predicate() -> Result<()> {
     let expected_fee = 2;
     assert_eq!(
         predicate
-            .get_asset_balance(provider.base_asset_id())
+            .get_asset_balance(consensus_parameters.base_asset_id())
             .await?,
         191 - expected_fee
     );
@@ -309,9 +310,10 @@ async fn pay_with_predicate_vector_data() -> Result<()> {
 
     // TODO: https://github.com/FuelLabs/fuels-rs/issues/1394
     let expected_fee = 1;
+    let consensus_parameters = provider.consensus_parameters().await?;
     assert_eq!(
         predicate
-            .get_asset_balance(provider.base_asset_id())
+            .get_asset_balance(consensus_parameters.base_asset_id())
             .await?,
         192 - expected_fee
     );
@@ -327,7 +329,7 @@ async fn pay_with_predicate_vector_data() -> Result<()> {
     assert_eq!(42, response.value);
     assert_eq!(
         predicate
-            .get_asset_balance(provider.base_asset_id())
+            .get_asset_balance(consensus_parameters.base_asset_id())
             .await?,
         191 - expected_fee
     );
@@ -849,9 +851,14 @@ async fn predicate_transfer_non_base_asset() -> Result<()> {
     let inputs = predicate
         .get_asset_inputs_for_amount(non_base_asset_id, amount, None)
         .await?;
+    let consensus_parameters = provider.consensus_parameters().await?;
     let outputs = vec![
         Output::change(wallet.address().into(), 0, non_base_asset_id),
-        Output::change(wallet.address().into(), 0, *provider.base_asset_id()),
+        Output::change(
+            wallet.address().into(),
+            0,
+            *consensus_parameters.base_asset_id(),
+        ),
     ];
 
     let mut tb = ScriptTransactionBuilder::prepare_transfer(
@@ -982,14 +989,16 @@ async fn tx_id_not_changed_after_adding_witnesses() -> Result<()> {
     .build(&provider)
     .await?;
 
-    let tx_id = tx.id(provider.chain_id());
+    let consensus_parameters = provider.consensus_parameters().await?;
+    let chain_id = consensus_parameters.chain_id();
+    let tx_id = tx.id(chain_id);
 
     let witness = ABIEncoder::default().encode(&[64u64.into_token()])?; // u64 because this is VM memory
     let witness2 = ABIEncoder::default().encode(&[4096u64.into_token()])?;
 
     tx.append_witness(witness.into())?;
     tx.append_witness(witness2.into())?;
-    let tx_id_after_witnesses = tx.id(provider.chain_id());
+    let tx_id_after_witnesses = tx.id(chain_id);
 
     let tx_id_from_provider = provider.send_transaction(tx).await?;
 

--- a/examples/contracts/src/lib.rs
+++ b/examples/contracts/src/lib.rs
@@ -1017,6 +1017,7 @@ mod tests {
         )?;
         let max_allowed = provider
             .consensus_parameters()
+            .await?
             .contract_params()
             .contract_max_size();
 
@@ -1105,11 +1106,19 @@ mod tests {
         // ANCHOR_END: use_loader
 
         // ANCHOR: show_max_tx_size
-        provider.consensus_parameters().tx_params().max_size();
+        provider
+            .consensus_parameters()
+            .await?
+            .tx_params()
+            .max_size();
         // ANCHOR_END: show_max_tx_size
 
         // ANCHOR: show_max_tx_gas
-        provider.consensus_parameters().tx_params().max_gas_per_tx();
+        provider
+            .consensus_parameters()
+            .await?
+            .tx_params()
+            .max_gas_per_tx();
         // ANCHOR_END: show_max_tx_gas
 
         let wallet = main_wallet;

--- a/examples/cookbook/src/lib.rs
+++ b/examples/cookbook/src/lib.rs
@@ -163,6 +163,7 @@ mod tests {
         // ANCHOR: transfer_multiple_input
         let balances = wallet_1.get_balances().await?;
 
+        let consensus_parameters = provider.consensus_parameters().await?;
         let mut inputs = vec![];
         let mut outputs = vec![];
         for (id_string, amount) in balances {
@@ -174,7 +175,7 @@ mod tests {
             inputs.extend(input);
 
             // we don't transfer the full base asset so we can cover fees
-            let output = if id == *provider.base_asset_id() {
+            let output = if id == *consensus_parameters.base_asset_id() {
                 wallet_1.get_asset_outputs_for_amount(wallet_2.address(), id, amount / 2)
             } else {
                 wallet_1.get_asset_outputs_for_amount(wallet_2.address(), id, amount)
@@ -197,7 +198,7 @@ mod tests {
 
         assert_eq!(balances.len(), NUM_ASSETS as usize);
         for (id, balance) in balances {
-            if id == provider.base_asset_id().to_string() {
+            if id == *consensus_parameters.base_asset_id().to_string() {
                 assert_eq!(balance, AMOUNT / 2);
             } else {
                 assert_eq!(balance, AMOUNT);
@@ -269,12 +270,13 @@ mod tests {
         // ANCHOR_END: custom_tx
 
         // ANCHOR: custom_tx_io_base
+        let consensus_parameters = provider.consensus_parameters().await?;
         let base_inputs = hot_wallet
-            .get_asset_inputs_for_amount(*provider.base_asset_id(), ask_amount, None)
+            .get_asset_inputs_for_amount(*consensus_parameters.base_asset_id(), ask_amount, None)
             .await?;
         let base_outputs = hot_wallet.get_asset_outputs_for_amount(
             &receiver,
-            *provider.base_asset_id(),
+            *consensus_parameters.base_asset_id(),
             ask_amount,
         );
         // ANCHOR_END: custom_tx_io_base

--- a/examples/providers/src/lib.rs
+++ b/examples/providers/src/lib.rs
@@ -71,8 +71,9 @@ mod tests {
         // ANCHOR_END: setup_test_blockchain
 
         // ANCHOR: get_coins
+        let consensus_parameters = provider.consensus_parameters().await?;
         let coins = provider
-            .get_coins(wallet.address(), *provider.base_asset_id())
+            .get_coins(wallet.address(), *consensus_parameters.base_asset_id())
             .await?;
         assert_eq!(coins.len(), 1);
         // ANCHOR_END: get_coins

--- a/packages/fuels-accounts/Cargo.toml
+++ b/packages/fuels-accounts/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { workspace = true, features = ["full"], optional = true }
 zeroize = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
+mockall = { workspace = true, default-features = false }
 fuel-tx = { workspace = true, features = ["test-helpers", "random"] }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }

--- a/packages/fuels-accounts/src/account.rs
+++ b/packages/fuels-accounts/src/account.rs
@@ -126,15 +126,16 @@ pub trait ViewOnlyAccount: std::fmt::Debug + Send + Sync + Clone {
         used_base_amount: u64,
     ) -> Result<()> {
         let provider = self.try_provider()?;
+        let consensus_parameters = provider.consensus_parameters().await?;
         let (base_assets, base_amount) =
-            available_base_assets_and_amount(tb, provider.base_asset_id());
+            available_base_assets_and_amount(tb, consensus_parameters.base_asset_id());
         let missing_base_amount =
             calculate_missing_base_amount(tb, base_amount, used_base_amount, provider).await?;
 
         if missing_base_amount > 0 {
             let new_base_inputs = self
                 .get_asset_inputs_for_amount(
-                    *provider.base_asset_id(),
+                    *consensus_parameters.base_asset_id(),
                     missing_base_amount,
                     Some(base_assets),
                 )
@@ -144,7 +145,7 @@ pub trait ViewOnlyAccount: std::fmt::Debug + Send + Sync + Clone {
                 tb,
                 new_base_inputs,
                 self.address(),
-                provider.base_asset_id(),
+                consensus_parameters.base_asset_id(),
             );
         };
 
@@ -181,7 +182,8 @@ pub trait Account: ViewOnlyAccount {
 
         self.add_witnesses(&mut tx_builder)?;
 
-        let used_base_amount = if asset_id == *provider.base_asset_id() {
+        let consensus_parameters = provider.consensus_parameters().await?;
+        let used_base_amount = if asset_id == *consensus_parameters.base_asset_id() {
             amount
         } else {
             0
@@ -190,7 +192,7 @@ pub trait Account: ViewOnlyAccount {
             .await?;
 
         let tx = tx_builder.build(provider).await?;
-        let tx_id = tx.id(provider.chain_id());
+        let tx_id = tx.id(consensus_parameters.chain_id());
 
         let tx_status = provider.send_transaction_and_await_commit(tx).await?;
 
@@ -253,7 +255,8 @@ pub trait Account: ViewOnlyAccount {
 
         let tx = tb.build(provider).await?;
 
-        let tx_id = tx.id(provider.chain_id());
+        let consensus_parameters = provider.consensus_parameters().await?;
+        let tx_id = tx.id(consensus_parameters.chain_id());
         let tx_status = provider.send_transaction_and_await_commit(tx).await?;
 
         let receipts = tx_status.take_receipts_checked(None)?;
@@ -271,9 +274,10 @@ pub trait Account: ViewOnlyAccount {
         tx_policies: TxPolicies,
     ) -> Result<(TxId, Nonce, Vec<Receipt>)> {
         let provider = self.try_provider()?;
+        let consensus_parameters = provider.consensus_parameters().await?;
 
         let inputs = self
-            .get_asset_inputs_for_amount(*provider.base_asset_id(), amount, None)
+            .get_asset_inputs_for_amount(*consensus_parameters.base_asset_id(), amount, None)
             .await?;
 
         let mut tb = ScriptTransactionBuilder::prepare_message_to_output(
@@ -281,7 +285,7 @@ pub trait Account: ViewOnlyAccount {
             amount,
             inputs,
             tx_policies,
-            *provider.base_asset_id(),
+            *consensus_parameters.base_asset_id(),
         );
 
         self.add_witnesses(&mut tb)?;
@@ -289,7 +293,7 @@ pub trait Account: ViewOnlyAccount {
 
         let tx = tb.build(provider).await?;
 
-        let tx_id = tx.id(provider.chain_id());
+        let tx_id = tx.id(consensus_parameters.chain_id());
         let tx_status = provider.send_transaction_and_await_commit(tx).await?;
 
         let receipts = tx_status.take_receipts_checked(None)?;
@@ -361,8 +365,8 @@ mod tests {
             })
         }
 
-        fn consensus_parameters(&self) -> &ConsensusParameters {
-            &self.c_param
+        async fn consensus_parameters(&self) -> Result<ConsensusParameters> {
+            Ok(self.c_param.clone())
         }
 
         async fn estimate_gas_price(&self, _block_header: u32) -> Result<u64> {

--- a/packages/fuels-accounts/src/provider.rs
+++ b/packages/fuels-accounts/src/provider.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "coin-cache")]
 use std::sync::Arc;
-use std::{collections::HashMap, fmt::Debug, net::SocketAddr, time::Duration};
+use std::{collections::HashMap, fmt::Debug, net::SocketAddr};
 
 mod cache;
 mod retry_util;

--- a/packages/fuels-accounts/src/provider.rs
+++ b/packages/fuels-accounts/src/provider.rs
@@ -129,7 +129,6 @@ impl Provider {
         Self::connect(format!("http://{addr}")).await
     }
 
-    /// To be applied to future requests, call [`clear_cache`] if you need to clear the cache.
     pub fn set_cache_ttl(&mut self, ttl: TtlConfig) {
         self.cached_client.set_ttl(ttl);
     }

--- a/packages/fuels-accounts/src/provider/cache.rs
+++ b/packages/fuels-accounts/src/provider/cache.rs
@@ -21,6 +21,14 @@ pub struct TtlConfig {
     pub consensus_parameters: Duration,
 }
 
+impl Default for TtlConfig {
+    fn default() -> Self {
+        TtlConfig {
+            consensus_parameters: Duration::from_secs(60),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 struct Dated<T> {
     value: T,
@@ -60,12 +68,26 @@ impl<Client, Clock> CachedClient<Client, Clock> {
         }
     }
 
+    /// To be applied going forward
+    pub fn set_ttl(&mut self, ttl: TtlConfig) {
+        self.ttl_config = ttl
+    }
+
     pub fn inner(&self) -> &Client {
         &self.client
     }
 
     pub fn inner_mut(&mut self) -> &mut Client {
         &mut self.client
+    }
+}
+
+impl<Client, Clk> CachedClient<Client, Clk>
+where
+    Client: CacheableRpcs,
+{
+    pub async fn clear(&self) {
+        let _ = self.cached_consensus_params.write().await.take();
     }
 }
 

--- a/packages/fuels-accounts/src/provider/cache.rs
+++ b/packages/fuels-accounts/src/provider/cache.rs
@@ -1,0 +1,225 @@
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use fuel_tx::ConsensusParameters;
+use fuels_core::types::errors::Result;
+use tokio::sync::RwLock;
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait CacheableRpcs {
+    async fn consensus_parameters(&self) -> Result<ConsensusParameters>;
+}
+
+trait Clock {
+    fn now(&self) -> DateTime<Utc>;
+}
+
+#[derive(Debug, Clone)]
+pub struct TtlConfig {
+    pub consensus_parameters: Duration,
+}
+
+#[derive(Debug, Clone)]
+struct Dated<T> {
+    value: T,
+    date: DateTime<Utc>,
+    ttl: Duration,
+}
+
+impl<T> Dated<T> {
+    fn is_stale(&self, now: DateTime<Utc>) -> bool {
+        self.date + self.ttl < now
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SystemClock;
+impl Clock for SystemClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CachedClient<Client, Clock = SystemClock> {
+    client: Client,
+    ttl_config: TtlConfig,
+    cached_consensus_params: Arc<RwLock<Option<Dated<ConsensusParameters>>>>,
+    clock: Clock,
+}
+
+impl<Client, Clock> CachedClient<Client, Clock> {
+    pub fn new(client: Client, ttl: TtlConfig, clock: Clock) -> Self {
+        Self {
+            client,
+            ttl_config: ttl,
+            cached_consensus_params: Default::default(),
+            clock,
+        }
+    }
+
+    pub fn inner(&self) -> &Client {
+        &self.client
+    }
+
+    pub fn inner_mut(&mut self) -> &mut Client {
+        &mut self.client
+    }
+}
+
+#[async_trait]
+impl<Client, Clk> CacheableRpcs for CachedClient<Client, Clk>
+where
+    Clk: Clock + Send + Sync,
+    Client: CacheableRpcs + Send + Sync,
+{
+    async fn consensus_parameters(&self) -> Result<ConsensusParameters> {
+        {
+            let read_lock = self.cached_consensus_params.read().await;
+            if let Some(entry) = read_lock.as_ref() {
+                if !entry.is_stale(self.clock.now()) {
+                    return Ok(entry.value.clone());
+                }
+            }
+        }
+
+        let mut write_lock = self.cached_consensus_params.write().await;
+
+        // because it could have been updated since we last checked
+        if let Some(entry) = write_lock.as_ref() {
+            if !entry.is_stale(self.clock.now()) {
+                return Ok(entry.value.clone());
+            }
+        }
+
+        let fresh_parameters = self.client.consensus_parameters().await?;
+        *write_lock = Some(Dated {
+            value: fresh_parameters.clone(),
+            date: self.clock.now(),
+            ttl: self.ttl_config.consensus_parameters,
+        });
+
+        Ok(fresh_parameters)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use fuel_types::ChainId;
+
+    use super::*;
+
+    #[derive(Clone, Default)]
+    struct TestClock {
+        time: Arc<Mutex<DateTime<Utc>>>,
+    }
+
+    impl TestClock {
+        fn update_time(&self, time: DateTime<Utc>) {
+            *self.time.lock().unwrap() = time;
+        }
+    }
+
+    impl Clock for TestClock {
+        fn now(&self) -> DateTime<Utc> {
+            *self.time.lock().unwrap()
+        }
+    }
+
+    #[tokio::test]
+    async fn initial_call_to_consensus_params_fwd_to_api() {
+        // given
+        let mut api = MockCacheableRpcs::new();
+        api.expect_consensus_parameters()
+            .once()
+            .return_once(|| Ok(ConsensusParameters::default()));
+        let sut = CachedClient::new(
+            api,
+            TtlConfig {
+                consensus_parameters: Duration::from_secs(10),
+            },
+            TestClock::default(),
+        );
+
+        // when
+        let _consensus_params = sut.consensus_parameters().await.unwrap();
+
+        // then
+        // mock validates the call went through
+    }
+
+    #[tokio::test]
+    async fn new_call_to_consensus_params_cached() {
+        // given
+        let mut api = MockCacheableRpcs::new();
+        api.expect_consensus_parameters()
+            .once()
+            .return_once(|| Ok(ConsensusParameters::default()));
+        let sut = CachedClient::new(
+            api,
+            TtlConfig {
+                consensus_parameters: Duration::from_secs(10),
+            },
+            TestClock::default(),
+        );
+        let consensus_parameters = sut.consensus_parameters().await.unwrap();
+
+        // when
+        let second_call_consensus_params = sut.consensus_parameters().await.unwrap();
+
+        // then
+        // mock validates only one call
+        assert_eq!(consensus_parameters, second_call_consensus_params);
+    }
+
+    #[tokio::test]
+    async fn if_ttl_expired_cache_is_updated() {
+        // given
+        let original_consensus_params = ConsensusParameters::default();
+
+        let changed_consensus_params = {
+            let mut params = original_consensus_params.clone();
+            params.set_chain_id(ChainId::new(99));
+            params
+        };
+
+        let api = {
+            let mut api = MockCacheableRpcs::new();
+            let original_consensus_params = original_consensus_params.clone();
+            let changed_consensus_params = changed_consensus_params.clone();
+            api.expect_consensus_parameters()
+                .once()
+                .return_once(move || Ok(original_consensus_params));
+
+            api.expect_consensus_parameters()
+                .once()
+                .return_once(move || Ok(changed_consensus_params));
+            api
+        };
+
+        let clock = TestClock::default();
+        let start_time = clock.now();
+
+        let sut = CachedClient::new(
+            api,
+            TtlConfig {
+                consensus_parameters: Duration::from_secs(10),
+            },
+            clock.clone(),
+        );
+        let consensus_parameters = sut.consensus_parameters().await.unwrap();
+
+        clock.update_time(start_time + Duration::from_secs(11));
+        // when
+        let second_call_consensus_params = sut.consensus_parameters().await.unwrap();
+
+        // then
+        // mock validates two calls made
+        assert_eq!(consensus_parameters, original_consensus_params);
+        assert_eq!(second_call_consensus_params, changed_consensus_params);
+    }
+}

--- a/packages/fuels-core/src/types/dry_runner.rs
+++ b/packages/fuels-core/src/types/dry_runner.rs
@@ -25,7 +25,7 @@ impl DryRun {
 pub trait DryRunner: Send + Sync {
     async fn dry_run(&self, tx: FuelTransaction) -> Result<DryRun>;
     async fn estimate_gas_price(&self, block_horizon: u32) -> Result<u64>;
-    fn consensus_parameters(&self) -> &ConsensusParameters;
+    async fn consensus_parameters(&self) -> Result<ConsensusParameters>;
     async fn maybe_estimate_predicates(
         &self,
         tx: &FuelTransaction,
@@ -44,8 +44,8 @@ impl<T: DryRunner> DryRunner for &T {
         (*self).estimate_gas_price(block_horizon).await
     }
 
-    fn consensus_parameters(&self) -> &ConsensusParameters {
-        (*self).consensus_parameters()
+    async fn consensus_parameters(&self) -> Result<ConsensusParameters> {
+        (*self).consensus_parameters().await
     }
 
     async fn maybe_estimate_predicates(

--- a/packages/fuels-core/src/types/transaction_builders.rs
+++ b/packages/fuels-core/src/types/transaction_builders.rs
@@ -226,7 +226,7 @@ macro_rules! impl_tx_builder_trait {
                     tx.estimate_predicates(&provider, None).await?;
                 }
 
-                let consensus_parameters = provider.consensus_parameters();
+                let consensus_parameters = provider.consensus_parameters().await?;
 
                 let gas_price = provider
                     .estimate_gas_price(self.gas_price_estimation_block_horizon)
@@ -236,7 +236,7 @@ macro_rules! impl_tx_builder_trait {
                     tx.tx,
                     self.max_fee_estimation_tolerance,
                     gas_price,
-                    consensus_parameters,
+                    &consensus_parameters,
                 )
             }
 
@@ -369,13 +369,13 @@ macro_rules! impl_tx_builder_trait {
                 }
 
                 let gas_price = provider.estimate_gas_price(block_horizon).await?;
-                let consensus_parameters = provider.consensus_parameters();
+                let consensus_parameters = provider.consensus_parameters().await?;
 
                 let max_fee = $crate::types::transaction_builders::estimate_max_fee_w_tolerance(
                     wrapper_tx.tx,
                     max_fee_estimation_tolerance,
                     gas_price,
-                    consensus_parameters,
+                    &consensus_parameters,
                 )?;
 
                 tx.policies_mut().set(PolicyType::MaxFee, Some(max_fee));
@@ -705,14 +705,16 @@ impl ScriptTransactionBuilder {
             .await?;
         }
 
-        script_tx_estimator.prepare_for_estimation(&mut tx, should_saturate_variable_outputs);
+        script_tx_estimator
+            .prepare_for_estimation(&mut tx, should_saturate_variable_outputs)
+            .await?;
 
         Ok(tx)
     }
 
     async fn set_witnesses(self, tx: &mut fuel_tx::Script, provider: impl DryRunner) -> Result<()> {
         let missing_witnesses = generate_missing_witnesses(
-            tx.id(&provider.consensus_parameters().chain_id()),
+            tx.id(&provider.consensus_parameters().await?.chain_id()),
             &self.unresolved_signers,
         )
         .await?;
@@ -946,7 +948,7 @@ impl CreateTransactionBuilder {
     }
 
     async fn resolve_fuel_tx(self, provider: impl DryRunner) -> Result<Create> {
-        let chain_id = provider.consensus_parameters().chain_id();
+        let chain_id = provider.consensus_parameters().await?.chain_id();
         let num_witnesses = self.num_witnesses()?;
         let policies = self.generate_fuel_policies()?;
         let is_using_predicates = self.is_using_predicates();
@@ -1069,7 +1071,7 @@ impl UploadTransactionBuilder {
     }
 
     async fn resolve_fuel_tx(self, provider: impl DryRunner) -> Result<Upload> {
-        let chain_id = provider.consensus_parameters().chain_id();
+        let chain_id = provider.consensus_parameters().await?.chain_id();
         let num_witnesses = self.num_witnesses()?;
         let policies = self.generate_fuel_policies()?;
         let is_using_predicates = self.is_using_predicates();
@@ -1202,7 +1204,7 @@ impl UpgradeTransactionBuilder {
     }
 
     async fn resolve_fuel_tx(self, provider: impl DryRunner) -> Result<Upgrade> {
-        let chain_id = provider.consensus_parameters().chain_id();
+        let chain_id = provider.consensus_parameters().await?.chain_id();
         let num_witnesses = self.num_witnesses()?;
         let policies = self.generate_fuel_policies()?;
         let is_using_predicates = self.is_using_predicates();
@@ -1574,8 +1576,8 @@ mod tests {
             })
         }
 
-        fn consensus_parameters(&self) -> &ConsensusParameters {
-            &self.c_param
+        async fn consensus_parameters(&self) -> Result<ConsensusParameters> {
+            Ok(self.c_param.clone())
         }
 
         async fn estimate_gas_price(&self, _block_horizon: u32) -> Result<u64> {

--- a/packages/fuels-core/src/types/transaction_builders/blob.rs
+++ b/packages/fuels-core/src/types/transaction_builders/blob.rs
@@ -130,8 +130,14 @@ impl BlobTransactionBuilder {
             .await?;
 
         let current_tx_size = tx.size();
-        let max_tx_size = usize::try_from(provider.consensus_parameters().tx_params().max_size())
-            .unwrap_or(usize::MAX);
+        let max_tx_size = usize::try_from(
+            provider
+                .consensus_parameters()
+                .await?
+                .tx_params()
+                .max_size(),
+        )
+        .unwrap_or(usize::MAX);
 
         Ok(max_tx_size.saturating_sub(current_tx_size))
     }
@@ -170,7 +176,7 @@ impl BlobTransactionBuilder {
     }
 
     async fn resolve_fuel_tx(mut self, provider: &impl DryRunner) -> Result<fuel_tx::Blob> {
-        let chain_id = provider.consensus_parameters().chain_id();
+        let chain_id = provider.consensus_parameters().await?.chain_id();
 
         let free_witness_index = self.num_witnesses()?;
         let body = self.blob.as_blob_body(free_witness_index);

--- a/packages/fuels-programs/src/calls/call_handler.rs
+++ b/packages/fuels-programs/src/calls/call_handler.rs
@@ -166,7 +166,9 @@ where
         let tx = self.build_tx().await?;
         let provider = self.account.try_provider()?;
 
-        self.cached_tx_id = Some(tx.id(provider.chain_id()));
+        let consensus_parameters = provider.consensus_parameters().await?;
+        let chain_id = consensus_parameters.chain_id();
+        self.cached_tx_id = Some(tx.id(chain_id));
 
         let tx_status = provider.send_transaction_and_await_commit(tx).await?;
 
@@ -425,8 +427,10 @@ where
         let tx = self.build_tx().await?;
 
         let provider = self.account.try_provider()?;
+        let consensus_parameters = provider.consensus_parameters().await?;
+        let chain_id = consensus_parameters.chain_id();
 
-        self.cached_tx_id = Some(tx.id(provider.chain_id()));
+        self.cached_tx_id = Some(tx.id(chain_id));
 
         let tx_status = provider.send_transaction_and_await_commit(tx).await?;
 

--- a/packages/fuels-programs/src/contract/regular.rs
+++ b/packages/fuels-programs/src/contract/regular.rs
@@ -212,6 +212,7 @@ impl Contract<Regular> {
         let provider = account.try_provider()?;
         let max_contract_size = provider
             .consensus_parameters()
+            .await?
             .contract_params()
             .contract_max_size() as usize;
 

--- a/packages/fuels-test-helpers/src/accounts.rs
+++ b/packages/fuels-test-helpers/src/accounts.rs
@@ -105,11 +105,14 @@ mod tests {
 
         let wallets = launch_custom_provider_and_get_wallets(config, None, None).await?;
         let provider = wallets.first().unwrap().try_provider()?;
+        let consensus_parameters = provider.consensus_parameters().await?;
 
         assert_eq!(wallets.len(), num_wallets as usize);
 
         for wallet in &wallets {
-            let coins = wallet.get_coins(*provider.base_asset_id()).await?;
+            let coins = wallet
+                .get_coins(*consensus_parameters.base_asset_id())
+                .await?;
 
             assert_eq!(coins.len(), num_coins as usize);
 
@@ -224,6 +227,7 @@ mod tests {
                 wallet
                     .try_provider()?
                     .consensus_parameters()
+                    .await?
                     .tx_params()
                     .max_gas_per_tx(),
                 max_gas_per_tx

--- a/packages/fuels-test-helpers/src/lib.rs
+++ b/packages/fuels-test-helpers/src/lib.rs
@@ -344,9 +344,9 @@ mod tests {
         };
         let provider = setup_test_provider(vec![], vec![], None, Some(chain_config)).await?;
 
-        let retrieved_parameters = provider.consensus_parameters();
+        let retrieved_parameters = provider.consensus_parameters().await?;
 
-        assert_eq!(*retrieved_parameters, consensus_parameters);
+        assert_eq!(retrieved_parameters, consensus_parameters);
 
         Ok(())
     }


### PR DESCRIPTION
- Closes #1561 
# Release notes


In this release, we:

- Made the `ConsensusParameters` cache expire-able in `Provider`

# Summary

The `Provider` now evicts the cached `ConsensusParameters` after the preconfigured TTL (defaulted to 60s).

You can change the TTL by doing:
```rust
    provider.set_cache_ttl(TtlConfig {
        consensus_parameters: Duration::from_secs(5),
    });
```

If you want to clear the cache immediately you can do so by:
```rust
    provider.clear_cache().await;
```

# Breaking Changes

The `consensus_parameters` method in `Provider` is now `async` and fallable:
```rust
    pub async fn consensus_parameters(&self) -> Result<ConsensusParameters>
```

The following methods have been removed:
- `base_asset_id` -- now acquired by `provider.consensus_parameters().await?.base_asset_id()`
- `chain_id` -- now acquired by `provider.consensus_parameters().await?.chain_id()`

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
