### PR TITLE
feat: make configurable max_fee_estimation_tolerance in call handlers

### DIFF
--- a/e2e/tests/contracts.rs
+++ b/e2e/tests/contracts.rs
@@ -2880,3 +2880,45 @@ async fn test_returned_method_descriptors_are_valid() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_max_fee_estimation_tolerance() -> Result<()> {
+    setup_program_test!(
+        Wallets("wallet"),
+        Abigen(Contract(
+            name = "TestContract",
+            project = "e2e/sway/contracts/contract_test"
+        )),
+        Deploy(
+            name = "contract_instance",
+            contract = "TestContract",
+            wallet = "wallet",
+            random_salt = false,
+        ),
+    );
+
+    // Test with default tolerance
+    let contract_methods = contract_instance.methods();
+    let response_default = contract_methods.get_single(5).call().await?;
+    assert_eq!(response_default.value, 5);
+
+    // Test with custom tolerance (lower than default)
+    let custom_tolerance = 0.1; // 10% tolerance
+    let response_custom = contract_methods
+        .get_single(5)
+        .with_max_fee_estimation_tolerance(custom_tolerance)
+        .call()
+        .await?;
+    assert_eq!(response_custom.value, 5);
+
+    // Test with custom tolerance (higher than default)
+    let high_tolerance = 1.0; // 100% tolerance
+    let response_high = contract_methods
+        .get_single(5)
+        .with_max_fee_estimation_tolerance(high_tolerance)
+        .call()
+        .await?;
+    assert_eq!(response_high.value, 5);
+
+    Ok(())
+}

--- a/packages/fuels-programs/src/calls/call_handler.rs
+++ b/packages/fuels-programs/src/calls/call_handler.rs
@@ -49,6 +49,7 @@ pub struct CallHandler<A, C, T> {
     cached_tx_id: Option<Bytes32>,
     variable_output_policy: VariableOutputPolicy,
     unresolved_signers: Vec<Arc<dyn Signer + Send + Sync>>,
+    max_fee_estimation_tolerance: f32,
 }
 
 impl<A, C, T> CallHandler<A, C, T> {
@@ -83,6 +84,17 @@ impl<A, C, T> CallHandler<A, C, T> {
 
     pub fn add_signer(mut self, signer: impl Signer + Send + Sync + 'static) -> Self {
         self.unresolved_signers.push(Arc::new(signer));
+        self
+    }
+
+    /// Sets the max fee estimation tolerance for a given transaction.
+    /// This tolerance is used as a buffer when estimating the maximum fee.
+    /// Note that this is a builder method, i.e. use it as a chain:
+    /// ```ignore
+    /// my_contract_instance.my_method(...).with_max_fee_estimation_tolerance(0.25).call()
+    /// ```
+    pub fn with_max_fee_estimation_tolerance(mut self, max_fee_estimation_tolerance: f32) -> Self {
+        self.max_fee_estimation_tolerance = max_fee_estimation_tolerance;
         self
     }
 }
@@ -123,6 +135,7 @@ where
             consensus_parameters,
             asset_inputs,
             &self.account,
+            self.max_fee_estimation_tolerance,
         )?;
 
         tb.add_signers(&self.unresolved_signers)?;
@@ -317,6 +330,7 @@ where
             cached_tx_id: None,
             variable_output_policy: VariableOutputPolicy::default(),
             unresolved_signers: vec![],
+            max_fee_estimation_tolerance: crate::DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE,
         }
     }
 
@@ -405,6 +419,7 @@ where
             cached_tx_id: None,
             variable_output_policy: VariableOutputPolicy::default(),
             unresolved_signers: vec![],
+            max_fee_estimation_tolerance: crate::DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE,
         }
     }
 
@@ -438,6 +453,7 @@ where
             cached_tx_id: None,
             variable_output_policy: VariableOutputPolicy::default(),
             unresolved_signers: vec![],
+            max_fee_estimation_tolerance: crate::DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE,
         }
     }
 

