### PR TITLE
docs: regenerate the abigen sample bindings

### DIFF
--- a/examples/rust_bindings/src/rust_bindings_formatted.rs
+++ b/examples/rust_bindings/src/rust_bindings_formatted.rs
@@ -1,16 +1,22 @@
 pub mod abigen_bindings {
     pub mod my_contract_mod {
+        // Changing the ABI file triggers a recompilation of the `abigen!` macro.
+        const _: &[u8] = include_bytes!("/path/to/examples/rust_bindings/src/abi.json");
         #[derive(Debug, Clone)]
-        pub struct MyContract<A: ::fuels::accounts::Account> {
+        pub struct MyContract<A = ()> {
             contract_id: ::fuels::types::ContractId,
             account: A,
             log_decoder: ::fuels::core::codec::LogDecoder,
             encoder_config: ::fuels::core::codec::EncoderConfig,
         }
-        impl<A: ::fuels::accounts::Account> MyContract<A> {
+        impl MyContract {
+            pub const METHODS: MyContractMethodVariants = MyContractMethodVariants;
+        }
+        impl<A> MyContract<A> {
             pub fn new(contract_id: ::fuels::types::ContractId, account: A) -> Self {
                 let log_decoder = ::fuels::core::codec::LogDecoder::new(
                     ::fuels::core::codec::log_formatters_lookup(vec![], contract_id.clone().into()),
+                    ::std::collections::HashMap::from([]),
                 );
                 let encoder_config = ::fuels::core::codec::EncoderConfig::default();
                 Self {
@@ -20,11 +26,11 @@ pub mod abigen_bindings {
                     encoder_config,
                 }
             }
-            pub fn contract_id(&self) -> &::fuels::types::ContractId {
+            pub fn contract_id(&self) -> ::fuels::types::ContractId {
                 self.contract_id
             }
-            pub fn account(&self) -> A {
-                self.account.clone()
+            pub fn account(&self) -> &A {
+                &self.account
             }
             pub fn with_account<U: ::fuels::accounts::Account>(self, account: U) -> MyContract<U> {
                 MyContract {
@@ -45,13 +51,19 @@ pub mod abigen_bindings {
                 &self,
             ) -> ::fuels::types::errors::Result<
                 ::std::collections::HashMap<::fuels::types::AssetId, u64>,
-            > {
+            >
+            where
+                A: ::fuels::accounts::ViewOnlyAccount,
+            {
                 ::fuels::accounts::ViewOnlyAccount::try_provider(&self.account)?
                     .get_contract_balances(&self.contract_id)
                     .await
                     .map_err(::std::convert::Into::into)
             }
-            pub fn methods(&self) -> MyContractMethods<A> {
+            pub fn methods(&self) -> MyContractMethods<A>
+            where
+                A: Clone,
+            {
                 MyContractMethods {
                     contract_id: self.contract_id.clone(),
                     account: self.account.clone(),
@@ -60,33 +72,13 @@ pub mod abigen_bindings {
                 }
             }
         }
-        pub struct MyContractMethods<A: ::fuels::accounts::Account> {
+        pub struct MyContractMethods<A> {
             contract_id: ::fuels::types::ContractId,
             account: A,
             log_decoder: ::fuels::core::codec::LogDecoder,
             encoder_config: ::fuels::core::codec::EncoderConfig,
         }
-        impl<A: ::fuels::accounts::Account> MyContractMethods<A> {
-            #[doc = " This method will read the counter from storage, increment it"]
-            #[doc = " and write the incremented value to storage"]
-            pub fn increment_counter(
-                &self,
-                value: ::core::primitive::u64,
-            ) -> ::fuels::programs::calls::CallHandler<
-                A,
-                ::fuels::programs::calls::ContractCall,
-                ::core::primitive::u64,
-            > {
-                ::fuels::programs::calls::CallHandler::new_contract_call(
-                    self.contract_id.clone(),
-                    self.account.clone(),
-                    ::fuels::core::codec::encode_fn_selector("increment_counter"),
-                    &[::fuels::core::traits::Tokenizable::into_token(value)],
-                    self.log_decoder.clone(),
-                    false,
-                    self.encoder_config.clone(),
-                )
-            }
+        impl<A: ::fuels::accounts::Account + Clone> MyContractMethods<A> {
             pub fn initialize_counter(
                 &self,
                 value: ::core::primitive::u64,
@@ -105,10 +97,28 @@ pub mod abigen_bindings {
                     self.encoder_config.clone(),
                 )
             }
+            pub fn increment_counter(
+                &self,
+                value: ::core::primitive::u64,
+            ) -> ::fuels::programs::calls::CallHandler<
+                A,
+                ::fuels::programs::calls::ContractCall,
+                ::core::primitive::u64,
+            > {
+                ::fuels::programs::calls::CallHandler::new_contract_call(
+                    self.contract_id.clone(),
+                    self.account.clone(),
+                    ::fuels::core::codec::encode_fn_selector("increment_counter"),
+                    &[::fuels::core::traits::Tokenizable::into_token(value)],
+                    self.log_decoder.clone(),
+                    false,
+                    self.encoder_config.clone(),
+                )
+            }
         }
-        impl<A: ::fuels::accounts::Account> ::fuels::programs::calls::ContractDependency for MyContract<A> {
+        impl<A> ::fuels::programs::calls::ContractDependency for MyContract<A> {
             fn id(&self) -> ::fuels::types::ContractId {
-                self.contract_id.clone()
+                self.contract_id
             }
             fn log_decoder(&self) -> ::fuels::core::codec::LogDecoder {
                 self.log_decoder.clone()
@@ -116,7 +126,7 @@ pub mod abigen_bindings {
         }
         #[derive(Clone, Debug, Default)]
         pub struct MyContractConfigurables {
-            offsets_with_data: ::std::vec::Vec<(u64, ::std::vec::Vec<u8>)>,
+            offsets_with_data: ::std::vec::Vec<::fuels::core::Configurable>,
             encoder: ::fuels::core::codec::ABIEncoder,
         }
         impl MyContractConfigurables {
@@ -126,14 +136,43 @@ pub mod abigen_bindings {
                     ..::std::default::Default::default()
                 }
             }
+            // A `with_XXX` method is generated here for every `configurable` in the ABI.
+            // This contract has none, so the list is empty.
         }
         impl From<MyContractConfigurables> for ::fuels::core::Configurables {
             fn from(config: MyContractConfigurables) -> Self {
                 ::fuels::core::Configurables::new(config.offsets_with_data)
             }
         }
+        impl From<MyContractConfigurables> for ::std::vec::Vec<::fuels::core::Configurable> {
+            fn from(
+                config: MyContractConfigurables,
+            ) -> ::std::vec::Vec<::fuels::core::Configurable> {
+                config.offsets_with_data
+            }
+        }
+        #[derive(Debug, Clone, Copy)]
+        pub struct MyContractMethodVariants;
+        impl MyContractMethodVariants {
+            pub const fn initialize_counter(&self) -> ::fuels::types::MethodDescriptor {
+                ::fuels::types::MethodDescriptor {
+                    name: "initialize_counter",
+                    fn_selector: b"\0\0\0\0\0\0\0\x12initialize_counter",
+                }
+            }
+            pub const fn increment_counter(&self) -> ::fuels::types::MethodDescriptor {
+                ::fuels::types::MethodDescriptor {
+                    name: "increment_counter",
+                    fn_selector: b"\0\0\0\0\0\0\0\x11increment_counter",
+                }
+            }
+            pub const fn iter(&self) -> [::fuels::types::MethodDescriptor; 2usize] {
+                [Self.initialize_counter(), Self.increment_counter()]
+            }
+        }
     }
 }
 pub use abigen_bindings::my_contract_mod::MyContract;
 pub use abigen_bindings::my_contract_mod::MyContractConfigurables;
+pub use abigen_bindings::my_contract_mod::MyContractMethodVariants;
 pub use abigen_bindings::my_contract_mod::MyContractMethods;


### PR DESCRIPTION
# Summary

`examples/rust_bindings/src/rust_bindings_formatted.rs` is included verbatim into the book at `docs/src/abigen/the-abigen-macro.md` as the canonical "here is what `abigen!` generates" example, but it had drifted from what `fuels-code-gen` actually emits.

I regenerated it by running `Abigen::generate` over `examples/rust_bindings/src/abi.json` and rustfmt-ing the output, rather than hand-patching, so the sample is the real codegen result. What changed:

- `MyContract<A = ()>` with no `Account` bound on the struct; the bounds moved onto `get_balances` (`ViewOnlyAccount`) and `methods` (`Clone`).
- `LogDecoder::new` now takes a second `error_codes` map argument.
- `offsets_with_data: Vec<::fuels::core::Configurable>` plus the `From<MyContractConfigurables> for Vec<Configurable>` impl added in #1685.
- Added `MyContract::METHODS` and the `MyContractMethodVariants` struct with its per-method `MethodDescriptor`s and `iter()`.
- Added the `const _: &[u8] = include_bytes!(..)` recompile trigger.
- `contract_id()` now returns `ContractId` by value, `account()` returns `&A`.
- Dropped the stale doc comments on `increment_counter` — `abi.json` has no `doc-comment` attributes, so codegen emits none.

Two deliberate deviations from raw codegen output, both for readability (the book already labels this "shortened for brevity's sake"):

- The `#[no_implicit_prelude]` / `#[allow(clippy::..)]` attributes and the prelude `use ::core::{..}` / `use ::std::{..}` blocks are trimmed, as they were in the previous sample.
- The `include_bytes!` argument is a `/path/to/..` placeholder, because codegen canonicalizes it to a machine-specific absolute path.

Note that no `MyContractConfigurables::with_XXX` builder methods appear: they are generated per `configurable` in the ABI, and this ABI declares none. I left a short comment at that spot rather than inventing output this ABI cannot produce. Happy to add a `configurables` entry to `abi.json` instead if we would rather the docs actually show one.

Verified with `cargo run --bin check-docs` (exit 0, no errors or warnings) and `rustfmt --edition 2024 --check`.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
