### PR TITLE
Add possibility to place a predefined gas amount for predicate

### DIFF
--- a/packages/fuels-core/src/types/wrappers/input.rs
+++ b/packages/fuels-core/src/types/wrappers/input.rs
@@ -16,6 +16,7 @@ pub enum Input {
         resource: CoinType,
         code: Vec<u8>,
         data: Vec<u8>,
+        gas_used: u64,
     },
     Contract {
         utxo_id: UtxoId,
@@ -36,6 +37,21 @@ impl Input {
             resource,
             code,
             data,
+            gas_used: 0,
+        }
+    }
+
+    pub const fn resource_predicate_with_gas(
+        resource: CoinType,
+        code: Vec<u8>,
+        data: Vec<u8>,
+        gas_used: u64,
+    ) -> Self {
+        Self::ResourcePredicate {
+            resource,
+            code,
+            data,
+            gas_used,
         }
     }
 


### PR DESCRIPTION
Useful to be forced to `estimate_predicates` and let the user define it if he wants. Tried to make it non-breaking by using a new constructor (I don't know if the new field in the enum variant is considered breaking)

# Release notes

In this release, we:

- Added a new constructor for `Input`:  `resource_predicate_with_gas` to let user place a predefined amount 

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
