### PR TITLE
chore: pin `base64ct` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ rust-version = "1.81.0"
 version = "0.70.0"
 
 [workspace.dependencies]
-base64ct = "1.6.0"
+base64ct = "=1.6.0"
 Inflector = "0.11.4"
 anyhow = { version = "1.0", default-features = false }
 dialoguer = { version = "0.11", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ version = "0.70.0"
 
 [workspace.dependencies]
 #TODO: [issue](https://github.com/FuelLabs/fuels-rs/issues/1609)
-base64ct = "=1.6.0"
+base64ct = "<1.7.0"
 Inflector = "0.11.4"
 anyhow = { version = "1.0", default-features = false }
 dialoguer = { version = "0.11", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ rust-version = "1.81.0"
 version = "0.70.0"
 
 [workspace.dependencies]
+#TODO: [issue](https://github.com/FuelLabs/fuels-rs/issues/1609)
+base64ct = "=1.6.0"
 Inflector = "0.11.4"
 anyhow = { version = "1.0", default-features = false }
 dialoguer = { version = "0.11", default-features = false }
@@ -117,4 +119,3 @@ fuels-macros = { version = "0.70.0", path = "./packages/fuels-macros", default-f
 fuels-programs = { version = "0.70.0", path = "./packages/fuels-programs", default-features = false }
 fuels-test-helpers = { version = "0.70.0", path = "./packages/fuels-test-helpers", default-features = false }
 versions-replacer = { version = "0.70.0", path = "./scripts/versions-replacer", default-features = false }
-base64ct = "=1.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ rust-version = "1.81.0"
 version = "0.70.0"
 
 [workspace.dependencies]
+base64ct = "1.6.0"
 Inflector = "0.11.4"
 anyhow = { version = "1.0", default-features = false }
 dialoguer = { version = "0.11", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ rust-version = "1.81.0"
 version = "0.70.0"
 
 [workspace.dependencies]
-base64ct = "=1.6.0"
 Inflector = "0.11.4"
 anyhow = { version = "1.0", default-features = false }
 dialoguer = { version = "0.11", default-features = false }
@@ -118,3 +117,4 @@ fuels-macros = { version = "0.70.0", path = "./packages/fuels-macros", default-f
 fuels-programs = { version = "0.70.0", path = "./packages/fuels-programs", default-features = false }
 fuels-test-helpers = { version = "0.70.0", path = "./packages/fuels-test-helpers", default-features = false }
 versions-replacer = { version = "0.70.0", path = "./scripts/versions-replacer", default-features = false }
+base64ct = "=1.6.0"

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 build = "build.rs"
 
 [dev-dependencies]
+#TODO: [issue](https://github.com/FuelLabs/fuels-rs/issues/1609)
 base64ct = "=1.6.0"
 # used in test assertions
 chrono = { workspace = true }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 build = "build.rs"
 
 [dev-dependencies]
+base64ct = "=1.6.0"
 # used in test assertions
 chrono = { workspace = true }
 fuel-asm = { workspace = true }


### PR DESCRIPTION
our CI is failing because `base64ct` version `1.7.0` is requiring cargo feature called `edition2024`
