### PR TITLE
chore: update public key recovery example in docs

### DIFF
--- a/packages/fuels-accounts/src/signers/private_key.rs
+++ b/packages/fuels-accounts/src/signers/private_key.rs
@@ -110,7 +110,7 @@ mod tests {
         );
 
         // Recover the public key that signed the message
-        let recovered_pub_key = signature.recover(&message)?;
+        let recovered_pub_key: PublicKey = signature.recover(&message)?;
 
         assert_eq!(signer.address().hash(), recovered_pub_key.hash());
 

--- a/packages/fuels-accounts/src/signers/private_key.rs
+++ b/packages/fuels-accounts/src/signers/private_key.rs
@@ -109,13 +109,13 @@ mod tests {
             )?
         );
 
-        // Recover address that signed the message
-        let recovered_address = signature.recover(&message)?;
+        // Recover the public key that signed the message
+        let recovered_pub_key = signature.recover(&message)?;
 
-        assert_eq!(signer.address().hash(), recovered_address.hash());
+        assert_eq!(signer.address().hash(), recovered_pub_key.hash());
 
         // Verify signature
-        signature.verify(&recovered_address, &message)?;
+        signature.verify(&recovered_pub_key, &message)?;
         // ANCHOR_END: sign_message
 
         Ok(())


### PR DESCRIPTION
# Summary

<!--
Please write a summary of your changes and why you made them.
Not all PRs will be complex or substantial enough to require this
section, so you can remove it if you think it's unnecessary.
-->

When viewing the [docs hub example](https://docs.fuel.network/docs/fuels-rs/wallets/signing/#signing) on how to recover a public key, the variable name provided is `recovered_address`. This is misleading and leads to confusion as the recovered type is a `PublicKey` https://github.com/FuelLabs/fuel-vm/blob/09c500838b734603970c62d414e0e95825f44773/fuel-crypto/src/secp256/signature.rs#L140C56-L140C65. This has been updated to a more appropriate name.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
