### PR TITLE
chore!: remove option return from predicate estimation

### DIFF
--- a/packages/fuels-accounts/src/account.rs
+++ b/packages/fuels-accounts/src/account.rs
@@ -373,12 +373,12 @@ mod tests {
             Ok(0)
         }
 
-        async fn maybe_estimate_predicates(
+        async fn estimate_predicates(
             &self,
             _: &FuelTransaction,
             _: Option<u32>,
-        ) -> Result<Option<FuelTransaction>> {
-            Ok(None)
+        ) -> Result<FuelTransaction> {
+            unimplemented!()
         }
     }
 

--- a/packages/fuels-accounts/src/provider.rs
+++ b/packages/fuels-accounts/src/provider.rs
@@ -869,14 +869,12 @@ impl DryRunner for Provider {
         Ok(self.estimate_gas_price(block_horizon).await?.gas_price)
     }
 
-    async fn maybe_estimate_predicates(
+    async fn estimate_predicates(
         &self,
         tx: &FuelTransaction,
         _latest_chain_executor_version: Option<u32>,
-    ) -> Result<Option<FuelTransaction>> {
-        // We always delegate the estimation to the client because estimating locally is no longer
-        // possible due to the need of blob storage
-        Ok(Some(self.uncached_client().estimate_predicates(tx).await?))
+    ) -> Result<FuelTransaction> {
+        Ok(self.uncached_client().estimate_predicates(tx).await?)
     }
 
     async fn consensus_parameters(&self) -> Result<ConsensusParameters> {

--- a/packages/fuels-core/src/types/dry_runner.rs
+++ b/packages/fuels-core/src/types/dry_runner.rs
@@ -26,11 +26,11 @@ pub trait DryRunner: Send + Sync {
     async fn dry_run(&self, tx: FuelTransaction) -> Result<DryRun>;
     async fn estimate_gas_price(&self, block_horizon: u32) -> Result<u64>;
     async fn consensus_parameters(&self) -> Result<ConsensusParameters>;
-    async fn maybe_estimate_predicates(
+    async fn estimate_predicates(
         &self,
         tx: &FuelTransaction,
         latest_chain_executor_version: Option<u32>,
-    ) -> Result<Option<FuelTransaction>>;
+    ) -> Result<FuelTransaction>;
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -48,13 +48,13 @@ impl<T: DryRunner> DryRunner for &T {
         (*self).consensus_parameters().await
     }
 
-    async fn maybe_estimate_predicates(
+    async fn estimate_predicates(
         &self,
         tx: &FuelTransaction,
         latest_chain_executor_version: Option<u32>,
-    ) -> Result<Option<FuelTransaction>> {
+    ) -> Result<FuelTransaction> {
         (*self)
-            .maybe_estimate_predicates(tx, latest_chain_executor_version)
+            .estimate_predicates(tx, latest_chain_executor_version)
             .await
     }
 }

--- a/packages/fuels-core/src/types/transaction_builders.rs
+++ b/packages/fuels-core/src/types/transaction_builders.rs
@@ -1584,12 +1584,12 @@ mod tests {
             Ok(0)
         }
 
-        async fn maybe_estimate_predicates(
+        async fn estimate_predicates(
             &self,
             _tx: &FuelTransaction,
             _: Option<u32>,
-        ) -> Result<Option<FuelTransaction>> {
-            Ok(None)
+        ) -> Result<FuelTransaction> {
+            unimplemented!("")
         }
     }
 

--- a/packages/fuels-core/src/types/wrappers/transaction.rs
+++ b/packages/fuels-core/src/types/wrappers/transaction.rs
@@ -548,19 +548,11 @@ impl EstimablePredicates for UploadTransaction {
         provider: impl DryRunner,
         latest_chain_executor_version: Option<u32>,
     ) -> Result<()> {
-        if let Some(tx) = provider
-            .maybe_estimate_predicates(&self.tx.clone().into(), latest_chain_executor_version)
-            .await?
-        {
-            tx.as_upload().expect("is upload").clone_into(&mut self.tx);
-        } else {
-            // We no longer estimate locally since we don't have the blob storage.
-            // maybe_estimate_predicates should always return an estimation
-            return Err(error!(
-                Other,
-                "Should have been given an estimation from the node. This is a bug."
-            ));
-        }
+        let tx = provider
+            .estimate_predicates(&self.tx.clone().into(), latest_chain_executor_version)
+            .await?;
+
+        tx.as_upload().expect("is upload").clone_into(&mut self.tx);
 
         Ok(())
     }
@@ -574,21 +566,13 @@ impl EstimablePredicates for UpgradeTransaction {
         provider: impl DryRunner,
         latest_chain_executor_version: Option<u32>,
     ) -> Result<()> {
-        if let Some(tx) = provider
-            .maybe_estimate_predicates(&self.tx.clone().into(), latest_chain_executor_version)
-            .await?
-        {
-            tx.as_upgrade()
-                .expect("is upgrade")
-                .clone_into(&mut self.tx);
-        } else {
-            // We no longer estimate locally since we don't have the blob storage.
-            // maybe_estimate_predicates should always return an estimation
-            return Err(error!(
-                Other,
-                "Should have been given an estimation from the node. This is a bug."
-            ));
-        }
+        let tx = provider
+            .estimate_predicates(&self.tx.clone().into(), latest_chain_executor_version)
+            .await?;
+
+        tx.as_upgrade()
+            .expect("is upgrade")
+            .clone_into(&mut self.tx);
 
         Ok(())
     }
@@ -602,19 +586,11 @@ impl EstimablePredicates for CreateTransaction {
         provider: impl DryRunner,
         latest_chain_executor_version: Option<u32>,
     ) -> Result<()> {
-        if let Some(tx) = provider
-            .maybe_estimate_predicates(&self.tx.clone().into(), latest_chain_executor_version)
-            .await?
-        {
-            tx.as_create().expect("is create").clone_into(&mut self.tx);
-        } else {
-            // We no longer estimate locally since we don't have the blob storage.
-            // maybe_estimate_predicates should always return an estimation
-            return Err(error!(
-                Other,
-                "Should have been given an estimation from the node. This is a bug."
-            ));
-        }
+        let tx = provider
+            .estimate_predicates(&self.tx.clone().into(), latest_chain_executor_version)
+            .await?;
+
+        tx.as_create().expect("is create").clone_into(&mut self.tx);
 
         Ok(())
     }
@@ -642,19 +618,11 @@ impl EstimablePredicates for ScriptTransaction {
         provider: impl DryRunner,
         latest_chain_executor_version: Option<u32>,
     ) -> Result<()> {
-        if let Some(tx) = provider
-            .maybe_estimate_predicates(&self.tx.clone().into(), latest_chain_executor_version)
-            .await?
-        {
-            tx.as_script().expect("is script").clone_into(&mut self.tx);
-        } else {
-            // We no longer estimate locally since we don't have the blob storage.
-            // maybe_estimate_predicates should always return an estimation
-            return Err(error!(
-                Other,
-                "Should have been given an estimation from the node. This is a bug."
-            ));
-        }
+        let tx = provider
+            .estimate_predicates(&self.tx.clone().into(), latest_chain_executor_version)
+            .await?;
+
+        tx.as_script().expect("is script").clone_into(&mut self.tx);
 
         Ok(())
     }
@@ -668,19 +636,11 @@ impl EstimablePredicates for BlobTransaction {
         provider: impl DryRunner,
         latest_chain_executor_version: Option<u32>,
     ) -> Result<()> {
-        if let Some(tx) = provider
-            .maybe_estimate_predicates(&self.tx.clone().into(), latest_chain_executor_version)
-            .await?
-        {
-            tx.as_blob().expect("is blob").clone_into(&mut self.tx);
-        } else {
-            // We no longer estimate locally since we don't have the blob storage.
-            // maybe_estimate_predicates should always return an estimation
-            return Err(error!(
-                Other,
-                "Should have been given an estimation from the node. This is a bug."
-            ));
-        }
+        let tx = provider
+            .estimate_predicates(&self.tx.clone().into(), latest_chain_executor_version)
+            .await?;
+
+        tx.as_blob().expect("is blob").clone_into(&mut self.tx);
 
         Ok(())
     }


### PR DESCRIPTION
# Release notes


In this release, we:

- `estimate_predicates` no longer returns an option

# Summary

At one point we stopped estimating predicates locally due to not having blobs available to dry run the predicates with. We couldn't break the API at that point so we always returned `Some(tx)`. 

We now remove the `Option` from the API

# Breaking Changes

`maybe_estimate_predicates` renamed to `estimate_predicates` and the return type changed from `Result<Option<Tx>>` to `Result<tx>`.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x]  I **described** all **Breaking Changes** (or there's none)
