### PR TITLE
Provide errors in case of `fuel_bin_service::run_node` failing

### DIFF
--- a/packages/fuels-test-helpers/src/fuel_bin_service.rs
+++ b/packages/fuels-test-helpers/src/fuel_bin_service.rs
@@ -212,7 +212,9 @@ async fn run_node(extended_config: ExtendedConfig) -> FuelResult<(SocketAddr, Jo
     let mut stdout_reader = BufReader::new(stdout).lines();
     let mut stderr_reader = BufReader::new(stderr).lines();
 
-    let bound_address = tokio::time::timeout(Duration::from_secs(30), async {
+    let mut startup_logs = Vec::new();
+
+    let scan_result = tokio::time::timeout(Duration::from_secs(30), async {
         while let Some(line) = stderr_reader
             .next_line()
             .await
@@ -227,19 +229,39 @@ async fn run_node(extended_config: ExtendedConfig) -> FuelResult<(SocketAddr, Jo
                 })?;
                 return Ok(bound_address);
             }
+            startup_logs.push(format!("[stderr] {line}"));
         }
+
+        // The process exited (or closed stderr) before reporting its bound
+        // address, so stdout is at EOF too — drain it for additional messages.
+        while let Ok(Some(line)) = stdout_reader.next_line().await {
+            startup_logs.push(format!("[stdout] {line}"));
+        }
+
         Err(error!(
             Other,
             "fuel-core process exited before reporting its bound address"
         ))
     })
-    .await
-    .map_err(|_| {
-        error!(
-            Other,
-            "timed out waiting for fuel-core to report its bound address"
-        )
-    })??;
+    .await;
+
+    let bound_address = match scan_result {
+        Ok(Ok(bound_address)) => bound_address,
+        Ok(Err(e)) => {
+            return Err(error!(
+                Other,
+                "{e}. captured output:\n{}",
+                startup_logs.join("\n")
+            ));
+        }
+        Err(_elapsed) => {
+            return Err(error!(
+                Other,
+                "timed out waiting for fuel-core to report its bound address. captured output:\n{}",
+                startup_logs.join("\n")
+            ));
+        }
+    };
 
     let join_handle = spawn(async move {
         // ensure drop is not called on the tmp dir and it lives throughout the lifetime of the node


### PR DESCRIPTION
# Summary

This PR captures stderr and stdout in case of `run_node` not being able to get the bound address.

When the spawned `fuel-core` process exits (or times out) before logging its bound address, the resulting error was just "fuel-core process exited before reporting its bound address". The process's actual output was discarded, making the failure undiagnosable from test logs alone.

`run_node` now buffers the startup lines read from stderr and, on failure, drains stdout as well, appending everything the process printed to the error message. This matters in practice: e.g. when fuel-core resolves to the fuelup proxy, the proxy reports its failures on stdout and exits with status 0, so previously no trace of the real cause survived.

Example of the new error:

```
fuel-core process exited before reporting its bound address. captured output:
[stdout] Adding component fuel-core v0.48.0 to 'testnet-x86_64-unknown-linux-gnu'
[stdout] Could not add component fuel-core(0.48.0): No such file or directory (os error 2)
```

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)