### PR TITLE
feat: add context to `Result`

### DIFF
--- a/packages/fuels-core/src/types/errors.rs
+++ b/packages/fuels-core/src/types/errors.rs
@@ -1,6 +1,4 @@
 pub mod transaction {
-    use std::fmt::Display;
-
     #[derive(thiserror::Error, Debug, Clone)]
     pub enum Reason {
         #[error("builder: {0}")]
@@ -20,7 +18,7 @@ pub mod transaction {
     }
 
     impl Reason {
-        pub(crate) fn context(self, context: impl Display) -> Self {
+        pub(crate) fn context(self, context: impl std::fmt::Display) -> Self {
             match self {
                 Reason::Builder(msg) => Reason::Builder(format!("{context}: {msg}")),
                 Reason::Validation(msg) => Reason::Validation(format!("{context}: {msg}")),

--- a/packages/fuels-core/src/types/errors.rs
+++ b/packages/fuels-core/src/types/errors.rs
@@ -75,6 +75,18 @@ impl Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Provides `context` and `with_context` to `Result`.
+///
+/// # Examples
+/// ```
+/// use fuels_core::types:: errors::{Context, Error, Result};
+///
+/// let res_with_context: Result<()> =
+/// Err(Error::Other("some error".to_owned())).context("some context");
+///
+/// let res_with_context: Result<()> =
+/// Err(Error::Other("some error".to_owned())).with_context(|| "some context");
+/// ```
 pub trait Context<T>: Sealed {
     fn context<C>(self, context: C) -> Result<T>
     where

--- a/packages/fuels-core/src/types/errors.rs
+++ b/packages/fuels-core/src/types/errors.rs
@@ -40,6 +40,9 @@ pub mod transaction {
     }
 }
 
+use crate::sealed::Sealed;
+use std::fmt::Display;
+
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum Error {
     #[error("io: {0}")]
@@ -114,8 +117,6 @@ macro_rules! error {
     $crate::types::errors::Error::$err_variant(format!($fmt_str,$($arg),*))
    }
 }
-use std::fmt::Display;
-
 pub use error;
 
 /// This macro can only be used for `Error::Transaction` variants that have a `String` field.
@@ -128,8 +129,6 @@ macro_rules! error_transaction {
    }
 }
 pub use error_transaction;
-
-use crate::sealed::Sealed;
 
 impl From<fuel_vm::checked_transaction::CheckError> for Error {
     fn from(err: fuel_vm::checked_transaction::CheckError) -> Error {

--- a/packages/fuels-core/src/types/errors.rs
+++ b/packages/fuels-core/src/types/errors.rs
@@ -1,4 +1,6 @@
 pub mod transaction {
+    use std::fmt::Display;
+
     #[derive(thiserror::Error, Debug, Clone)]
     pub enum Reason {
         #[error("builder: {0}")]
@@ -15,6 +17,26 @@ pub mod transaction {
         },
         #[error(": {0}")]
         Other(String),
+    }
+
+    impl Reason {
+        pub(crate) fn context(self, context: impl Display) -> Self {
+            match self {
+                Reason::Builder(msg) => Reason::Builder(format!("{context}: {msg}")),
+                Reason::Validation(msg) => Reason::Validation(format!("{context}: {msg}")),
+                Reason::SqueezedOut(msg) => Reason::SqueezedOut(format!("{context}: {msg}")),
+                Reason::Reverted {
+                    reason,
+                    revert_id,
+                    receipts,
+                } => Reason::Reverted {
+                    reason: format!("{context}: {reason}"),
+                    revert_id,
+                    receipts,
+                },
+                Reason::Other(msg) => Reason::Other(format!("{context}: {msg}")),
+            }
+        }
     }
 }
 
@@ -38,7 +60,51 @@ impl From<std::io::Error> for Error {
     }
 }
 
+impl Error {
+    pub(crate) fn context(self, context: impl Display) -> Self {
+        match self {
+            Error::IO(msg) => Error::IO(format!("{context}: {msg}")),
+            Error::Codec(msg) => Error::Codec(format!("{context}: {msg}")),
+            Error::Transaction(reason) => Error::Transaction(reason.context(context)),
+            Error::Provider(msg) => Error::Provider(format!("{context}: {msg}")),
+            Error::Other(msg) => Error::Other(format!("{context}: {msg}")),
+        }
+    }
+}
+
 pub type Result<T> = std::result::Result<T, Error>;
+
+pub trait Context<T>: Sealed {
+    fn context<C>(self, context: C) -> Result<T>
+    where
+        C: Display + Send + Sync + 'static;
+
+    fn with_context<C, F>(self, f: F) -> Result<T>
+    where
+        C: Display + Send + Sync + 'static,
+        F: FnOnce() -> C;
+}
+
+impl<T> Sealed for Result<T> {}
+
+impl<T> Context<T> for Result<T> {
+    /// Wrap the error value with additional context
+    fn context<C>(self, context: C) -> Result<T>
+    where
+        C: Display + Send + Sync + 'static,
+    {
+        self.map_err(|e| e.context(context))
+    }
+
+    /// Wrap the error value with additional context that is evaluated lazily
+    fn with_context<C, F>(self, context: F) -> Result<T>
+    where
+        C: Display + Send + Sync + 'static,
+        F: FnOnce() -> C,
+    {
+        self.context(context())
+    }
+}
 
 /// This macro can only be used for `Error` variants that have a `String` field.
 /// Those are: `IO`, `Codec`, `Provider`, `Other`.
@@ -48,6 +114,8 @@ macro_rules! error {
     $crate::types::errors::Error::$err_variant(format!($fmt_str,$($arg),*))
    }
 }
+use std::fmt::Display;
+
 pub use error;
 
 /// This macro can only be used for `Error::Transaction` variants that have a `String` field.
@@ -60,6 +128,8 @@ macro_rules! error_transaction {
    }
 }
 pub use error_transaction;
+
+use crate::sealed::Sealed;
 
 impl From<fuel_vm::checked_transaction::CheckError> for Error {
     fn from(err: fuel_vm::checked_transaction::CheckError) -> Error {
@@ -91,3 +161,52 @@ impl_error_from!(Other, hex::FromHexError);
 impl_error_from!(Other, std::array::TryFromSliceError);
 impl_error_from!(Other, std::str::Utf8Error);
 impl_error_from!(Other, fuel_abi_types::error::Error);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn result_context() {
+        {
+            let res_with_context: Result<()> =
+                Err(error!(Provider, "some error")).context("some context");
+
+            assert_eq!(
+                res_with_context.unwrap_err().to_string(),
+                "provider: some context: some error",
+            );
+        }
+        {
+            let res_with_context: Result<()> =
+                Err(error_transaction!(Builder, "some error")).context("some context");
+
+            assert_eq!(
+                res_with_context.unwrap_err().to_string(),
+                "transaction builder: some context: some error"
+            );
+        }
+    }
+
+    #[test]
+    fn result_with_context() {
+        {
+            let res_with_context: Result<()> =
+                Err(error!(Other, "some error")).with_context(|| "some context");
+
+            assert_eq!(
+                res_with_context.unwrap_err().to_string(),
+                "some context: some error",
+            );
+        }
+        {
+            let res_with_context: Result<()> =
+                Err(error_transaction!(Validation, "some error")).with_context(|| "some context");
+
+            assert_eq!(
+                res_with_context.unwrap_err().to_string(),
+                "transaction validation: some context: some error"
+            );
+        }
+    }
+}


### PR DESCRIPTION
# Summary
Adds `context` and `with_context` to `Result` - based on `anyhows`'s `Context` trait.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
