### PR TITLE
Bump fuel-abi-types to 0.15.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ cynic = { version = "3.1.0", default-features = false }
 test-case = { version = "3.3", default-features = false }
 eth-keystore = "0.5.0"
 flate2 = { version = "1.0", default-features = false }
-fuel-abi-types = "0.13.0"
+fuel-abi-types = "0.15.0"
 futures = "0.3.29"
 hex = { version = "0.4.3", default-features = false }
 itertools = "0.12.0"

--- a/packages/fuels-code-gen/src/program_bindings/abigen.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen.rs
@@ -169,6 +169,7 @@ mod tests {
             type_field: type_field.to_string(),
             components: vec![],
             type_parameters: vec![],
+            alias_of: None,
         });
 
         let shared_types = Abigen::filter_shared_types(&types);

--- a/packages/fuels-code-gen/src/program_bindings/abigen/bindings/function_generator.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/bindings/function_generator.rs
@@ -183,6 +183,7 @@ mod tests {
             type_field: "generic T".to_string(),
             components: vec![],
             type_parameters: vec![],
+            alias_of: None,
         };
         let custom_struct_type = FullTypeDeclaration {
             type_field: "struct CustomStruct".to_string(),
@@ -193,6 +194,7 @@ mod tests {
                 error_message: None,
             }],
             type_parameters: vec![generic_type_t],
+            alias_of: None,
         };
 
         let fn_output = FullTypeApplication {
@@ -204,6 +206,7 @@ mod tests {
                     type_field: "u64".to_string(),
                     components: vec![],
                     type_parameters: vec![],
+                    alias_of: None,
                 },
                 type_arguments: vec![],
                 error_message: None,
@@ -219,6 +222,7 @@ mod tests {
                     type_field: "u8".to_string(),
                     components: vec![],
                     type_parameters: vec![],
+                    alias_of: None,
                 },
                 type_arguments: vec![],
                 error_message: None,

--- a/packages/fuels-code-gen/src/program_bindings/abigen/bindings/utils.rs
+++ b/packages/fuels-code-gen/src/program_bindings/abigen/bindings/utils.rs
@@ -59,6 +59,7 @@ mod tests {
                     type_field: "".to_string(),
                     components: vec![],
                     type_parameters: vec![],
+                    alias_of: None,
                 },
                 type_arguments: vec![],
                 error_message: None,

--- a/packages/fuels-code-gen/src/program_bindings/custom_types.rs
+++ b/packages/fuels-code-gen/src/program_bindings/custom_types.rs
@@ -615,6 +615,7 @@ mod tests {
             type_field: "struct some_shared_lib::SharedStruct".to_string(),
             components: vec![],
             type_parameters: vec![],
+            alias_of: None,
         };
         let shared_types = HashSet::from([type_decl.clone()]);
 

--- a/packages/fuels-code-gen/src/program_bindings/custom_types/utils.rs
+++ b/packages/fuels-code-gen/src/program_bindings/custom_types/utils.rs
@@ -37,12 +37,14 @@ mod tests {
             type_field: "".to_string(),
             components: None,
             type_parameters: Some(vec![1, 2]),
+            alias_of: None,
         };
         let generic_1 = UnifiedTypeDeclaration {
             type_id: 1,
             type_field: "generic T".to_string(),
             components: None,
             type_parameters: None,
+            alias_of: None,
         };
 
         let generic_2 = UnifiedTypeDeclaration {
@@ -50,6 +52,7 @@ mod tests {
             type_field: "generic K".to_string(),
             components: None,
             type_parameters: None,
+            alias_of: None,
         };
 
         let types = [generic_1, generic_2]
@@ -81,6 +84,7 @@ mod tests {
             type_field: "struct SomeName".to_string(),
             components: None,
             type_parameters: None,
+            alias_of: None,
         };
 
         let struct_name = extract_custom_type_name(&declaration.type_field).unwrap();
@@ -95,6 +99,7 @@ mod tests {
             type_field: "enum SomeEnumName".to_string(),
             components: None,
             type_parameters: None,
+            alias_of: None,
         };
 
         let struct_name = extract_custom_type_name(&declaration.type_field).unwrap();

--- a/packages/fuels-code-gen/src/program_bindings/resolved_type.rs
+++ b/packages/fuels-code-gen/src/program_bindings/resolved_type.rs
@@ -468,6 +468,7 @@ mod tests {
                         },
                     ]),
                     type_parameters: Some(vec![1]),
+                    alias_of: None,
                 },
                 UnifiedTypeDeclaration {
                     type_id: 1,
@@ -495,6 +496,7 @@ mod tests {
                         },
                     ]),
                     type_parameters: Some(vec![1]),
+                    alias_of: None,
                 },
                 UnifiedTypeDeclaration {
                     type_id: 4,
@@ -662,6 +664,7 @@ mod tests {
                         },
                     ]),
                     type_parameters: Some(vec![1]),
+                    alias_of: None,
                 },
                 UnifiedTypeDeclaration {
                     type_id: 1,
@@ -698,6 +701,7 @@ mod tests {
                         },
                     ]),
                     type_parameters: Some(vec![1]),
