### PR TITLE
bug: backport msg w data fee adjustment fix

### DIFF
--- a/e2e/tests/predicates.rs
+++ b/e2e/tests/predicates.rs
@@ -805,9 +805,9 @@ async fn predicate_adjust_fee_persists_message_w_data() -> Result<()> {
     let mut tb = ScriptTransactionBuilder::prepare_transfer(
         vec![message_input.clone()],
         vec![],
-        TxPolicies::default().with_tip(1),
+        TxPolicies::default(),
     );
-    predicate.adjust_for_fee(&mut tb, 1000).await?;
+    predicate.adjust_for_fee(&mut tb, 0).await?;
 
     let tx = tb.build(&provider).await?;
 

--- a/packages/fuels-accounts/src/accounts_utils.rs
+++ b/packages/fuels-accounts/src/accounts_utils.rs
@@ -57,8 +57,13 @@ pub fn available_base_assets_and_amount(
                         resource.id()
                     }
                     CoinType::Message(message) => {
-                        sum += message.amount;
-                        resource.id()
+                        if message.data.is_empty() {
+                            sum += message.amount;
+
+                            resource.id()
+                        } else {
+                            None
+                        }
                     }
                     _ => None,
                 },


### PR DESCRIPTION
Pure cherry pick, no additional changes. 

# Release notes

In this release, we:

- Backported a fix that doesn't take into account messages with data as assets that can cover gas fees.



# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
