### PR TITLE
chore(release): prepare for release 0.75.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ readme = "README.md"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuels-rs"
 rust-version = "1.86.0"
-version = "0.74.0"
+version = "0.75.0"
 
 [workspace.dependencies]
 Inflector = "0.11.4"
@@ -113,11 +113,11 @@ fuel-types = { version = "0.62.0" }
 fuel-vm = { version = "0.62.0" }
 
 # Workspace projects
-fuels = { version = "0.74.0", path = "./packages/fuels", default-features = false }
-fuels-accounts = { version = "0.74.0", path = "./packages/fuels-accounts", default-features = false }
-fuels-code-gen = { version = "0.74.0", path = "./packages/fuels-code-gen", default-features = false }
-fuels-core = { version = "0.74.0", path = "./packages/fuels-core", default-features = false }
-fuels-macros = { version = "0.74.0", path = "./packages/fuels-macros", default-features = false }
-fuels-programs = { version = "0.74.0", path = "./packages/fuels-programs", default-features = false }
-fuels-test-helpers = { version = "0.74.0", path = "./packages/fuels-test-helpers", default-features = false }
-versions-replacer = { version = "0.74.0", path = "./scripts/versions-replacer", default-features = false }
+fuels = { version = "0.75.0", path = "./packages/fuels", default-features = false }
+fuels-accounts = { version = "0.75.0", path = "./packages/fuels-accounts", default-features = false }
+fuels-code-gen = { version = "0.75.0", path = "./packages/fuels-code-gen", default-features = false }
+fuels-core = { version = "0.75.0", path = "./packages/fuels-core", default-features = false }
+fuels-macros = { version = "0.75.0", path = "./packages/fuels-macros", default-features = false }
+fuels-programs = { version = "0.75.0", path = "./packages/fuels-programs", default-features = false }
+fuels-test-helpers = { version = "0.75.0", path = "./packages/fuels-test-helpers", default-features = false }
+versions-replacer = { version = "0.75.0", path = "./scripts/versions-replacer", default-features = false }


### PR DESCRIPTION
looks like some documentation was already updated to use 0.75.0, its not on crates.io or gh releases though