+                    alias_of: None,
                 },
                 UnifiedTypeDeclaration {
                     type_id: 1,
@@ -740,6 +744,7 @@ mod tests {
                         },
                     ]),
                     type_parameters: Some(vec![4]),
+                    alias_of: None,
                 },
                 UnifiedTypeDeclaration {
                     type_id: 1,
@@ -791,6 +796,7 @@ mod tests {
                 type_field: format!("struct {type_path}"),
                 components: vec![],
                 type_parameters: vec![],
+                alias_of: None,
             },
             type_arguments: vec![],
             error_message: None,

--- a/packages/fuels-code-gen/src/program_bindings/utils.rs
+++ b/packages/fuels-code-gen/src/program_bindings/utils.rs
@@ -230,6 +230,7 @@ mod tests {
                 type_field: "u64".to_string(),
                 components: vec![],
                 type_parameters: vec![],
+                alias_of: None,
             },
             type_arguments: vec![],
             error_message: None,

--- a/packages/fuels-core/src/types/param_types/from_type_application.rs
+++ b/packages/fuels-core/src/types/param_types/from_type_application.rs
@@ -373,6 +373,7 @@ mod tests {
                 type_field: type_field.to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             }];
 
             let type_lookup = declarations
@@ -419,12 +420,14 @@ mod tests {
                     error_message: None,
                 }]),
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 1,
                 type_field: "u8".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
         ];
 
@@ -451,12 +454,14 @@ mod tests {
                 type_field: "generic T".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 2,
                 type_field: "raw untyped ptr".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 3,
@@ -476,6 +481,7 @@ mod tests {
                     },
                 ]),
                 type_parameters: Some(vec![1]),
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 4,
@@ -500,18 +506,21 @@ mod tests {
                     },
                 ]),
                 type_parameters: Some(vec![1]),
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 5,
                 type_field: "u64".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 6,
                 type_field: "u8".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
         ];
 
@@ -550,6 +559,7 @@ mod tests {
                 type_field: "generic T".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 2,
@@ -561,12 +571,14 @@ mod tests {
                     error_message: None,
                 }]),
                 type_parameters: Some(vec![1]),
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 3,
                 type_field: "u8".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
         ];
 
@@ -612,6 +624,7 @@ mod tests {
                 type_field: "generic T".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 2,
@@ -623,12 +636,14 @@ mod tests {
                     error_message: None,
                 }]),
                 type_parameters: Some(vec![1]),
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 3,
                 type_field: "u8".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
         ];
 
@@ -687,18 +702,21 @@ mod tests {
                     },
                 ]),
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 2,
                 type_field: "str[15]".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 3,
                 type_field: "u8".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
         ];
 
@@ -747,6 +765,7 @@ mod tests {
                     },
                 ]),
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 2,
@@ -766,6 +785,7 @@ mod tests {
                     },
                 ]),
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 3,
@@ -785,6 +805,7 @@ mod tests {
                     },
                 ]),
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 4,
@@ -816,6 +837,7 @@ mod tests {
                     error_message: None,
                 }]),
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 5,
@@ -827,6 +849,7 @@ mod tests {
                     error_message: None,
                 }]),
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 6,
@@ -838,12 +861,14 @@ mod tests {
                     error_message: None,
                 }]),
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 7,
                 type_field: "b256".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 8,
@@ -863,54 +888,63 @@ mod tests {
                     },
                 ]),
                 type_parameters: Some(vec![12]),
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 9,
                 type_field: "generic K".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 10,
                 type_field: "generic L".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 11,
                 type_field: "generic M".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 12,
                 type_field: "generic N".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 13,
                 type_field: "generic T".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 14,
                 type_field: "generic U".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 15,
                 type_field: "raw untyped ptr".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 16,
                 type_field: "str[2]".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 17,
@@ -935,6 +969,7 @@ mod tests {
                     },
                 ]),
                 type_parameters: Some(vec![13, 14]),
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 18,
@@ -951,6 +986,7 @@ mod tests {
                     error_message: None,
                 }]),
                 type_parameters: Some(vec![9]),
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 19,
@@ -970,6 +1006,7 @@ mod tests {
                     },
                 ]),
                 type_parameters: Some(vec![13]),
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 20,
@@ -981,6 +1018,7 @@ mod tests {
                     error_message: None,
                 }]),
                 type_parameters: Some(vec![13]),
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 21,
@@ -992,6 +1030,7 @@ mod tests {
                     error_message: None,
                 }]),
                 type_parameters: Some(vec![10]),
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 22,
@@ -1003,6 +1042,7 @@ mod tests {
                     error_message: None,
                 }]),
                 type_parameters: Some(vec![11]),
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 23,
@@ -1027,18 +1067,21 @@ mod tests {
                     },
                 ]),
                 type_parameters: Some(vec![13]),
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 24,
                 type_field: "u32".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
             UnifiedTypeDeclaration {
                 type_id: 25,
                 type_field: "u64".to_string(),
                 components: None,
                 type_parameters: None,
+                alias_of: None,
             },
         ];
 


### PR DESCRIPTION
This stubs out a few things due to interdependency issues with Sway, the next PR for alias will properly implement these out.
