### PR TITLE
chore(log_id): lazy data decode

### DIFF
--- a/packages/fuels-accounts/src/provider.rs
+++ b/packages/fuels-accounts/src/provider.rs
@@ -134,7 +134,7 @@ impl Provider {
 
     /// Returns the underlying uncached client.
     pub fn client(&self) -> &FuelClient {
-        &self.cached_client.inner().client()
+        self.cached_client.inner().client()
     }
 
     pub fn set_cache_ttl(&mut self, ttl: TtlConfig) {

--- a/packages/fuels-core/src/codec/logs.rs
+++ b/packages/fuels-core/src/codec/logs.rs
@@ -242,11 +242,11 @@ impl LogDecoder {
         &'a self,
         receipt: &'a Receipt,
     ) -> impl Iterator<Item = impl FnOnce() -> Result<T>> + 'a {
-        let target_ids: HashSet<LogId> = self
+        let target_ids: HashSet<&LogId> = self
             .log_formatters
             .iter()
             .filter(|(_, log_formatter)| log_formatter.can_handle_type::<T>())
-            .map(|(log_id, _)| log_id.clone())
+            .map(|(log_id, _)| log_id)
             .collect();
 
         std::iter::once(receipt).extract_matching_logs_lazy::<T>(target_ids, self.decoder_config)
@@ -266,7 +266,7 @@ trait ExtractLogIdData {
 trait ExtractLogIdLazy {
     fn extract_matching_logs_lazy<T: Tokenizable + Parameterize + 'static>(
         self,
-        target_ids: HashSet<LogId>,
+        target_ids: HashSet<&LogId>,
         decoder_config: DecoderConfig,
     ) -> impl Iterator<Item = impl FnOnce() -> Result<T>>;
 }
@@ -292,7 +292,7 @@ impl<'a, I: Iterator<Item = &'a Receipt>> ExtractLogIdData for I {
 impl<'a, I: Iterator<Item = &'a Receipt>> ExtractLogIdLazy for I {
     fn extract_matching_logs_lazy<T: Tokenizable + Parameterize + 'static>(
         self,
-        target_ids: HashSet<LogId>,
+        target_ids: HashSet<&LogId>,
         decoder_config: DecoderConfig,
     ) -> impl Iterator<Item = impl FnOnce() -> Result<T>> {
         self.filter_map(move |r| {

--- a/packages/fuels-core/src/codec/logs.rs
+++ b/packages/fuels-core/src/codec/logs.rs
@@ -255,10 +255,9 @@ impl LogDecoder {
             .extract_log_id_and_data()
             .filter_map(move |(log_id, bytes)| {
                 target_ids.contains(&log_id).then(|| {
-                    let bytes_owned = bytes.to_vec();
                     let decode_fn = move || -> Result<T> {
                         let token = ABIDecoder::new(decoder_config)
-                            .decode(&T::param_type(), bytes_owned.as_slice())?;
+                            .decode(&T::param_type(), bytes.as_slice())?;
                         T::from_token(token)
                     };
                     decode_fn

--- a/packages/fuels-core/src/codec/logs.rs
+++ b/packages/fuels-core/src/codec/logs.rs
@@ -241,7 +241,7 @@ impl LogDecoder {
     pub fn decode_logs_lazy<'a, T: Tokenizable + Parameterize + 'static>(
         &'a self,
         receipt: &'a Receipt,
-    ) -> impl Iterator<Item = (LogId, impl FnOnce() -> Result<T>)> + 'a {
+    ) -> impl Iterator<Item = impl FnOnce() -> Result<T>> + 'a {
         let target_ids: HashSet<LogId> = self
             .log_formatters
             .iter()
@@ -261,7 +261,7 @@ impl LogDecoder {
                             .decode(&T::param_type(), bytes_owned.as_slice())?;
                         T::from_token(token)
                     };
-                    (log_id, decode_fn)
+                    decode_fn
                 })
             })
     }


### PR DESCRIPTION
This pull request introduces a new lazy log decoding feature to the `fuels-core` log codec, enabling more efficient and flexible extraction and decoding of logs from receipts. The main changes focus on adding a lazy decoding API, supporting type-specific log extraction, and implementing the necessary traits and iterator logic.

### Lazy Log Decoding API

* Added the `decode_logs_lazy` method to the `LogDecoder` struct, allowing users to obtain an iterator of lazy decoder functions for a specific log type from a single `Receipt`. This enables on-demand decoding and can improve performance for large log sets.

### Iterator Trait and Implementation for Lazy Extraction

* Introduced the `ExtractLogIdLazy` trait, which provides the `extract_matching_logs_lazy` method for iterators over receipts. This method filters receipts by target log IDs and returns an iterator of lazy decoder closures.
* Implemented the `ExtractLogIdLazy` trait for iterators over receipts, including logic to match log IDs, extract relevant data, and construct lazy decoding closures for the specified type.