### PR TITLE
docs: remove stray backtick in contributing guide

### DIFF
--- a/docs/src/contributing/CONTRIBUTING.md
+++ b/docs/src/contributing/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest in contributing to the Fuel Rust SDK!
 
-This document outlines the process for installing dependencies, setting up for development, and conventions for contributing.`
+This document outlines the process for installing dependencies, setting up for development, and conventions for contributing.
 
 If you run into any difficulties getting started, you can always ask questions on our [Discourse](https://forum.fuel.network/).
 


### PR DESCRIPTION
## Summary
- remove the stray trailing backtick from the opening paragraph of the contributing guide
- keep the change scoped to the existing docs typo fix with no behavior changes

## Testing
- not run (docs-only change)