--- a/packages/fuels-programs/src/calls/traits/transaction_tuner.rs
+++ b/packages/fuels-programs/src/calls/traits/transaction_tuner.rs
@@ -29,6 +29,7 @@ pub trait TransactionTuner: sealed::Sealed {
         consensus_parameters: &ConsensusParameters,
         asset_input: Vec<Input>,
         account: &T,
+        max_fee_estimation_tolerance: f32,
     ) -> Result<ScriptTransactionBuilder>;
 
     async fn build_tx<T: Account>(
@@ -51,6 +52,7 @@ impl TransactionTuner for ContractCall {
         consensus_parameters: &ConsensusParameters,
         asset_input: Vec<Input>,
         account: &T,
+        max_fee_estimation_tolerance: f32,
     ) -> Result<ScriptTransactionBuilder> {
         transaction_builder_from_contract_calls(
             std::slice::from_ref(self),
@@ -59,6 +61,7 @@ impl TransactionTuner for ContractCall {
             consensus_parameters,
             asset_input,
             account,
+            max_fee_estimation_tolerance,
         )
     }
 
@@ -84,6 +87,7 @@ impl TransactionTuner for ScriptCall {
         _: &ConsensusParameters,
         _: Vec<Input>,
         _account: &T,
+        max_fee_estimation_tolerance: f32,
     ) -> Result<ScriptTransactionBuilder> {
         let (inputs, outputs) = self.prepare_inputs_outputs()?;
 
@@ -95,7 +99,7 @@ impl TransactionTuner for ScriptCall {
             .with_inputs(inputs)
             .with_outputs(outputs)
             .with_gas_estimation_tolerance(DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE)
-            .with_max_fee_estimation_tolerance(DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE))
+            .with_max_fee_estimation_tolerance(max_fee_estimation_tolerance))
     }
 
     async fn build_tx<T: Account>(
@@ -128,6 +132,7 @@ impl TransactionTuner for Vec<ContractCall> {
         consensus_parameters: &ConsensusParameters,
         asset_input: Vec<Input>,
         account: &T,
+        max_fee_estimation_tolerance: f32,
     ) -> Result<ScriptTransactionBuilder> {
         validate_contract_calls(self)?;
 
@@ -138,6 +143,7 @@ impl TransactionTuner for Vec<ContractCall> {
             consensus_parameters,
             asset_input,
             account,
+            max_fee_estimation_tolerance,
         )
     }
 

--- a/packages/fuels-programs/src/calls/utils.rs
+++ b/packages/fuels-programs/src/calls/utils.rs
@@ -37,6 +37,7 @@ pub(crate) fn transaction_builder_from_contract_calls(
     consensus_parameters: &ConsensusParameters,
     asset_inputs: Vec<Input>,
     account: &impl Account,
+    max_fee_estimation_tolerance: f32,
 ) -> Result<ScriptTransactionBuilder> {
     let calls_instructions_len = compute_calls_instructions_len(calls);
     let data_offset = call_script_data_offset(consensus_parameters, calls_instructions_len)?;
@@ -63,7 +64,7 @@ pub(crate) fn transaction_builder_from_contract_calls(
         .with_inputs(inputs)
         .with_outputs(outputs)
         .with_gas_estimation_tolerance(DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE)
-        .with_max_fee_estimation_tolerance(DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE))
+        .with_max_fee_estimation_tolerance(max_fee_estimation_tolerance))
 }
 
 /// Creates a [`ScriptTransaction`] from contract calls. The internal [Transaction] is

--- a/packages/fuels-programs/src/executable.rs
+++ b/packages/fuels-programs/src/executable.rs
@@ -168,6 +168,16 @@ impl Executable<Loader> {
         &self,
         account: impl fuels_accounts::Account,
     ) -> Result<Option<TxResponse>> {
+        self.upload_blob_with_tolerance(account, DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE).await
+    }
+
+    /// If not previously uploaded, uploads a blob containing the original executable code minus the data section,
+    /// using the specified max fee estimation tolerance.
+    pub async fn upload_blob_with_tolerance(
+        &self,
+        account: impl fuels_accounts::Account,
+        max_fee_estimation_tolerance: f32,
+    ) -> Result<Option<TxResponse>> {
         let blob = self.blob();
         let provider = account.try_provider()?;
         let consensus_parameters = provider.consensus_parameters().await?;
@@ -178,7 +188,7 @@ impl Executable<Loader> {
 
         let mut tb = BlobTransactionBuilder::default()
             .with_blob(self.blob())
-            .with_max_fee_estimation_tolerance(DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE);
+            .with_max_fee_estimation_tolerance(max_fee_estimation_tolerance);
 
         account
             .adjust_for_fee(&mut tb, 0)


### PR DESCRIPTION
Closes #1591

<!--
List the issues this PR closes (if any) in a bullet list format, e.g.:
- Closes #ABCD
- Closes #EFGH
-->

# Release notes

<!--
Use this only if this PR requires a mention in the Release
Notes Summary. Valuable features and critical fixes are good
examples. For everything else, please delete the whole section.
-->

In this release, we:

- Added a possibility to configure max_fee_estimation_tolerance in `CallHandler`, `TransactionTuner` and `Executable`


# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a configurable `max_fee_estimation_tolerance` across call handlers, transaction builders, and loader blob uploads, with tests.
> 
> - **SDK - Calls**:
>   - `CallHandler`:
>     - Add field `max_fee_estimation_tolerance` with builder `with_max_fee_estimation_tolerance(...)`.
>     - Propagate tolerance into `transaction_builder_with_parameters` and builder creation.
>   - `TransactionTuner` (trait and impls):
>     - Extend `transaction_builder(...)` signature to accept `max_fee_estimation_tolerance: f32`.
>     - `ScriptCall`/`ContractCall`/`Vec<ContractCall>` pass tolerance to `ScriptTransactionBuilder.with_max_fee_estimation_tolerance(...)`.
>   - `calls/utils.rs`:
>     - `transaction_builder_from_contract_calls(...)` now takes tolerance and forwards it to the builder.
> - **SDK - Executable**:
>   - Add `upload_blob_with_tolerance(account, max_fee_estimation_tolerance)`; `upload_blob` delegates to it.
>   - Use tolerance in `BlobTransactionBuilder.with_max_fee_estimation_tolerance(...)`.
> - **Tests**:
>   - Add `test_max_fee_estimation_tolerance` in `e2e/tests/contracts.rs` validating default and custom tolerances.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0c5d84738db573aaf4a544a5f79e97a35adb524. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->