### PR TITLE
Document U256 type

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -58,6 +58,7 @@
   - [Structs and enums](./types/custom_types.md)
   - [`String`](./types/string.md)
   - [`Bits256`](./types/bits256.md)
+  - [`U256`](./types/u256.md)
   - [`Bytes`](./types/bytes.md)
   - [`B512`](./types/B512.md)
   - [`EvmAddress`](./types/evm_address.md)

--- a/docs/src/types/u256.md
+++ b/docs/src/types/u256.md
@@ -1,0 +1,31 @@
+# `U256`
+
+Sway's `u256` type is represented in the Rust SDK as `U256`.
+Use it when a contract method accepts or returns a `u256` value.
+
+Import `U256` from `fuels::types`:
+
+```rust,ignore
+use fuels::types::U256;
+```
+
+For values that fit in smaller Rust integer types, construct a value with `U256::from`:
+
+```rust,ignore
+let amount = U256::from(42u64);
+```
+
+For larger values, parse a decimal string:
+
+```rust,ignore
+let amount = U256::from_dec_str("340282366920938463463374607431768211456")?;
+```
+
+You can pass `U256` values directly to generated contract bindings when the corresponding Sway ABI type is `u256`:
+
+```rust,ignore
+let value = U256::from(1_000_000u64);
+contract.methods().set_large_value(value).call().await?;
+```
+
+`U256` serializes to a decimal string, which keeps JSON representations readable and avoids losing precision in environments that do not support 256-bit integers natively.


### PR DESCRIPTION
## Summary
- add a U256 page to the Types section
- show how Sway u256 maps to fuels::types::U256
- include construction examples for small integers and decimal strings

## Verification
- ran git diff --check
- confirmed docs/src/SUMMARY.md links to docs/src/types/u256.md
- confirmed U256, U256::from_dec_str, and decimal-string serialization are present in the SDK source

Note: I could not run cargo test -p check-docs locally because cargo is not installed in this environment.

Closes #1320