### PR TITLE
chore: remove patch branch from e2e `Cargo.toml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
   FUEL_CORE_PATCH_REVISION: ""
   RUST_VERSION: 1.86.0
   FORC_VERSION: 0.69.1
-  FORC_PATCH_BRANCH: "ironcev/abi-backtracing-compile-backtracing"
+  FORC_PATCH_BRANCH: ""
   FORC_PATCH_REVISION: ""
   NEXTEST_HIDE_PROGRESS_BAR: "true"
   NEXTEST_STATUS_LEVEL: "fail"


### PR DESCRIPTION
# Summary

This PR removes the obsolete patch branch from the `e2e` test's `Forc.toml`. The `#[patch]` section is left in the `Forc.toml` for expected future use.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)