### PR TITLE
chore!: remove `CoinStatus` and `block_created` from `Coin`

### DIFF
--- a/packages/fuels-core/src/types/wrappers/coin.rs
+++ b/packages/fuels-core/src/types/wrappers/coin.rs
@@ -8,32 +8,21 @@ use fuel_core_client::client::types::{
 
 use crate::types::bech32::Bech32Address;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
-pub enum CoinStatus {
-    #[default]
-    Unspent,
-    Spent,
-}
-
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct Coin {
     pub amount: u64,
-    pub block_created: u32,
     pub asset_id: AssetId,
     pub utxo_id: UtxoId,
     pub owner: Bech32Address,
-    pub status: CoinStatus,
 }
 
 impl From<ClientCoin> for Coin {
     fn from(coin: ClientCoin) -> Self {
         Self {
             amount: coin.amount,
-            block_created: coin.block_created,
             asset_id: coin.asset_id,
             utxo_id: coin.utxo_id,
             owner: Bech32Address::from(coin.owner),
-            status: CoinStatus::Unspent,
         }
     }
 }
@@ -43,11 +32,10 @@ impl From<Coin> for CoinConfig {
         Self {
             tx_id: *coin.utxo_id.tx_id(),
             output_index: coin.utxo_id.output_index(),
-            tx_pointer_block_height: coin.block_created.into(),
-            tx_pointer_tx_idx: Default::default(),
             owner: coin.owner.into(),
             amount: coin.amount,
             asset_id: coin.asset_id,
+            ..Default::default()
         }
     }
 }

--- a/packages/fuels-programs/src/calls/utils.rs
+++ b/packages/fuels-programs/src/calls/utils.rs
@@ -345,11 +345,7 @@ mod test {
     use std::slice;
 
     use fuels_accounts::signers::private_key::PrivateKeySigner;
-    use fuels_core::types::{
-        coin::{Coin, CoinStatus},
-        coin_type::CoinType,
-        param_types::ParamType,
-    };
+    use fuels_core::types::{coin::Coin, coin_type::CoinType, param_types::ParamType};
     use rand::{Rng, thread_rng};
 
     use super::*;
@@ -526,11 +522,9 @@ mod test {
             .map(|asset_id| {
                 let coin = CoinType::Coin(Coin {
                     amount: 100,
-                    block_created: 0u32,
                     asset_id,
                     utxo_id: Default::default(),
                     owner: Default::default(),
-                    status: CoinStatus::Unspent,
                 });
                 Input::resource_signed(coin)
             })

--- a/packages/fuels-test-helpers/src/lib.rs
+++ b/packages/fuels-test-helpers/src/lib.rs
@@ -8,7 +8,7 @@ use fuel_types::{AssetId, Nonce};
 use fuels_accounts::provider::Provider;
 use fuels_core::types::{
     bech32::Bech32Address,
-    coin::{Coin, CoinStatus},
+    coin::Coin,
     errors::Result,
     message::{Message, MessageStatus},
 };
@@ -96,8 +96,6 @@ pub fn setup_single_asset_coins(
                 utxo_id,
                 amount: amount_per_coin,
                 asset_id,
-                status: CoinStatus::Unspent,
-                block_created: Default::default(),
             }
         })
         .collect();


### PR DESCRIPTION
closing: https://github.com/FuelLabs/fuels-rs/issues/1663

# Breaking Changes

removed `CoinStatus` and `created_at` from `Coin`

```rust
//old
pub struct Coin {
    pub amount: u64,
    pub block_created: u32,
    pub asset_id: AssetId,
    pub utxo_id: UtxoId,
    pub owner: Bech32Address,
    pub status: CoinStatus,
}
```
```rust
//new
pub struct Coin {
    pub amount: u64,
    pub asset_id: AssetId,
    pub utxo_id: UtxoId,
    pub owner: Bech32Address,
}
```