### PR TITLE
Version bump yo `v0.75.1` due to `fuel-abi-types` dependency update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ readme = "README.md"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuels-rs"
 rust-version = "1.86.0"
-version = "0.75.0"
+version = "0.75.1"
 
 [workspace.dependencies]
 Inflector = "0.11.4"
@@ -52,7 +52,7 @@ cynic = { version = "3.1.0", default-features = false }
 test-case = { version = "3.3", default-features = false }
 eth-keystore = "0.5.0"
 flate2 = { version = "1.0", default-features = false }
-fuel-abi-types = "0.15.0"
+fuel-abi-types = "0.15.3"
 futures = "0.3.29"
 hex = { version = "0.4.3", default-features = false }
 itertools = "0.12.0"
@@ -113,11 +113,11 @@ fuel-types = { version = "0.62.0" }
 fuel-vm = { version = "0.62.0" }
 
 # Workspace projects
-fuels = { version = "0.75.0", path = "./packages/fuels", default-features = false }
-fuels-accounts = { version = "0.75.0", path = "./packages/fuels-accounts", default-features = false }
-fuels-code-gen = { version = "0.75.0", path = "./packages/fuels-code-gen", default-features = false }
-fuels-core = { version = "0.75.0", path = "./packages/fuels-core", default-features = false }
-fuels-macros = { version = "0.75.0", path = "./packages/fuels-macros", default-features = false }
-fuels-programs = { version = "0.75.0", path = "./packages/fuels-programs", default-features = false }
-fuels-test-helpers = { version = "0.75.0", path = "./packages/fuels-test-helpers", default-features = false }
-versions-replacer = { version = "0.75.0", path = "./scripts/versions-replacer", default-features = false }
+fuels = { version = "0.75.1", path = "./packages/fuels", default-features = false }
+fuels-accounts = { version = "0.75.1", path = "./packages/fuels-accounts", default-features = false }
+fuels-code-gen = { version = "0.75.1", path = "./packages/fuels-code-gen", default-features = false }
+fuels-core = { version = "0.75.1", path = "./packages/fuels-core", default-features = false }
+fuels-macros = { version = "0.75.1", path = "./packages/fuels-macros", default-features = false }
+fuels-programs = { version = "0.75.1", path = "./packages/fuels-programs", default-features = false }
+fuels-test-helpers = { version = "0.75.1", path = "./packages/fuels-test-helpers", default-features = false }
+versions-replacer = { version = "0.75.1", path = "./scripts/versions-replacer", default-features = false }

--- a/docs/src/connecting/short-lived.md
+++ b/docs/src/connecting/short-lived.md
@@ -27,7 +27,7 @@ let wallet = launch_provider_and_get_wallet().await?;
 The `fuel-core-lib` feature allows us to run a `fuel-core` node without installing the `fuel-core` binary on the local machine. Using the `fuel-core-lib` feature flag entails downloading all the dependencies needed to run the fuel-core node.
 
 ```rust,ignore
-fuels = { version = "0.75.0", features = ["fuel-core-lib"] }
+fuels = { version = "0.75.1", features = ["fuel-core-lib"] }
 ```
 
 ### RocksDB
@@ -35,5 +35,5 @@ fuels = { version = "0.75.0", features = ["fuel-core-lib"] }
 The `rocksdb` is an additional feature that, when combined with `fuel-core-lib`, provides persistent storage capabilities while using `fuel-core` as a library.
 
 ```rust,ignore
-fuels = { version = "0.75.0", features = ["rocksdb"] }
+fuels = { version = "0.75.1", features = ["rocksdb"] }
 ```


### PR DESCRIPTION
This pull request updates the `fuels` crate and related workspace packages from version `0.75.0` to `0.75.1`, ensuring consistency across dependencies and documentation.
It also updates the `fuel-abi-types` dependency to a newer patch version.

Documentation updates:

* Updated usage examples in `docs/src/connecting/short-lived.md` to reference `fuels = { version = "0.75.1" }` in code snippets, ensuring documentation matches the current version.