### PR TITLE
bug: script/predicate blob upload now uses the default max fee estimation tolerance

### DIFF
--- a/e2e/tests/contracts.rs
+++ b/e2e/tests/contracts.rs
@@ -7,6 +7,7 @@ use fuel_tx::{
 use fuels::{
     core::codec::{calldata, encode_fn_selector, DecoderConfig, EncoderConfig},
     prelude::*,
+    programs::DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE,
     tx::ContractParameters,
     types::{errors::transaction::Reason, input::Input, Bits256, Identity},
 };
@@ -2114,8 +2115,8 @@ async fn max_fee_estimation_respects_tolerance() -> Result<()> {
                 .unwrap();
 
             assert_eq!(
-                builder.max_fee_estimation_tolerance, 0.05,
-                "Expected pre-set tolerance of 0.05"
+                builder.max_fee_estimation_tolerance, DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE,
+                "Expected pre-set tolerance"
             );
 
             builder

--- a/packages/fuels-accounts/src/provider.rs
+++ b/packages/fuels-accounts/src/provider.rs
@@ -758,7 +758,7 @@ impl Provider {
         let receipts = self.dry_run_opt(tx, false, None).await?.take_receipts();
         let gas_used = self.get_script_gas_used(&receipts);
 
-        Ok((gas_used as f64 * (1.0 + tolerance)) as u64)
+        Ok((gas_used as f64 * (1.0 + tolerance)).ceil() as u64)
     }
 
     fn get_script_gas_used(&self, receipts: &[Receipt]) -> u64 {

--- a/packages/fuels-core/src/types/dry_runner.rs
+++ b/packages/fuels-core/src/types/dry_runner.rs
@@ -16,7 +16,7 @@ impl DryRun {
     pub fn gas_with_tolerance(&self, tolerance: f32) -> u64 {
         let gas_used = self.script_gas as f64;
         let adjusted_gas = gas_used * (1.0 + f64::from(tolerance));
-        adjusted_gas as u64
+        adjusted_gas.ceil() as u64
     }
 }
 

--- a/packages/fuels-core/src/types/transaction_builders.rs
+++ b/packages/fuels-core/src/types/transaction_builders.rs
@@ -456,7 +456,7 @@ pub(crate) fn estimate_max_fee_w_tolerance<T: Chargeable>(
 
     let max_fee_w_tolerance = tx_fee.max_fee() as f64 * (1.0 + f64::from(tolerance));
 
-    Ok(max_fee_w_tolerance as u64)
+    Ok(max_fee_w_tolerance.ceil() as u64)
 }
 
 impl Debug for dyn Signer + Send + Sync {

--- a/packages/fuels-programs/src/calls/traits/transaction_tuner.rs
+++ b/packages/fuels-programs/src/calls/traits/transaction_tuner.rs
@@ -7,9 +7,12 @@ use fuels_core::types::{
     },
 };
 
-use crate::calls::{
-    utils::{build_tx_from_contract_calls, sealed, transaction_builder_from_contract_calls},
-    ContractCall, ScriptCall,
+use crate::{
+    calls::{
+        utils::{build_tx_from_contract_calls, sealed, transaction_builder_from_contract_calls},
+        ContractCall, ScriptCall,
+    },
+    DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE,
 };
 
 #[async_trait::async_trait]
@@ -79,8 +82,8 @@ impl TransactionTuner for ScriptCall {
             .with_script_data(self.compute_script_data()?)
             .with_inputs(inputs)
             .with_outputs(outputs)
-            .with_gas_estimation_tolerance(0.05)
-            .with_max_fee_estimation_tolerance(0.05))
+            .with_gas_estimation_tolerance(DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE)
+            .with_max_fee_estimation_tolerance(DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE))
     }
 
     async fn build_tx<T: Account>(

--- a/packages/fuels-programs/src/calls/utils.rs
+++ b/packages/fuels-programs/src/calls/utils.rs
@@ -22,6 +22,7 @@ use itertools::{chain, Itertools};
 use crate::{
     assembly::contract_call::{CallOpcodeParamsOffset, ContractCallInstructions},
     calls::ContractCall,
+    DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE,
 };
 
 pub(crate) mod sealed {
@@ -73,8 +74,8 @@ pub(crate) async fn transaction_builder_from_contract_calls(
         .with_script_data(script_data.clone())
         .with_inputs(inputs)
         .with_outputs(outputs)
-        .with_gas_estimation_tolerance(0.05)
-        .with_max_fee_estimation_tolerance(0.05))
+        .with_gas_estimation_tolerance(DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE)
+        .with_max_fee_estimation_tolerance(DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE))
 }
 
 /// Creates a [`ScriptTransaction`] from contract calls. The internal [Transaction] is

--- a/packages/fuels-programs/src/contract/loader.rs
+++ b/packages/fuels-programs/src/contract/loader.rs
@@ -12,7 +12,7 @@ use fuels_core::{
     },
 };
 
-use crate::assembly::contract_call::loader_contract_asm;
+use crate::{assembly::contract_call::loader_contract_asm, DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE};
 
 use super::{compute_contract_id_and_state_root, Contract, Regular};
 
@@ -138,7 +138,7 @@ impl Contract<Loader<BlobsNotUploaded>> {
             let mut tb = BlobTransactionBuilder::default()
                 .with_blob(blob)
                 .with_tx_policies(tx_policies)
-                .with_max_fee_estimation_tolerance(0.05);
+                .with_max_fee_estimation_tolerance(DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE);
 
             account.adjust_for_fee(&mut tb, 0).await?;
             account.add_witnesses(&mut tb)?;

--- a/packages/fuels-programs/src/contract/regular.rs
+++ b/packages/fuels-programs/src/contract/regular.rs
@@ -14,6 +14,8 @@ use fuels_core::{
     Configurables,
 };
 
+use crate::DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE;
+
 use super::{
     compute_contract_id_and_state_root, validate_path_and_extension, BlobsNotUploaded, Contract,
     Loader, StorageConfiguration,
@@ -152,7 +154,7 @@ impl Contract<Regular> {
             storage_slots.to_vec(),
             tx_policies,
         )
-        .with_max_fee_estimation_tolerance(0.05);
+        .with_max_fee_estimation_tolerance(DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE);
 
         account.add_witnesses(&mut tb)?;
         account.adjust_for_fee(&mut tb, 0).await?;

--- a/packages/fuels-programs/src/executable.rs
+++ b/packages/fuels-programs/src/executable.rs
@@ -6,7 +6,10 @@ use fuels_core::{
     Configurables,
 };
 
-use crate::assembly::script_and_predicate_loader::{extract_data_offset, LoaderCode};
+use crate::{
+    assembly::script_and_predicate_loader::{extract_data_offset, LoaderCode},
+    DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE,
+};
 
 /// This struct represents a standard executable with its associated bytecode and configurables.
 #[derive(Debug, Clone, PartialEq)]
@@ -151,7 +154,9 @@ impl Executable<Loader> {
             return Ok(());
         }
 
-        let mut tb = BlobTransactionBuilder::default().with_blob(self.blob());
+        let mut tb = BlobTransactionBuilder::default()
+            .with_blob(self.blob())
+            .with_max_fee_estimation_tolerance(DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE);
 
         account.adjust_for_fee(&mut tb, 0).await?;
 

--- a/packages/fuels-programs/src/lib.rs
+++ b/packages/fuels-programs/src/lib.rs
@@ -7,7 +7,7 @@ pub mod executable;
 #[cfg(feature = "std")]
 pub mod responses;
 
-pub const DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE: f32 = 0.10;
+pub const DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE: f32 = 0.50;
 
 pub mod debug;
 

--- a/packages/fuels-programs/src/lib.rs
+++ b/packages/fuels-programs/src/lib.rs
@@ -7,6 +7,8 @@ pub mod executable;
 #[cfg(feature = "std")]
 pub mod responses;
 
+pub const DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE: f32 = 0.10;
+
 pub mod debug;
 
 pub(crate) mod assembly;


### PR DESCRIPTION
- Closes: #1589 
# Release notes

In this release, we:

- added max fee estimation tolerance to `ScriptCallHandler`'s `convert_into_loader` to reduce the occurrence of invalid max fees.

# Summary

`ScriptCallHandler::convert_into_loader` and `Executable::upload_blob` now use the default max fee estimation tolerance when building the blob tx. This should lessen the occurrence of invalid max fees due to using a different amount of coins than what we estimated with.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
