### PR TITLE
bug: fallback to single large request if no indexation available

### DIFF
--- a/packages/fuels-accounts/src/provider/cache.rs
+++ b/packages/fuels-accounts/src/provider/cache.rs
@@ -128,10 +128,12 @@ where
     }
 
     async fn node_info(&self) -> Result<NodeInfo> {
+        // must borrow from consensus_parameters to keep the change non-breaking
+        let ttl = self.ttl_config.consensus_parameters;
         {
             let read_lock = self.cached_node_info.read().await;
             if let Some(entry) = read_lock.as_ref() {
-                if !entry.is_stale(self.clock.now(), self.ttl_config.consensus_parameters) {
+                if !entry.is_stale(self.clock.now(), ttl) {
                     return Ok(entry.value.clone());
                 }
             }
@@ -141,7 +143,7 @@ where
 
         // because it could have been updated since we last checked
         if let Some(entry) = write_lock.as_ref() {
-            if !entry.is_stale(self.clock.now(), self.ttl_config.consensus_parameters) {
+            if !entry.is_stale(self.clock.now(), ttl) {
                 return Ok(entry.value.clone());
             }
         }

--- a/packages/fuels-accounts/src/provider/retryable_client.rs
+++ b/packages/fuels-accounts/src/provider/retryable_client.rs
@@ -50,7 +50,11 @@ pub(crate) struct RetryableClient {
 #[async_trait]
 impl CacheableRpcs for RetryableClient {
     async fn consensus_parameters(&self) -> Result<ConsensusParameters> {
-        Ok(self.client.chain_info().await?.consensus_parameters)
+        Ok(self.chain_info().await?.consensus_parameters)
+    }
+
+    async fn node_info(&self) -> Result<NodeInfo> {
+        Ok(self.node_info().await?)
     }
 }
 


### PR DESCRIPTION
Closes: #1615 

# Release notes

In this release, we:

- added a fallback for querying balances when indexation is not supported

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
