### PR TITLE
Update `fuel-abi-types` to 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ readme = "README.md"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuels-rs"
 rust-version = "1.85.0"
-version = "0.74.0"
+version = "0.75.0"
 
 [workspace.dependencies]
 Inflector = "0.11.4"
@@ -113,11 +113,11 @@ fuel-types = { version = "0.62.0" }
 fuel-vm = { version = "0.62.0" }
 
 # Workspace projects
-fuels = { version = "0.74.0", path = "./packages/fuels", default-features = false }
-fuels-accounts = { version = "0.74.0", path = "./packages/fuels-accounts", default-features = false }
-fuels-code-gen = { version = "0.74.0", path = "./packages/fuels-code-gen", default-features = false }
-fuels-core = { version = "0.74.0", path = "./packages/fuels-core", default-features = false }
-fuels-macros = { version = "0.74.0", path = "./packages/fuels-macros", default-features = false }
-fuels-programs = { version = "0.74.0", path = "./packages/fuels-programs", default-features = false }
-fuels-test-helpers = { version = "0.74.0", path = "./packages/fuels-test-helpers", default-features = false }
-versions-replacer = { version = "0.74.0", path = "./scripts/versions-replacer", default-features = false }
+fuels = { version = "0.75.0", path = "./packages/fuels", default-features = false }
+fuels-accounts = { version = "0.75.0", path = "./packages/fuels-accounts", default-features = false }
+fuels-code-gen = { version = "0.75.0", path = "./packages/fuels-code-gen", default-features = false }
+fuels-core = { version = "0.75.0", path = "./packages/fuels-core", default-features = false }
+fuels-macros = { version = "0.75.0", path = "./packages/fuels-macros", default-features = false }
+fuels-programs = { version = "0.75.0", path = "./packages/fuels-programs", default-features = false }
+fuels-test-helpers = { version = "0.75.0", path = "./packages/fuels-test-helpers", default-features = false }
+versions-replacer = { version = "0.75.0", path = "./scripts/versions-replacer", default-features = false }

--- a/docs/src/connecting/short-lived.md
+++ b/docs/src/connecting/short-lived.md
@@ -27,7 +27,7 @@ let wallet = launch_provider_and_get_wallet().await?;
 The `fuel-core-lib` feature allows us to run a `fuel-core` node without installing the `fuel-core` binary on the local machine. Using the `fuel-core-lib` feature flag entails downloading all the dependencies needed to run the fuel-core node.
 
 ```rust,ignore
-fuels = { version = "0.74.0", features = ["fuel-core-lib"] }
+fuels = { version = "0.75.0", features = ["fuel-core-lib"] }
 ```
 
 ### RocksDB
@@ -35,5 +35,5 @@ fuels = { version = "0.74.0", features = ["fuel-core-lib"] }
 The `rocksdb` is an additional feature that, when combined with `fuel-core-lib`, provides persistent storage capabilities while using `fuel-core` as a library.
 
 ```rust,ignore
-fuels = { version = "0.74.0", features = ["rocksdb"] }
+fuels = { version = "0.75.0", features = ["rocksdb"] }
 ```


### PR DESCRIPTION
See https://github.com/FuelLabs/fuel-abi-types/pull/34 for more information.

Also updates the version to 0.75.0 so we can publish a new release.