### PR TITLE
fix: message with data exluded in `adjust_for_fee`

### DIFF
--- a/e2e/tests/predicates.rs
+++ b/e2e/tests/predicates.rs
@@ -805,9 +805,9 @@ async fn predicate_adjust_fee_persists_message_w_data() -> Result<()> {
     let mut tb = ScriptTransactionBuilder::prepare_transfer(
         vec![message_input.clone()],
         vec![],
-        TxPolicies::default().with_tip(1),
+        TxPolicies::default(),
     );
-    predicate.adjust_for_fee(&mut tb, 1000).await?;
+    predicate.adjust_for_fee(&mut tb, 0).await?;
 
     let tx = tb.build(&provider).await?;
 

--- a/e2e/tests/wallets.rs
+++ b/e2e/tests/wallets.rs
@@ -1,4 +1,7 @@
-use fuels::{prelude::*, types::output::Output};
+use fuels::{
+    prelude::*,
+    types::{coin_type::CoinType, input::Input, output::Output},
+};
 
 #[tokio::test]
 async fn test_wallet_balance_api_multi_asset() -> Result<()> {
@@ -101,6 +104,46 @@ async fn adjust_fee_empty_transaction() -> Result<()> {
     )];
 
     assert_eq!(tx.outputs(), &expected_outputs);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn adjust_for_fee_with_message_data_input() -> Result<()> {
+    let mut wallet = WalletUnlocked::new_random(None);
+    let mut reciever = WalletUnlocked::new_random(None);
+
+    let messages = setup_single_message(
+        &Bech32Address::default(),
+        wallet.address(),
+        100,
+        0.into(),
+        vec![1, 2, 3], // has data
+    );
+    let asset_id = AssetId::zeroed();
+    let coins = setup_single_asset_coins(wallet.address(), asset_id, 1, 100);
+    let provider = setup_test_provider(coins, vec![messages], None, None).await?;
+    wallet.set_provider(provider.clone());
+    reciever.set_provider(provider.clone());
+
+    let amount_to_send = 14;
+    let message = wallet.get_messages().await?.pop().unwrap();
+    let input = Input::resource_signed(CoinType::Message(message));
+    let outputs = wallet.get_asset_outputs_for_amount(reciever.address(), asset_id, amount_to_send);
+
+    let mut tb =
+        ScriptTransactionBuilder::prepare_transfer(vec![input], outputs, TxPolicies::default());
+
+    tb.add_signer(wallet.clone())?;
+    wallet.adjust_for_fee(&mut tb, 0).await?;
+
+    let tx = tb.build(wallet.try_provider()?).await?;
+
+    assert_eq!(reciever.get_asset_balance(&asset_id).await?, 0);
+
+    provider.send_transaction_and_await_commit(tx).await?;
+
+    assert_eq!(reciever.get_asset_balance(&asset_id).await?, amount_to_send);
 
     Ok(())
 }

--- a/e2e/tests/wallets.rs
+++ b/e2e/tests/wallets.rs
@@ -111,7 +111,7 @@ async fn adjust_fee_empty_transaction() -> Result<()> {
 #[tokio::test]
 async fn adjust_for_fee_with_message_data_input() -> Result<()> {
     let mut wallet = WalletUnlocked::new_random(None);
-    let mut reciever = WalletUnlocked::new_random(None);
+    let mut receiver = WalletUnlocked::new_random(None);
 
     let messages = setup_single_message(
         &Bech32Address::default(),
@@ -124,12 +124,12 @@ async fn adjust_for_fee_with_message_data_input() -> Result<()> {
     let coins = setup_single_asset_coins(wallet.address(), asset_id, 1, 100);
     let provider = setup_test_provider(coins, vec![messages], None, None).await?;
     wallet.set_provider(provider.clone());
-    reciever.set_provider(provider.clone());
+    receiver.set_provider(provider.clone());
 
     let amount_to_send = 14;
     let message = wallet.get_messages().await?.pop().unwrap();
     let input = Input::resource_signed(CoinType::Message(message));
-    let outputs = wallet.get_asset_outputs_for_amount(reciever.address(), asset_id, amount_to_send);
+    let outputs = wallet.get_asset_outputs_for_amount(receiver.address(), asset_id, amount_to_send);
 
     let mut tb =
         ScriptTransactionBuilder::prepare_transfer(vec![input], outputs, TxPolicies::default());
@@ -139,11 +139,11 @@ async fn adjust_for_fee_with_message_data_input() -> Result<()> {
 
     let tx = tb.build(wallet.try_provider()?).await?;
 
-    assert_eq!(reciever.get_asset_balance(&asset_id).await?, 0);
+    assert_eq!(receiver.get_asset_balance(&asset_id).await?, 0);
 
     provider.send_transaction_and_await_commit(tx).await?;
 
-    assert_eq!(reciever.get_asset_balance(&asset_id).await?, amount_to_send);
+    assert_eq!(receiver.get_asset_balance(&asset_id).await?, amount_to_send);
 
     Ok(())
 }

--- a/packages/fuels-accounts/src/accounts_utils.rs
+++ b/packages/fuels-accounts/src/accounts_utils.rs
@@ -57,7 +57,7 @@ pub fn available_base_assets_and_amount(
                         resource.id()
                     }
                     CoinType::Message(message) => {
-                        sum += message.amount;
+                        sum += message.amount; // TODO: @hal3e not if the message has data!
                         resource.id()
                     }
                     _ => None,

--- a/packages/fuels-accounts/src/accounts_utils.rs
+++ b/packages/fuels-accounts/src/accounts_utils.rs
@@ -57,8 +57,13 @@ pub fn available_base_assets_and_amount(
                         resource.id()
                     }
                     CoinType::Message(message) => {
-                        sum += message.amount; // TODO: @hal3e not if the message has data!
-                        resource.id()
+                        if message.data.is_empty() {
+                            sum += message.amount;
+
+                            resource.id()
+                        } else {
+                            None
+                        }
                     }
                     _ => None,
                 },


### PR DESCRIPTION
# Summary

`adjust_for_fee` should not count messages with data as spendable inputs.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
