### PR TITLE
fix: revive `wasm-tests` and re-enable the WASM CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,13 +249,14 @@ jobs:
         with:
           node-version: 22.8.0
 
-      # Until we fix the "missing env error"
-      # - name: Test WASM
-      #   if: ${{ matrix.command == 'test_wasm' }}
-      #   run: |
-      #     curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      #     cd wasm-tests
-      #     wasm-pack test --node
+      - name: Install wasm-pack
+        if: ${{ matrix.command == 'test_wasm' }}
+        uses: taiki-e/install-action@wasm-pack
+
+      - name: Test WASM
+        if: ${{ matrix.command == 'test_wasm' }}
+        working-directory: wasm-tests
+        run: wasm-pack test --node
 
       - name: Check that fuel_core version.rs file is up to date
         if: ${{ matrix.command == 'check_fuel_core_version' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,13 @@
 # > If you are using a virtual workspace, you will still need to explicitly set the resolver field in the [workspace]
 #   definition if you want to opt-in to the new resolver.
 # https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html#details
-resolver = "2"
+#
+# Resolver "3" is resolver "2" plus MSRV-aware version selection. `Cargo.lock` is not
+# committed (this is a library workspace), so CI resolves dependencies from scratch on
+# every run; without this, a dependency publishing a release that raises its `rust-version`
+# above our MSRV breaks every build until it is pinned by hand.
+# https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
+resolver = "3"
 members = [
   "e2e",
   "examples/codec",

--- a/packages/fuels-core/src/lib.rs
+++ b/packages/fuels-core/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 pub mod codec;
 pub mod traits;
 pub mod types;

--- a/packages/fuels-programs/src/lib.rs
+++ b/packages/fuels-programs/src/lib.rs
@@ -11,5 +11,8 @@ pub const DEFAULT_MAX_FEE_ESTIMATION_TOLERANCE: f32 = 0.50;
 
 pub mod debug;
 
+// `assembly` backs both `debug` (always compiled) and the `std`-only program APIs above.
+// Without `std` the latter are gone, leaving parts of it unused.
+#[cfg_attr(not(feature = "std"), allow(dead_code))]
 pub(crate) mod assembly;
 pub(crate) mod utils;

--- a/wasm-tests/src/lib.rs
+++ b/wasm-tests/src/lib.rs
@@ -9,9 +9,9 @@ mod tests {
         core::{codec::ABIEncoder, traits::Tokenizable},
         macros::wasm_abigen,
         programs::debug::ScriptType,
-        types::{AssetId, bech32::Bech32Address, errors::Result},
+        types::{Address, AssetId, errors::Result},
     };
-    use fuels_core::codec::abi_formatter::ABIFormatter;
+    use fuels_core::codec::ABIFormatter;
     use wasm_bindgen_test::wasm_bindgen_test;
 
     #[wasm_bindgen_test]
@@ -206,11 +206,11 @@ mod tests {
 
         assert_eq!(*predicate.code(), expected_code);
 
-        let expected_address = Bech32Address::from_str(
-            "fuel1c7rzx6ljxdz8egkcfjswffe7w8u06rm4nfvyu4lelyjua7qlcmdss9jkjm",
+        let expected_address = Address::from_str(
+            "0xc786236bf233447ca2d84ca0e4a73e71f8fd0f759a584e57f9f925cef81fc6db",
         )?;
 
-        assert_eq!(*predicate.address(), expected_address);
+        assert_eq!(predicate.address(), expected_address);
 
         Ok(())
     }
@@ -429,7 +429,7 @@ mod tests {
         assert_eq!(
             decoder.decode_fn_args(
                 &call_description.decode_fn_selector().unwrap(),
-                &call_description.encoded_args
+                call_description.encoded_args.as_slice()
             )?,
             vec!["AllStruct { some_struct: SomeStruct { field: 2, field_2: true } }"]
         );
@@ -448,7 +448,7 @@ mod tests {
         assert_eq!(
             decoder.decode_fn_args(
                 &call_description.decode_fn_selector().unwrap(),
-                &call_description.encoded_args
+                call_description.encoded_args.as_slice()
             )?,
             vec![
                 "AllStruct { some_struct: SomeStruct { field: 2, field_2: true } }",


### PR DESCRIPTION
# Release notes

In this release, we:

- Fixed `fuels-core` failing to compile without the `std` feature
- Revived the `wasm-tests` crate and re-enabled the WASM job in CI

# Summary

`wasm-tests` is gated behind `#[cfg(all(test, target_arch = "wasm32"))]` and the CI
step that built it has been commented out since #1544, so host-side `cargo check` /
`cargo test` never compiled it and it silently bit-rotted:

- `Bech32Address` was removed in #1669 — assert against `Address` instead.
- `codec::abi_formatter` is a private module; `ABIFormatter` is only reachable
  through the glob re-export in `codec`.
- `ABIFormatter::decode_fn_args` now takes `R: Read` rather than a byte slice.

Fixing those exposed that `fuels-core` did not compile without `std` at all: #1697
added `#[cfg(not(feature = "std"))] use alloc::sync::Arc;` to `types::errors` and
`types::tx_status`, but the crate never declared `extern crate alloc`. `wasm-tests`
is the only no-std consumer, so nothing caught it.

The "missing env error" that motivated disabling the CI step no longer reproduces —
it was most likely the `fuels-accounts` build script writing the cynic schema into
`target/`, which #1544 itself removed in favour of a checked-in `schema.sdl`.
`wasm-pack test --node` passes locally, so the step is restored, using
`taiki-e/install-action` for consistency with nextest and cargo-machete in the
same job.

This crate is the only coverage for the `wasm_abigen!` path and for
`Abigen::wasm_paths_hotfix`'s std->alloc rewriting.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
